### PR TITLE
Extract finalize_hex helper to deduplicate hash formatting

### DIFF
--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 use crate::error::UtilError;
+use crate::hash::finalize_hex;
 
 /// Convert `usize` to `u64`. Infallible on 32-bit and 64-bit platforms.
 fn u64_from_usize(n: usize) -> u64 {
@@ -101,7 +102,7 @@ pub fn download_with_progress(
         eprintln!("    Downloaded {label} {version} ({mb} MB)");
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(finalize_hex(hasher))
 }
 
 #[cfg(test)]

--- a/crates/konvoy-util/src/hash.rs
+++ b/crates/konvoy-util/src/hash.rs
@@ -6,11 +6,16 @@ use sha2::{Digest, Sha256};
 
 use crate::error::UtilError;
 
+/// Format a finalized SHA-256 hasher as a lowercase hex string.
+pub(crate) fn finalize_hex(hasher: Sha256) -> String {
+    format!("{:x}", hasher.finalize())
+}
+
 /// Compute the SHA-256 hex digest of a byte slice.
 pub fn sha256_bytes(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    finalize_hex(hasher)
 }
 
 /// Compute the SHA-256 hex digest of a file using streaming reads.
@@ -41,7 +46,7 @@ pub fn sha256_file(path: &Path) -> Result<String, UtilError> {
         };
         hasher.update(chunk);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(finalize_hex(hasher))
 }
 
 /// Hash all files matching `pattern` inside `dir`, sorted by relative path for determinism.
@@ -80,7 +85,7 @@ pub fn sha256_dir(dir: &Path, pattern: &str) -> Result<String, UtilError> {
         hasher.update(&data);
     }
 
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(finalize_hex(hasher))
 }
 
 /// Combine multiple string parts into a single composite SHA-256 hash.
@@ -94,7 +99,7 @@ pub fn sha256_multi(parts: &[&str]) -> String {
         hasher.update(len_bytes);
         hasher.update(part.as_bytes());
     }
-    format!("{:x}", hasher.finalize())
+    finalize_hex(hasher)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Extracts a `pub(crate) fn finalize_hex(hasher: Sha256) -> String` helper in `konvoy-util/src/hash.rs` to eliminate the repeated `format!("{:x}", hasher.finalize())` pattern
- Replaces all 5 call sites: 4 in `hash.rs` (`sha256_bytes`, `sha256_file`, `sha256_dir`, `sha256_multi`) and 1 in `download.rs` (`download_with_progress`)

Closes #175

## Test plan
- [x] `cargo test -p konvoy-util` -- all 56 tests pass
- [x] `cargo clippy -p konvoy-util -- -D warnings` -- no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)