### PR TITLE
Verify toolchain tarball SHA-256 hashes against lockfile

### DIFF
--- a/crates/konvoy-konanc/src/detect.rs
+++ b/crates/konvoy-konanc/src/detect.rs
@@ -45,17 +45,7 @@ pub fn resolve_konanc(version: &str) -> Result<ResolvedKonanc, KonancError> {
     let (konanc_tarball_sha256, jre_tarball_sha256) = if !installed {
         eprintln!("    Installing Kotlin/Native {version}...");
         let result = toolchain::install(version)?;
-        let konanc_sha = if result.konanc_tarball_sha256.is_empty() {
-            None
-        } else {
-            Some(result.konanc_tarball_sha256)
-        };
-        let jre_sha = if result.jre_tarball_sha256.is_empty() {
-            None
-        } else {
-            Some(result.jre_tarball_sha256)
-        };
-        (konanc_sha, jre_sha)
+        (result.konanc_tarball_sha256, result.jre_tarball_sha256)
     } else {
         (None, None)
     };


### PR DESCRIPTION
## Summary
- Changed `InstallResult` SHA-256 fields from `String` to `Option<String>` so "already installed" returns `None` instead of empty strings
- Updated `update_lockfile_if_needed` to preserve existing lockfile hashes when no fresh download occurred (toolchain already installed)
- Added hash mismatch detection: when a fresh download yields different hashes than what the lockfile stores, a warning is emitted
- Old hashes are only carried forward when the toolchain version hasn't changed; version upgrades clear stale hashes

## Test plan
- [x] `update_lockfile_preserves_hashes_when_no_download` — verifies existing hashes are kept when toolchain is already installed
- [x] `update_lockfile_updates_hashes_from_fresh_download` — verifies new hashes replace old ones on version change
- [x] `update_lockfile_preserves_hashes_on_same_version_no_download` — verifies same-version re-runs don't drop hashes
- [x] All existing tests pass (`cargo test --workspace` — 170 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)