### PR TITLE
Add --locked mode for dependency source hash enforcement

### DIFF
--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -77,4 +77,18 @@ pub enum EngineError {
         expected: String,
         actual: String,
     },
+
+    /// A dependency source hash does not match the lockfile (in --locked mode).
+    #[error("dependency `{name}` source hash mismatch — locked: {expected}, current: {actual}; remove --locked to allow lockfile updates")]
+    DependencyHashMismatch {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// The lockfile would need updating but --locked mode prevents it.
+    #[error(
+        "lockfile is out of date and --locked prevents updates; run without --locked to update"
+    )]
+    LockfileUpdateRequired,
 }


### PR DESCRIPTION
## Summary
- Adds `--locked` flag to `build`, `run`, and `test` commands
- In locked mode, dependency source hash mismatches become hard errors (instead of warnings)
- In locked mode, lockfile modifications are prevented — if the lockfile would need updating, the build fails
- Critical for CI environments where builds must be reproducible

## Test plan
- [x] `cargo test --workspace` — all 262 tests pass (4 new tests added)
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — properly formatted

### New tests
- `update_lockfile_locked_mode_mismatch_errors` — dep source hash differs + locked=true returns hard error
- `update_lockfile_unlocked_mode_warns` — dep source hash differs + locked=false returns Ok
- `update_lockfile_locked_mode_matching_hash_passes` — dep source hash matches + locked=true returns Ok
- `update_lockfile_locked_mode_prevents_writes` — lockfile needs updating + locked=true returns error

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)