### PR TITLE
Add concurrent toolchain install and cache access tests (#55)

### DIFF
--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -908,6 +908,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::panic)]
     fn concurrent_rename_race_simulation() {
         use std::sync::{Arc, Barrier};
         use std::thread;


### PR DESCRIPTION
## Summary
- Add `concurrent_store_same_key` test: spawns 8 threads that all try to `store()` the same cache key simultaneously, verifying the immutable-cache contract (first wins, others see it exists)
- Add `concurrent_materialize_same_key` test: stores an artifact then spawns 8 threads that all `materialize()` it simultaneously, verifying all produce correct output
- Add `concurrent_rename_race_simulation` test: simulates the atomic rename pattern used in toolchain installation by having 8 threads race to rename different source dirs to the same destination

## Test plan
- [x] `cargo test -p konvoy-konanc` passes (52 tests including new concurrent test)
- [x] `cargo test -p konvoy-engine --lib -- artifact::tests` passes (13 tests including 2 new concurrent tests)
- [x] `cargo clippy -p konvoy-konanc -- -D warnings` clean
- [x] `cargo clippy -p konvoy-engine --lib -- -D warnings` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)