### PR TITLE
Replace leaking custom tempdir() with tempfile::TempDir in lockfile tests (#97)

### DIFF
--- a/crates/konvoy-config/Cargo.toml
+++ b/crates/konvoy-config/Cargo.toml
@@ -14,3 +14,4 @@ toml.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+tempfile.workspace = true


### PR DESCRIPTION
## Summary
- Replaces manual `std::env::temp_dir()` + `create_dir_all()` in lockfile tests with `tempfile::TempDir`
- Ensures test temp directories are automatically cleaned up when the `TempDir` guard drops
- Adds `tempfile` as a dev-dependency to `konvoy-config`

Closes #97

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)