### PR TITLE
Make tarball hash mismatch a hard error

### DIFF
--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -69,4 +69,12 @@ pub enum EngineError {
     /// A dependency path escapes the project tree.
     #[error("dependency `{name}` path escapes the project tree — resolved to {path}; use a relative path within the workspace")]
     DependencyPathEscape { name: String, path: String },
+
+    /// A tarball hash in the lockfile does not match the freshly downloaded hash.
+    #[error("{kind} tarball hash mismatch — expected {expected}, got {actual}; re-run with --force to override")]
+    TarballHashMismatch {
+        kind: String,
+        expected: String,
+        actual: String,
+    },
 }


### PR DESCRIPTION
## Summary
- Tarball hash mismatch is now a hard error by default (prevents silently accepting tampered/rotated tarballs)
- New `--force` flag on `build`, `run`, and `test` commands allows overriding the check
- First downloads (no prior hash) still succeed normally
- Version changes skip the hash check (different versions naturally have different hashes)

## Test plan
- [x] cargo test --workspace (256 tests pass)
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo fmt --all -- --check

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)