### PR TITLE
Support in-place project init when --name is omitted

### DIFF
--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -16,6 +16,6 @@ pub use build::{build, BuildOptions, BuildOutcome, BuildResult};
 pub use cache::{CacheInputs, CacheKey};
 pub use detekt::{lint, DetektDiagnostic, LintOptions, LintResult};
 pub use error::EngineError;
-pub use init::{init_project, init_project_with_kind};
+pub use init::{init_project, init_project_in_place, init_project_with_kind};
 pub use resolve::{resolve_dependencies, ResolvedGraph};
 pub use test_build::{build_tests, TestBuildResult, TestOptions};


### PR DESCRIPTION
## Summary
- `konvoy init` (no `--name`) now initializes in the current directory, deriving the project name from the directory name
- `konvoy init --name foo` preserves existing behavior (creates subdirectory)
- Adds `init_project_in_place()` function with 6 unit tests

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)