### PR TITLE
Add HTTP timeouts to toolchain downloads

### DIFF
--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -415,7 +415,14 @@ fn download_with_progress(
     label: &str,
     version: &str,
 ) -> Result<String, KonancError> {
-    let response = ureq::get(url).call().map_err(|e| KonancError::Download {
+    let agent = ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .timeout_connect(Some(std::time::Duration::from_secs(30)))
+            .timeout_global(Some(std::time::Duration::from_secs(600)))
+            .build(),
+    );
+
+    let response = agent.get(url).call().map_err(|e| KonancError::Download {
         version: version.to_owned(),
         message: e.to_string(),
     })?;


### PR DESCRIPTION
## Summary
- Configures a ureq `Agent` with a 30-second connection timeout and 600-second global timeout for toolchain downloads
- Prevents indefinite hangs when network connectivity is lost or servers are unresponsive
- The 600-second global timeout allows enough time for large (~700MB) Kotlin/Native toolchain tarballs

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (167 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)