### PR TITLE
Replace rand_u32() with tempfile crate for secure temp files (#90)

### DIFF
--- a/crates/konvoy-konanc/Cargo.toml
+++ b/crates/konvoy-konanc/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 flate2.workspace = true
 konvoy-util.workspace = true
 tar.workspace = true
+tempfile = "3"
 thiserror.workspace = true
 
 [dev-dependencies]
-tempfile = "3"


### PR DESCRIPTION
## Summary
- Removes `rand_u32()` and `temp_suffix()` which used low-entropy `SystemTime` hashing and fell back to static values on error
- Uses `tempfile::Builder` for both tarball downloads and extraction directories in toolchain install
- Promotes `tempfile` from dev-dependency to regular dependency in konvoy-konanc

## Test plan
- [x] `cargo test -p konvoy-konanc` passes (59 tests)
- [x] `cargo clippy -p konvoy-konanc -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Uniqueness tests verify tempfile/tempdir names are distinct

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)