### PR TITLE
Make tempfile a workspace dependency (#102)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2"
 toml = "0.8"
 ureq = "3"
 proptest = "1"
+tempfile = "3"
 
 konvoy-config = { path = "crates/konvoy-config" }
 konvoy-engine = { path = "crates/konvoy-engine" }

--- a/crates/konvoy-engine/Cargo.toml
+++ b/crates/konvoy-engine/Cargo.toml
@@ -18,4 +18,4 @@ toml.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-tempfile = "3"
+tempfile.workspace = true

--- a/crates/konvoy-konanc/Cargo.toml
+++ b/crates/konvoy-konanc/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 flate2.workspace = true
 konvoy-util.workspace = true
 tar.workspace = true
-tempfile = "3"
+tempfile.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/konvoy-util/Cargo.toml
+++ b/crates/konvoy-util/Cargo.toml
@@ -14,4 +14,4 @@ thiserror.workspace = true
 ureq.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true


### PR DESCRIPTION
## Summary
- Adds `tempfile = "3"` to `[workspace.dependencies]` in root `Cargo.toml`
- Converts all crate-level tempfile references to `tempfile.workspace = true`

## Test plan
- [x] `cargo test --workspace` passes (319 tests)
- [x] `cargo clippy --workspace -- -D warnings` clean

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)