### PR TITLE
Fix TOCTOU race in ArtifactStore::store with atomic rename (#88)

### DIFF
--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -5,6 +5,9 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
+use crate::cache::CacheKey;
+use crate::error::EngineError;
+
 /// Guard that removes a temporary directory when dropped, unless disarmed.
 struct TempDirGuard {
     path: Option<PathBuf>,
@@ -28,9 +31,6 @@ impl Drop for TempDirGuard {
         }
     }
 }
-
-use crate::cache::CacheKey;
-use crate::error::EngineError;
 
 /// Metadata stored alongside a cached artifact.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Replaces check-then-create pattern with atomic write-to-temp-then-rename
- Adds `TempDirGuard` RAII struct for automatic temp directory cleanup on all error paths
- Handles concurrent store races: `AlreadyExists` and `DirectoryNotEmpty` return success (immutable cache semantics)
- No new dependencies — uses `std::collections::hash_map::RandomState` for entropy

## Test plan
- [x] `cargo test -p konvoy-engine` passes (108 tests)
- [x] `cargo clippy -p konvoy-engine -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `concurrent_store_same_key` — 8-thread barrier test verifies race safety
- [x] `store_cleans_up_temp_dirs` — verifies no temp dirs remain after store

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)