### PR TITLE
Remove redundant .to_owned() in parse_file_and_line (#96)

### DIFF
--- a/crates/konvoy-konanc/src/invoke.rs
+++ b/crates/konvoy-konanc/src/invoke.rs
@@ -317,13 +317,13 @@ fn parse_file_and_line(s: &str) -> Option<FileLocation> {
     match parts.len() {
         3 => {
             // file:line:col
-            let file = parts.first()?.to_owned().to_owned();
+            let file = (*parts.first()?).to_owned();
             let line: u32 = parts.get(1)?.parse().ok()?;
             Some(FileLocation { file, line })
         }
         2 => {
             // file:line
-            let file = parts.first()?.to_owned().to_owned();
+            let file = (*parts.first()?).to_owned();
             let line: u32 = parts.get(1)?.parse().ok()?;
             Some(FileLocation { file, line })
         }


### PR DESCRIPTION
## Summary
- Fixes `parts.first()?.to_owned().to_owned()` to `(*parts.first()?).to_owned()` in `parse_file_and_line()`
- Eliminates redundant intermediate copy

## Test plan
- [x] `cargo test -p konvoy-konanc` passes (59 tests)
- [x] `cargo clippy -p konvoy-konanc -- -D warnings` clean

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)