### PR TITLE
Return actionable error when explicit --config path does not exist (#136)

### DIFF
--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -269,22 +269,28 @@ fn resolve_java_bin(kotlin_version: &str) -> Result<(PathBuf, PathBuf), EngineEr
 
 /// Resolve the detekt config file path.
 ///
-/// If `--config` was passed, resolve it relative to the project root.
+/// If `--config` was passed, resolve it relative to the project root and
+/// verify the file exists (returning an error if it does not).
 /// Otherwise, use `detekt.yml` in the project root if it exists.
-fn resolve_config(root: &Path, explicit: Option<&Path>) -> Option<PathBuf> {
+fn resolve_config(root: &Path, explicit: Option<&Path>) -> Result<Option<PathBuf>, EngineError> {
     if let Some(cfg) = explicit {
         let resolved = if cfg.is_relative() {
             root.join(cfg)
         } else {
             cfg.to_path_buf()
         };
-        Some(resolved)
+        if !resolved.exists() {
+            return Err(EngineError::ConfigNotFound {
+                path: resolved.display().to_string(),
+            });
+        }
+        Ok(Some(resolved))
     } else {
         let default_config = root.join("detekt.yml");
         if default_config.exists() {
-            Some(default_config)
+            Ok(Some(default_config))
         } else {
-            None
+            Ok(None)
         }
     }
 }
@@ -335,7 +341,7 @@ fn run_detekt_process(
         }
     }
 
-    let diagnostics = parse_detekt_output(&raw_stdout);
+    let diagnostics = parse_detekt_output(&raw_output);
     let finding_count = diagnostics.len();
     let success = output.status.success();
 
@@ -410,7 +416,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     }
 
     // Resolve config and run detekt.
-    let config_path = resolve_config(root, options.config.as_deref());
+    let config_path = resolve_config(root, options.config.as_deref())?;
     run_detekt_process(
         &java_bin,
         &jre_home,
@@ -535,7 +541,9 @@ fn parse_detekt_line(line: &str) -> Option<DetektDiagnostic> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::{detekt_download_url, detekt_jar_path, parse_detekt_output, validate_version};
+    use super::{
+        detekt_download_url, detekt_jar_path, parse_detekt_output, resolve_config, validate_version,
+    };
 
     #[test]
     fn detekt_download_url_format() {
@@ -617,6 +625,38 @@ src/main.kt:3:5: MagicNumber - Magic number. [detekt.style]
         let diags = parse_detekt_output(output);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags.first().map(|d| d.rule.as_str()), Some("MagicNumber"));
+    }
+
+    /// Simulates combined stdout+stderr output from detekt, which is what
+    /// `run_detekt_process` now feeds to `parse_detekt_output`. Before the
+    /// fix for issue #134, only stdout was parsed (which typically contains
+    /// summary info), so finding_count was always 0.
+    #[test]
+    fn parse_detekt_combined_stdout_stderr() {
+        // Simulate stdout (summary) followed by stderr (findings).
+        let combined = "\
+detekt finished in 1234ms
+Overall debt: 30min
+
+src/main.kt:3:5: MagicNumber - Magic number. [detekt.style]
+src/util.kt:20:1: LongMethod - Method too long. [detekt.complexity]
+src/app.kt:5:10: EmptyFunctionBlock - Empty function. [detekt.empty-blocks]
+src/app.kt:12:1: MaxLineLength - Line is too long. [detekt.style]
+";
+        let diags = parse_detekt_output(combined);
+        assert_eq!(
+            diags.len(),
+            4,
+            "expected 4 findings from combined output, got {}",
+            diags.len()
+        );
+        assert_eq!(diags.get(0).map(|d| d.rule.as_str()), Some("MagicNumber"));
+        assert_eq!(diags.get(1).map(|d| d.rule.as_str()), Some("LongMethod"));
+        assert_eq!(
+            diags.get(2).map(|d| d.rule.as_str()),
+            Some("EmptyFunctionBlock")
+        );
+        assert_eq!(diags.get(3).map(|d| d.rule.as_str()), Some("MaxLineLength"));
     }
 
     #[test]
@@ -720,5 +760,63 @@ src/main.kt:3:5: MagicNumber - Magic number. [detekt.style]
         let (path, hash) = result.unwrap();
         assert_eq!(hash, real_hash);
         assert!(path.display().to_string().contains(version));
+    }
+
+    #[test]
+    fn resolve_config_errors_on_missing_explicit_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let missing = std::path::Path::new("nonexistent.yml");
+        let result = resolve_config(root, Some(missing));
+        assert!(result.is_err(), "expected Err for missing explicit config");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("config file not found"), "error was: {err}");
+        assert!(
+            err.contains("nonexistent.yml"),
+            "error should mention the path: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_config_returns_existing_explicit_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let cfg_path = root.join("my-detekt.yml");
+        std::fs::write(&cfg_path, "# config").unwrap();
+        let result = resolve_config(root, Some(std::path::Path::new("my-detekt.yml")));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        let resolved = result.unwrap();
+        assert_eq!(resolved, Some(cfg_path));
+    }
+
+    #[test]
+    fn resolve_config_returns_absolute_explicit_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let cfg_path = tmp.path().join("absolute-detekt.yml");
+        std::fs::write(&cfg_path, "# config").unwrap();
+        let result = resolve_config(root, Some(&cfg_path));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(result.unwrap(), Some(cfg_path));
+    }
+
+    #[test]
+    fn resolve_config_uses_default_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let default_cfg = root.join("detekt.yml");
+        std::fs::write(&default_cfg, "# default config").unwrap();
+        let result = resolve_config(root, None);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(result.unwrap(), Some(default_cfg));
+    }
+
+    #[test]
+    fn resolve_config_returns_none_when_no_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let result = resolve_config(root, None);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(result.unwrap(), None);
     }
 }

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -119,4 +119,12 @@ pub enum EngineError {
     /// Lint not configured.
     #[error("detekt not configured — add `detekt = \"1.23.7\"` to [toolchain] in konvoy.toml")]
     LintNotConfigured,
+
+    /// The project name supplied to `konvoy init` is invalid.
+    #[error("invalid project name \"{name}\": {reason}")]
+    InvalidProjectName { name: String, reason: String },
+
+    /// An explicit config file was not found on disk.
+    #[error("config file not found: {path} — check the --config path or create the file")]
+    ConfigNotFound { path: String },
 }


### PR DESCRIPTION
## Summary
- Changed `resolve_config` to return `Result<Option<PathBuf>, EngineError>` so it can validate that an explicit `--config` path exists on disk before using it
- Added `EngineError::ConfigNotFound` variant with actionable message guiding users to check the path or create the file
- Added tests for the new error path and the happy path

## Test plan
- [x] `cargo test -p konvoy-engine` passes (117 tests)
- [x] `cargo fmt --all` clean

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)