### PR TITLE
Fix --force flag help text to describe cache bypass

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -38,7 +38,7 @@ enum Command {
         /// Show compiler output
         #[arg(long)]
         verbose: bool,
-        /// Allow overriding hash mismatch checks
+        /// Force a rebuild, bypassing the cache
         #[arg(long)]
         force: bool,
         /// Require the lockfile to be up-to-date; error on any mismatch
@@ -56,7 +56,7 @@ enum Command {
         /// Show compiler output
         #[arg(long, short = 'v')]
         verbose: bool,
-        /// Allow overriding hash mismatch checks
+        /// Force a rebuild, bypassing the cache
         #[arg(long)]
         force: bool,
         /// Require the lockfile to be up-to-date; error on any mismatch
@@ -77,7 +77,7 @@ enum Command {
         /// Show compiler output
         #[arg(long)]
         verbose: bool,
-        /// Allow overriding hash mismatch checks
+        /// Force a rebuild, bypassing the cache
         #[arg(long)]
         force: bool,
         /// Require the lockfile to be up-to-date; error on any mismatch

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -23,7 +23,7 @@ pub struct BuildOptions {
     pub release: bool,
     /// Whether to show raw compiler output.
     pub verbose: bool,
-    /// Allow overriding hash mismatch checks.
+    /// Force a rebuild, bypassing the cache.
     pub force: bool,
     /// Require the lockfile to be up-to-date; error on any mismatch.
     pub locked: bool,

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -23,7 +23,7 @@ pub struct TestOptions {
     pub release: bool,
     /// Whether to show raw compiler output.
     pub verbose: bool,
-    /// Allow overriding hash mismatch checks.
+    /// Force a rebuild, bypassing the cache.
     pub force: bool,
     /// Require the lockfile to be up-to-date; error on any mismatch.
     pub locked: bool,


### PR DESCRIPTION
## Summary
- Updates `--force` help description from "Allow overriding hash mismatch checks" to "Force a rebuild, bypassing the cache"
- Updated in all 5 locations: build, run, and test commands in CLI, plus BuildOptions and TestOptions structs

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)