### PR TITLE
Fix --force flag to bypass build cache (#139)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "serde",
+ "tempfile",
  "thiserror",
  "toml",
 ]


### PR DESCRIPTION
## Summary
- The `--force` flag was not bypassing the build cache in `build_single`, causing `konvoy build --force` to return cached artifacts instead of recompiling.
- Updated the cache check in `build_single` to skip the cache lookup when `options.force` is `true`.
- Added a test (`build_single_force_bypasses_cache`) that verifies: without `--force` a pre-populated cache returns `Cached`, and with `--force` the cache is skipped (triggering a compilation attempt that fails because the fake `konanc` path doesn't exist, proving the cache was bypassed).

## Test plan
- [x] `cargo test -p konvoy-engine` passes (112 tests, including the new `build_single_force_bypasses_cache`)
- [x] `cargo fmt --all` produces no changes

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)