### PR TITLE
Add symlink detection in worktree cache path resolution

### DIFF
--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -351,7 +351,9 @@ mod tests {
     #[test]
     fn path_without_symlinks_returns_false() {
         let tmp = tempfile::tempdir().unwrap();
-        let nested = tmp.path().join("a").join("b").join("c");
+        // Canonicalize to resolve any OS-level symlinks (e.g. macOS /tmp -> /private/tmp).
+        let canonical = tmp.path().canonicalize().unwrap();
+        let nested = canonical.join("a").join("b").join("c");
         fs::create_dir_all(&nested).unwrap();
         assert!(!path_contains_symlink(&nested));
     }


### PR DESCRIPTION
## Summary

- Add `path_contains_symlink()` helper that walks each component of a path and checks for symlinks using `symlink_metadata()`
- Before returning the shared worktree cache path, check it for symlinks; if found, emit a warning via `eprintln!` and fall back to the local project cache
- Add unit tests for both regular directories (no symlinks) and symlink detection (`#[cfg(unix)]`)

Closes #39

## Test plan

- [x] `path_without_symlinks_returns_false` - verifies regular directories are not flagged
- [x] `path_with_symlink_detected` - verifies symlinks are detected (unix-only)
- [x] All existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes (no changes to formatted files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)