### PR TITLE
Deduplicate diagnostics in detect_toolchain_errors (#100)

### DIFF
--- a/crates/konvoy-konanc/src/invoke.rs
+++ b/crates/konvoy-konanc/src/invoke.rs
@@ -552,8 +552,7 @@ mod tests {
         // Pre-populate diagnostics with the same message that detect_toolchain_errors would add
         let mut diags = vec![Diagnostic {
             level: DiagnosticLevel::Error,
-            message: "Xcode Command Line Tools not found — run `xcode-select --install`"
-                .to_owned(),
+            message: "Xcode Command Line Tools not found — run `xcode-select --install`".to_owned(),
             file: None,
             line: None,
         }];


### PR DESCRIPTION
## Summary
- Adds `HashSet`-based deduplication to `detect_toolchain_errors()` in `konvoy-konanc`
- Prevents duplicate diagnostic messages when the same toolchain error appears multiple times in compiler output
- Adds tests verifying deduplication behavior

Closes #100

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)