### PR TITLE
Add #![forbid(unsafe_code)] to all crates

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use std::path::PathBuf;
 use std::process;
 

--- a/crates/konvoy-config/src/lib.rs
+++ b/crates/konvoy-config/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Parse and validate `konvoy.toml` and `konvoy.lock`.
 
 pub mod lockfile;

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Build orchestration, cache keying, and artifact store for Konvoy.
 
 pub mod artifact;

--- a/crates/konvoy-konanc/src/lib.rs
+++ b/crates/konvoy-konanc/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Compiler invocation and diagnostics normalization for `konanc`.
 
 pub mod detect;

--- a/crates/konvoy-targets/src/lib.rs
+++ b/crates/konvoy-targets/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Host detection and target triple mapping for Konvoy.
 //!
 //! Maps Rust compile-time platform information to Kotlin/Native target names

--- a/crates/konvoy-util/src/lib.rs
+++ b/crates/konvoy-util/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Hashing, filesystem utilities, and process helpers for Konvoy.
 
 pub mod error;


### PR DESCRIPTION
## Summary
- Adds `#![forbid(unsafe_code)]` as the first line of each crate root (`main.rs` or `lib.rs`) across all 6 workspace crates
- Ensures unsafe code cannot be introduced anywhere in the project at compile time

## Changes
- `crates/konvoy-cli/src/main.rs`
- `crates/konvoy-config/src/lib.rs`
- `crates/konvoy-engine/src/lib.rs`
- `crates/konvoy-konanc/src/lib.rs`
- `crates/konvoy-targets/src/lib.rs`
- `crates/konvoy-util/src/lib.rs`

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (169 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)