### PR TITLE
Remove dead CacheInputs::with_platform_defaults() method (#95)

### DIFF
--- a/crates/konvoy-engine/src/cache.rs
+++ b/crates/konvoy-engine/src/cache.rs
@@ -32,15 +32,6 @@ pub struct CacheInputs {
     pub dependency_hashes: Vec<String>,
 }
 
-impl CacheInputs {
-    /// Create inputs with OS and arch auto-detected from the current platform.
-    pub fn with_platform_defaults(mut self) -> Self {
-        self.os = std::env::consts::OS.to_owned();
-        self.arch = std::env::consts::ARCH.to_owned();
-        self
-    }
-}
-
 /// A content-addressed cache key wrapping a SHA-256 hex string.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CacheKey(String);


### PR DESCRIPTION
## Summary
- Removes the unused `with_platform_defaults()` method from `CacheInputs` in `konvoy-engine`
- The method was never called anywhere in production or test code

Closes #95

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)