### PR TITLE
Make all valid reviewer findings blocking

### DIFF
--- a/docs/agents/reviewer.md
+++ b/docs/agents/reviewer.md
@@ -28,8 +28,22 @@ Review code changes for correctness, style compliance, and alignment with projec
 - [ ] Tests cover the happy path and at least one failure path
 - [ ] Cache key changes are intentional and tested for stability
 
+## Feedback policy
+
+Every valid suggestion is blocking. There is no "non-blocking" category.
+
+If a finding is valid — meaning it violates a code style rule, a CLAUDE.md non-negotiable, a crate boundary convention, or a project quality standard — it blocks approval. Do not soften valid findings into optional suggestions. Small issues compound as the codebase grows, and the reviewer exists to catch them before they accumulate.
+
+- If it violates a documented rule, it blocks.
+- If it introduces an unnecessary dependency, it blocks.
+- If a public API is missing docs, it blocks.
+- If pre-existing technical debt is being moved to a new location (e.g. code extraction), flag it as blocking — the move is the right time to fix it.
+- If a function or type is `pub` without a doc comment, it blocks.
+
+If a finding is backed by a documented rule, cite the rule. If it is not covered by an existing rule but still represents a real quality concern, flag it anyway and recommend that the relevant convention document be updated to cover it.
+
 ## Constraints
 
 - The reviewer does not write production code — only review comments and pass/fail decisions
 - When rejecting, cite the specific rule or constraint being violated
-- When approving with suggestions, distinguish between blocking and non-blocking feedback
+- Do not distinguish between "blocking" and "non-blocking" — all valid findings block approval


### PR DESCRIPTION
## Summary

- Add a **Feedback policy** section to `docs/agents/reviewer.md` that eliminates the "non-blocking" category
- Every valid finding now blocks approval — style violations, missing docs, unnecessary deps, and pre-existing debt being moved to new locations
- Findings not covered by existing rules still block, and should recommend updating the relevant convention document
- Update constraints to remove the old "distinguish between blocking and non-blocking" instruction

## Test plan

- [x] Documentation-only change, no code affected
- [x] Review the updated `docs/agents/reviewer.md` for clarity and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)