### PR TITLE
Propagate lockfile serialization errors (#84)

### DIFF
--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -72,7 +72,7 @@ pub fn build_tests(
     // Build dependencies first (same as regular build).
     let dep_graph = resolve_dependencies(project_root, &manifest)?;
     let mut library_paths: Vec<PathBuf> = Vec::new();
-    let lockfile_content = lockfile_toml_content(&lockfile);
+    let lockfile_content = lockfile_toml_content(&lockfile)?;
 
     for dep in &dep_graph.order {
         let (dep_output, _) = crate::build::build_single(


### PR DESCRIPTION
## Summary
- Changes `lockfile_toml_content()` to return `Result<String, EngineError>` instead of silently returning empty string via `unwrap_or_default()`
- Updates all call sites in `build.rs` and `test_build.rs` to propagate errors with `?`
- Prevents incorrect cache keys when serialization fails

## Test plan
- [x] `cargo test -p konvoy-engine` passes (107 tests)
- [x] `cargo clippy -p konvoy-engine -- -D warnings` clean

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)