### PR TITLE
Bound dependency path resolution to project tree

### DIFF
--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -65,4 +65,8 @@ pub enum EngineError {
         dep_version: String,
         root_version: String,
     },
+
+    /// A dependency path escapes the project tree.
+    #[error("dependency `{name}` path escapes the project tree — resolved to {path}; use a relative path within the workspace")]
+    DependencyPathEscape { name: String, path: String },
 }


### PR DESCRIPTION
Closes #36

## Summary
- Reject absolute dependency paths in `resolve_dep_path` (e.g. `/etc/something`)
- Reject paths with more than 5 leading `..` components to prevent deep traversal escapes
- Add `DependencyPathEscape` error variant with actionable message
- Sibling dependencies like `../my-lib` continue to work as expected

## Test plan
- [x] `sibling_dependency_allowed` — verifies `../sibling-lib` resolves correctly
- [x] `deep_traversal_rejected` — verifies 10+ levels of `..` are rejected
- [x] `absolute_path_rejected` — verifies `/etc/something` is rejected
- [x] All existing tests pass (54 engine tests)
- [x] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)