### PR TITLE
Add explicit path validation during tar extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "konvoy-util",
  "sha2",
  "tar",
+ "tempfile",
  "thiserror",
  "ureq",
 ]

--- a/crates/konvoy-konanc/Cargo.toml
+++ b/crates/konvoy-konanc/Cargo.toml
@@ -14,3 +14,6 @@ sha2.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 ureq.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/konvoy-konanc/src/error.rs
+++ b/crates/konvoy-konanc/src/error.rs
@@ -63,6 +63,10 @@ pub enum KonancError {
     #[error("cannot extract Kotlin/Native {version}: {message}")]
     Extract { version: String, message: String },
 
+    /// A tarball entry attempted to escape the extraction directory.
+    #[error("tarball contains path traversal entry \"{entry_path}\" that escapes {dest}")]
+    PathTraversal { entry_path: String, dest: String },
+
     /// The installed toolchain version does not match the expected version.
     #[error("expected Kotlin/Native {expected} but found {actual}")]
     VersionMismatch { expected: String, actual: String },


### PR DESCRIPTION
## Summary
- Replaces `archive.unpack(dest)` with manual entry iteration in `extract_tarball()`
- Validates each tar entry path has no `..` components and stays within the destination directory
- Adds `PathTraversal` error variant with actionable error message
- Adds 3 tests: safe path extraction, parent dir traversal rejection, and mid-path dotdot rejection

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] New tests verify path traversal detection

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)