### PR TITLE
Add linux_arm64 toolchain download support

### DIFF
--- a/crates/konvoy-konanc/src/detect.rs
+++ b/crates/konvoy-konanc/src/detect.rs
@@ -33,7 +33,7 @@ pub struct ResolvedKonanc {
 /// Resolve a managed `konanc` installation for the given version.
 ///
 /// If the requested version is not installed, downloads and installs it
-/// from JetBrains GitHub releases. After installation, verifies the version
+/// from `download.jetbrains.com`. After installation, verifies the version
 /// matches and computes a fingerprint for cache keying.
 ///
 /// # Errors

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -1,6 +1,6 @@
 //! Managed toolchain download, installation, and discovery.
 //!
-//! Downloads Kotlin/Native prebuilt tarballs from JetBrains GitHub releases
+//! Downloads Kotlin/Native prebuilt tarballs from `download.jetbrains.com`
 //! and installs them under `~/.konvoy/toolchains/<version>/`.
 
 use std::path::{Path, PathBuf};
@@ -726,6 +726,7 @@ mod tests {
             assert!(url.contains("kotlin-native-prebuilt"));
             assert!(url.contains(".tar.gz"));
             assert!(url.starts_with("https://"));
+            assert!(url.contains("download.jetbrains.com"));
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `("linux", "aarch64")` to `platform_slug()` and `jre_platform_slug()` so linux_arm64 hosts can download toolchains
- Switches `download_url()` from `github.com/JetBrains/kotlin/releases` to `download.jetbrains.com` — the linux-aarch64 tarballs exist on JetBrains' download server but are not published to GitHub releases
- Updates `jre_platform_slug_valid` test to include `("linux", "aarch64")`

Replaces #105 (which incorrectly removed linux_arm64 support).

Fixes #83

## Test plan
- [x] `cargo test -p konvoy-konanc` passes (59 tests)
- [x] `cargo test -p konvoy-targets` passes (15 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Verified `download.jetbrains.com` returns 302 for linux-aarch64, linux-x86_64, and macos-aarch64 tarballs
- [x] Verified Adoptium API returns 307 for linux/aarch64 JRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)