### PR TITLE
Add release notes configuration for categorized changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Security
+      labels:
+        - security
+    - title: Bug Fixes
+      labels:
+        - bug
+        - correctness
+    - title: Enhancements
+      labels:
+        - enhancement
+        - high-priority
+    - title: Testing
+      labels:
+        - testing
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/release.yml` to configure GitHub's auto-generated release notes
- Groups PRs into categories: Security, Bug Fixes, Enhancements, Testing, Other
- Excludes PRs labeled `duplicate`, `invalid`, or `wontfix`

## Test plan
- [ ] Next release (after v0.0.1) shows categorized release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)