### PR TITLE
Implement cache keys, artifact store, and init scaffolding

### DIFF
--- a/crates/konvoy-engine/Cargo.toml
+++ b/crates/konvoy-engine/Cargo.toml
@@ -12,4 +12,9 @@ konvoy-config.workspace = true
 konvoy-konanc.workspace = true
 konvoy-targets.workspace = true
 konvoy-util.workspace = true
+serde.workspace = true
 thiserror.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -1,0 +1,259 @@
+//! Content-addressed artifact store for build outputs.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::cache::CacheKey;
+use crate::error::EngineError;
+
+/// Metadata stored alongside a cached artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildMetadata {
+    /// Kotlin/Native target (e.g. "linux_x64").
+    pub target: String,
+    /// Build profile ("debug" or "release").
+    pub profile: String,
+    /// konanc version used for the build.
+    pub konanc_version: String,
+    /// ISO 8601 timestamp of when the build was produced.
+    pub built_at: String,
+}
+
+/// Content-addressed store for compiled artifacts under `.konvoy/cache/`.
+#[derive(Debug)]
+pub struct ArtifactStore {
+    cache_root: PathBuf,
+}
+
+impl ArtifactStore {
+    /// Create a new artifact store rooted at `<project_root>/.konvoy/cache/`.
+    pub fn new(project_root: &Path) -> Self {
+        Self {
+            cache_root: project_root.join(".konvoy").join("cache"),
+        }
+    }
+
+    /// Return the cache directory path for a given key.
+    pub fn cache_path(&self, key: &CacheKey) -> PathBuf {
+        self.cache_root.join(key.as_hex())
+    }
+
+    /// Check whether a cache entry exists for the given key.
+    pub fn has(&self, key: &CacheKey) -> bool {
+        self.cache_path(key).is_dir()
+    }
+
+    /// Store an artifact and its metadata in the cache.
+    ///
+    /// The cache is immutable: if an entry already exists for this key,
+    /// the store is a no-op and returns `Ok(())`.
+    ///
+    /// # Errors
+    /// Returns an error if the cache directory cannot be created or the
+    /// artifact cannot be copied.
+    pub fn store(
+        &self,
+        key: &CacheKey,
+        artifact: &Path,
+        metadata: &BuildMetadata,
+    ) -> Result<(), EngineError> {
+        let entry_dir = self.cache_path(key);
+
+        // Immutable cache: never overwrite.
+        if entry_dir.is_dir() {
+            return Ok(());
+        }
+
+        konvoy_util::fs::ensure_dir(&entry_dir)?;
+
+        // Copy the artifact into the cache directory.
+        let Some(file_name) = artifact.file_name() else {
+            return Err(EngineError::Io {
+                path: artifact.display().to_string(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "artifact path has no file name",
+                ),
+            });
+        };
+        let cached_artifact = entry_dir.join(file_name);
+        std::fs::copy(artifact, &cached_artifact).map_err(|source| EngineError::Io {
+            path: cached_artifact.display().to_string(),
+            source,
+        })?;
+
+        // Write metadata alongside the artifact.
+        let metadata_path = entry_dir.join("metadata.toml");
+        let metadata_toml =
+            toml::to_string_pretty(metadata).map_err(|e| EngineError::Metadata {
+                message: e.to_string(),
+            })?;
+        std::fs::write(&metadata_path, metadata_toml).map_err(|source| EngineError::Io {
+            path: metadata_path.display().to_string(),
+            source,
+        })?;
+
+        Ok(())
+    }
+
+    /// Materialize a cached artifact to the given destination path.
+    ///
+    /// Prefers hard linking for disk efficiency, falls back to copy if linking
+    /// fails (e.g. cross-filesystem).
+    ///
+    /// # Errors
+    /// Returns an error if the cache entry does not exist or the artifact
+    /// cannot be materialized.
+    pub fn materialize(
+        &self,
+        key: &CacheKey,
+        artifact_name: &str,
+        dest: &Path,
+    ) -> Result<(), EngineError> {
+        let entry_dir = self.cache_path(key);
+        let cached_artifact = entry_dir.join(artifact_name);
+
+        if !cached_artifact.exists() {
+            return Err(EngineError::Io {
+                path: cached_artifact.display().to_string(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "cached artifact not found",
+                ),
+            });
+        }
+
+        konvoy_util::fs::materialize(&cached_artifact, dest)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn test_metadata() -> BuildMetadata {
+        BuildMetadata {
+            target: "linux_x64".to_owned(),
+            profile: "debug".to_owned(),
+            konanc_version: "2.1.0".to_owned(),
+            built_at: "2026-02-21T00:00:00Z".to_owned(),
+        }
+    }
+
+    fn test_key() -> CacheKey {
+        // Use CacheInputs to compute a real key.
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("main.kt"), "fun main() {}").unwrap();
+
+        let inputs = crate::cache::CacheInputs {
+            manifest_content: "[package]\nname = \"test\"".to_owned(),
+            lockfile_content: "".to_owned(),
+            konanc_version: "2.1.0".to_owned(),
+            konanc_fingerprint: "abc123".to_owned(),
+            target: "linux_x64".to_owned(),
+            profile: "debug".to_owned(),
+            source_dir: tmp.path().to_path_buf(),
+            source_glob: "**/*.kt".to_owned(),
+            os: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
+        };
+        CacheKey::compute(&inputs).unwrap()
+    }
+
+    #[test]
+    fn store_and_has() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        // Create a fake artifact.
+        let artifact = tmp.path().join("my-app");
+        fs::write(&artifact, b"binary content").unwrap();
+
+        assert!(!store.has(&key));
+        store.store(&key, &artifact, &test_metadata()).unwrap();
+        assert!(store.has(&key));
+    }
+
+    #[test]
+    fn store_writes_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        let artifact = tmp.path().join("my-app");
+        fs::write(&artifact, b"binary").unwrap();
+
+        store.store(&key, &artifact, &test_metadata()).unwrap();
+
+        let metadata_path = store.cache_path(&key).join("metadata.toml");
+        assert!(metadata_path.exists());
+        let content = fs::read_to_string(metadata_path).unwrap();
+        assert!(content.contains("linux_x64"));
+        assert!(content.contains("2.1.0"));
+    }
+
+    #[test]
+    fn store_is_immutable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        let artifact = tmp.path().join("my-app");
+        fs::write(&artifact, b"original").unwrap();
+        store.store(&key, &artifact, &test_metadata()).unwrap();
+
+        // Overwrite artifact content and store again — cache should not change.
+        fs::write(&artifact, b"modified").unwrap();
+        store.store(&key, &artifact, &test_metadata()).unwrap();
+
+        let cached = store.cache_path(&key).join("my-app");
+        let content = fs::read(&cached).unwrap();
+        assert_eq!(content, b"original");
+    }
+
+    #[test]
+    fn materialize_creates_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        let artifact = tmp.path().join("my-app");
+        fs::write(&artifact, b"binary content").unwrap();
+        store.store(&key, &artifact, &test_metadata()).unwrap();
+
+        let dest = tmp.path().join("output").join("my-app");
+        store.materialize(&key, "my-app", &dest).unwrap();
+
+        assert!(dest.exists());
+        assert_eq!(fs::read(&dest).unwrap(), b"binary content");
+    }
+
+    #[test]
+    fn materialize_missing_entry_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        let dest = tmp.path().join("output").join("my-app");
+        let result = store.materialize(&key, "my-app", &dest);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cache_path_includes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::new(tmp.path());
+        let key = test_key();
+
+        let path = store.cache_path(&key);
+        assert!(path.display().to_string().contains(key.as_hex()));
+    }
+}

--- a/crates/konvoy-engine/src/cache.rs
+++ b/crates/konvoy-engine/src/cache.rs
@@ -1,1 +1,312 @@
-//! Content-addressed cache for build artifacts.
+//! Content-addressed cache key computation for build artifacts.
+
+use std::fmt;
+use std::path::Path;
+
+use crate::error::EngineError;
+
+/// All inputs that contribute to a deterministic cache key.
+#[derive(Debug)]
+pub struct CacheInputs {
+    /// Normalized konvoy.toml content.
+    pub manifest_content: String,
+    /// Relevant konvoy.lock content (toolchain version).
+    pub lockfile_content: String,
+    /// konanc version string.
+    pub konanc_version: String,
+    /// SHA-256 fingerprint of the konanc binary.
+    pub konanc_fingerprint: String,
+    /// Target triple (e.g. "linux_x64").
+    pub target: String,
+    /// Build profile ("debug" or "release").
+    pub profile: String,
+    /// Root directory containing source files.
+    pub source_dir: std::path::PathBuf,
+    /// Glob pattern for source files (e.g. "**/*.kt").
+    pub source_glob: String,
+    /// Operating system identifier.
+    pub os: String,
+    /// Architecture identifier.
+    pub arch: String,
+}
+
+impl CacheInputs {
+    /// Create inputs with OS and arch auto-detected from the current platform.
+    pub fn with_platform_defaults(mut self) -> Self {
+        self.os = std::env::consts::OS.to_owned();
+        self.arch = std::env::consts::ARCH.to_owned();
+        self
+    }
+}
+
+/// A content-addressed cache key wrapping a SHA-256 hex string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CacheKey(String);
+
+impl CacheKey {
+    /// Compute a cache key from the given inputs.
+    ///
+    /// Source files are sorted by path before hashing for determinism.
+    /// Only file contents are hashed, not metadata like timestamps.
+    ///
+    /// # Errors
+    /// Returns an error if source files cannot be read.
+    pub fn compute(inputs: &CacheInputs) -> Result<Self, EngineError> {
+        let source_hash = konvoy_util::hash::sha256_dir(&inputs.source_dir, &inputs.source_glob)?;
+
+        let composite = konvoy_util::hash::sha256_multi(&[
+            &inputs.manifest_content,
+            &inputs.lockfile_content,
+            &inputs.konanc_version,
+            &inputs.konanc_fingerprint,
+            &inputs.target,
+            &inputs.profile,
+            &source_hash,
+            &inputs.os,
+            &inputs.arch,
+        ]);
+
+        Ok(Self(composite))
+    }
+
+    /// Return the hex string representation of this cache key.
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CacheKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<Path> for CacheKey {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn make_inputs(dir: &Path) -> CacheInputs {
+        CacheInputs {
+            manifest_content: "[package]\nname = \"test\"".to_owned(),
+            lockfile_content: "".to_owned(),
+            konanc_version: "2.1.0".to_owned(),
+            konanc_fingerprint: "abc123".to_owned(),
+            target: "linux_x64".to_owned(),
+            profile: "debug".to_owned(),
+            source_dir: dir.to_path_buf(),
+            source_glob: "**/*.kt".to_owned(),
+            os: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
+        }
+    }
+
+    fn setup_sources(dir: &Path) {
+        let src = dir.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("main.kt"), "fun main() {}").unwrap();
+    }
+
+    #[test]
+    fn same_inputs_same_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+        let key2 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn key_has_valid_hex_length() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+        assert_eq!(key.as_hex().len(), 64);
+    }
+
+    #[test]
+    fn display_matches_hex() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+        assert_eq!(key.to_string(), key.as_hex());
+    }
+
+    #[test]
+    fn changing_manifest_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.manifest_content = "[package]\nname = \"other\"".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_source_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        fs::write(
+            tmp.path().join("src").join("main.kt"),
+            "fun main() { changed }",
+        )
+        .unwrap();
+        let key2 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_target_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.target = "macos_arm64".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_profile_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.profile = "release".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_konanc_version_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.konanc_version = "2.2.0".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_konanc_fingerprint_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.konanc_fingerprint = "xyz789".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn adding_source_file_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        fs::write(tmp.path().join("src").join("extra.kt"), "fun extra() {}").unwrap();
+        let key2 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn file_order_does_not_affect_key() {
+        let dir1 = tempfile::tempdir().unwrap();
+        let src1 = dir1.path().join("src");
+        fs::create_dir_all(&src1).unwrap();
+        fs::write(src1.join("b.kt"), "fun b() {}").unwrap();
+        fs::write(src1.join("a.kt"), "fun a() {}").unwrap();
+
+        let dir2 = tempfile::tempdir().unwrap();
+        let src2 = dir2.path().join("src");
+        fs::create_dir_all(&src2).unwrap();
+        fs::write(src2.join("a.kt"), "fun a() {}").unwrap();
+        fs::write(src2.join("b.kt"), "fun b() {}").unwrap();
+
+        let mut inputs1 = make_inputs(dir1.path());
+        inputs1.source_dir = dir1.path().to_path_buf();
+        let key1 = CacheKey::compute(&inputs1).unwrap();
+
+        let mut inputs2 = make_inputs(dir2.path());
+        inputs2.source_dir = dir2.path().to_path_buf();
+        let key2 = CacheKey::compute(&inputs2).unwrap();
+
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn changing_os_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.os = "macos".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_arch_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.arch = "aarch64".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn changing_lockfile_changes_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs = make_inputs(tmp.path());
+        inputs.lockfile_content = "[toolchain]\nkonanc_version = \"2.0.0\"".to_owned();
+        let key2 = CacheKey::compute(&inputs).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+}

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -1,0 +1,28 @@
+//! Error types for konvoy-engine.
+
+/// Errors produced by engine operations.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    /// A filesystem operation failed.
+    #[error("cannot access {path}: {source}")]
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
+
+    /// A utility operation failed.
+    #[error("{0}")]
+    Util(#[from] konvoy_util::error::UtilError),
+
+    /// A manifest operation failed.
+    #[error("{0}")]
+    Manifest(#[from] konvoy_config::manifest::ManifestError),
+
+    /// A project already exists at the target path.
+    #[error("konvoy.toml already exists at {path} — cannot initialize over an existing project")]
+    ProjectExists { path: String },
+
+    /// Metadata serialization/deserialization failed.
+    #[error("cannot process metadata: {message}")]
+    Metadata { message: String },
+}

--- a/crates/konvoy-engine/src/init.rs
+++ b/crates/konvoy-engine/src/init.rs
@@ -1,0 +1,120 @@
+//! Project scaffolding for `konvoy init`.
+
+use std::path::Path;
+
+use konvoy_config::manifest::{Manifest, Package};
+
+use crate::error::EngineError;
+
+/// Scaffold a new Konvoy project.
+///
+/// Creates the project directory (if it doesn't exist), a `konvoy.toml` manifest,
+/// and a `src/main.kt` with a hello-world program.
+///
+/// # Errors
+/// Returns an error if:
+/// - A `konvoy.toml` already exists in `dir`
+/// - The directory or files cannot be created
+/// - The manifest cannot be serialized
+pub fn init_project(name: &str, dir: &Path) -> Result<(), EngineError> {
+    let manifest_path = dir.join("konvoy.toml");
+
+    if manifest_path.exists() {
+        return Err(EngineError::ProjectExists {
+            path: manifest_path.display().to_string(),
+        });
+    }
+
+    // Create project directory and src/ subdirectory.
+    let src_dir = dir.join("src");
+    konvoy_util::fs::ensure_dir(&src_dir)?;
+
+    // Generate and write konvoy.toml.
+    let manifest = Manifest {
+        package: Package {
+            name: name.to_owned(),
+            entrypoint: "src/main.kt".to_owned(),
+        },
+    };
+    let toml_content = manifest.to_toml()?;
+    std::fs::write(&manifest_path, toml_content).map_err(|source| EngineError::Io {
+        path: manifest_path.display().to_string(),
+        source,
+    })?;
+
+    // Generate and write src/main.kt.
+    let main_kt = format!("fun main() {{\n    println(\"Hello, {name}!\")\n}}\n");
+    let main_kt_path = src_dir.join("main.kt");
+    std::fs::write(&main_kt_path, main_kt).map_err(|source| EngineError::Io {
+        path: main_kt_path.display().to_string(),
+        source,
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn creates_project_structure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("my-app");
+
+        init_project("my-app", &project_dir).unwrap();
+
+        assert!(project_dir.join("konvoy.toml").exists());
+        assert!(project_dir.join("src").join("main.kt").exists());
+    }
+
+    #[test]
+    fn manifest_parses_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("test-proj");
+
+        init_project("test-proj", &project_dir).unwrap();
+
+        let manifest = Manifest::from_path(&project_dir.join("konvoy.toml")).unwrap();
+        assert_eq!(manifest.package.name, "test-proj");
+        assert_eq!(manifest.package.entrypoint, "src/main.kt");
+    }
+
+    #[test]
+    fn main_kt_contains_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("hello");
+
+        init_project("hello", &project_dir).unwrap();
+
+        let content = fs::read_to_string(project_dir.join("src").join("main.kt")).unwrap();
+        assert!(content.contains("Hello, hello!"));
+        assert!(content.contains("fun main()"));
+    }
+
+    #[test]
+    fn refuses_existing_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("existing");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(project_dir.join("konvoy.toml"), "").unwrap();
+
+        let result = init_project("existing", &project_dir);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("already exists"));
+    }
+
+    #[test]
+    fn creates_parent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("deep").join("nested").join("project");
+
+        init_project("project", &project_dir).unwrap();
+
+        assert!(project_dir.join("konvoy.toml").exists());
+    }
+}

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -1,4 +1,12 @@
 //! Build orchestration, cache keying, and artifact store for Konvoy.
 
+pub mod artifact;
 pub mod build;
 pub mod cache;
+pub mod error;
+pub mod init;
+
+pub use artifact::{ArtifactStore, BuildMetadata};
+pub use cache::{CacheInputs, CacheKey};
+pub use error::EngineError;
+pub use init::init_project;


### PR DESCRIPTION
## Summary
- Implement deterministic cache key computation from all 9 required inputs (#8)
- Implement content-addressed artifact store with immutable cache entries (#9)
- Implement project scaffolding for `konvoy init` (#11)

## Changes
- `crates/konvoy-engine/src/cache.rs`: `CacheInputs`, `CacheKey::compute()` with SHA-256
- `crates/konvoy-engine/src/artifact.rs`: `ArtifactStore` with `.has()`, `.store()`, `.materialize()`; `BuildMetadata` struct
- `crates/konvoy-engine/src/init.rs`: `init_project()` creating konvoy.toml and src/main.kt
- `crates/konvoy-engine/src/error.rs`: `EngineError` enum with thiserror
- `crates/konvoy-engine/src/lib.rs`: Module declarations and re-exports
- `crates/konvoy-engine/Cargo.toml`: Added serde, toml, tempfile dependencies

## Test plan
- [x] 25 unit tests passing (`cargo test -p konvoy-engine`)
- [x] `cargo clippy -p konvoy-engine -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Cache key stability: same inputs produce same key
- [x] Cache key sensitivity: changing any input changes the key (all 9 tested)
- [x] File order independence for source hashing
- [x] Artifact store immutability: never overwrites existing entries
- [x] Materialization via hardlink with copy fallback
- [x] Init refuses to overwrite existing projects

Closes #8, closes #9, closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)