### PR TITLE
Extract shared .kexe suffix handling into helper (#94)

### DIFF
--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -217,13 +217,7 @@ pub fn build_tests(
     }
 
     // Handle .kexe suffix on Linux.
-    let kexe_path = output_path.with_extension("kexe");
-    if !output_path.exists() && kexe_path.exists() {
-        std::fs::rename(&kexe_path, &output_path).map_err(|source| EngineError::Io {
-            path: output_path.display().to_string(),
-            source,
-        })?;
-    }
+    crate::build::normalize_konanc_output(&output_path)?;
 
     // Store in cache.
     let metadata = BuildMetadata {


### PR DESCRIPTION
## Summary
- Extracts duplicated `.kexe` suffix detection/renaming from `build.rs` and `test_build.rs` into `normalize_konanc_output()` helper
- Both `build_single()` and `build_tests()` now call the shared function

## Test plan
- [x] `cargo test -p konvoy-engine` passes (108 tests)
- [x] `cargo clippy -p konvoy-engine -- -D warnings` clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)