### PR TITLE
Scope konvoy clean to only remove .konvoy/build/ by default (#101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "konvoy-konanc",
  "konvoy-targets",
  "konvoy-util",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/konvoy-cli/Cargo.toml
+++ b/crates/konvoy-cli/Cargo.toml
@@ -18,3 +18,6 @@ konvoy-engine.workspace = true
 konvoy-konanc.workspace = true
 konvoy-targets.workspace = true
 konvoy-util.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true


### PR DESCRIPTION
## Summary
- Changes `konvoy clean` to only remove `.konvoy/build/` by default, preserving cache and other state
- Adds `--all` flag to restore the old behavior of removing the entire `.konvoy/` directory
- Both modes print what was removed
- Adds `clean_project` behavior tests covering default, `--all`, and idempotent edge cases

Closes #101

## Test plan
- [x] `cargo test --workspace` passes (58 CLI tests including 4 new `clean_project` tests)
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)