### PR TITLE
Bundle JRE with managed toolchain for hermetic builds

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -300,13 +300,22 @@ fn cmd_doctor() -> Result<(), String> {
                 eprintln!("  [ok] Project: {}", manifest.package.name);
                 let version = &manifest.toolchain.kotlin;
                 match konvoy_konanc::toolchain::is_installed(version) {
-                    Ok(true) => match konvoy_konanc::toolchain::managed_konanc_path(version) {
-                        Ok(path) => eprintln!("  [ok] konanc: {version} ({})", path.display()),
-                        Err(e) => {
-                            eprintln!("  [!!] konanc: {e}");
-                            issues = issues.saturating_add(1);
+                    Ok(true) => {
+                        match konvoy_konanc::toolchain::managed_konanc_path(version) {
+                            Ok(path) => eprintln!("  [ok] konanc: {version} ({})", path.display()),
+                            Err(e) => {
+                                eprintln!("  [!!] konanc: {e}");
+                                issues = issues.saturating_add(1);
+                            }
                         }
-                    },
+                        match konvoy_konanc::toolchain::jre_home_path(version) {
+                            Ok(path) => eprintln!("  [ok] JRE: {}", path.display()),
+                            Err(e) => {
+                                eprintln!("  [!!] JRE: {e}");
+                                issues = issues.saturating_add(1);
+                            }
+                        }
+                    }
                     Ok(false) => {
                         eprintln!("  [!!] konanc: Kotlin/Native {version} not installed — run `konvoy toolchain install` or `konvoy build`");
                         issues = issues.saturating_add(1);

--- a/crates/konvoy-konanc/src/error.rs
+++ b/crates/konvoy-konanc/src/error.rs
@@ -71,6 +71,10 @@ pub enum KonancError {
     #[error("corrupt toolchain at {path} — run `konvoy toolchain install {version}` to reinstall")]
     CorruptToolchain { path: PathBuf, version: String },
 
+    /// Failed to install or locate the bundled JRE.
+    #[error("JRE installation failed: {message}")]
+    JreInstall { message: String },
+
     /// A filesystem operation failed during toolchain management.
     #[error("cannot access {path}: {source}")]
     Io {

--- a/tests/smoke/Dockerfile
+++ b/tests/smoke/Dockerfile
@@ -1,15 +1,14 @@
 # syntax=docker/dockerfile:1
 FROM rust:1.93-slim-bookworm
 
-# System dependencies: build tools, git, and a JRE for konanc.
-# The kotlin-native-prebuilt tarball does NOT bundle a JRE; its run_konan
-# script requires `java` (>= 8) on PATH.
+# System dependencies: build tools, git.
+# No JRE needed — konvoy automatically downloads and bundles a JRE
+# alongside the managed Kotlin/Native toolchain.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         curl \
         ca-certificates \
         git \
-        default-jre-headless \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy project source and build konvoy.


### PR DESCRIPTION
## Summary

Closes #30.

- The kotlin-native-prebuilt tarball does **not** include a JRE, but konanc's `run_konan` script requires `java` on PATH
- `konvoy toolchain install` now also downloads an Adoptium Temurin 21 LTS JRE (~50MB) and stores it at `~/.konvoy/toolchains/<version>/jre/`
- `JAVA_HOME` is set automatically when invoking konanc — users never need to install Java
- Removed `default-jre-headless` from smoke test Dockerfile to prove bundled JRE works
- Renamed `tarball_sha256` → `konanc_tarball_sha256` and added `jre_tarball_sha256` to lockfile for integrity tracking
- `konvoy doctor` now checks JRE presence

## Test plan

- [x] All 167 unit tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace`)
- [x] Formatting clean (`cargo fmt --all --check`)
- [ ] Smoke tests pass in Docker without `default-jre-headless` (CI validates this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)