### PR TITLE
Move cmd_toolchain above test module in main.rs

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -493,6 +493,53 @@ fn cmd_doctor() -> CliResult {
     }
 }
 
+fn cmd_toolchain(action: ToolchainAction) -> CliResult {
+    match action {
+        ToolchainAction::Install { version } => {
+            let version = if let Some(v) = version {
+                v
+            } else {
+                // Read version from konvoy.toml in current directory.
+                let cwd = std::env::current_dir()?;
+                let manifest_path = cwd.join("konvoy.toml");
+                let manifest = konvoy_config::Manifest::from_path(&manifest_path)?;
+                manifest.toolchain.kotlin
+            };
+
+            match konvoy_konanc::toolchain::is_installed(&version) {
+                Ok(true) => {
+                    eprintln!("    Kotlin/Native {version} is already installed");
+                    return Ok(());
+                }
+                Ok(false) => {}
+                Err(e) => return Err(e.into()),
+            }
+
+            eprintln!("    Installing Kotlin/Native {version}...");
+            let result = konvoy_konanc::toolchain::install(&version)?;
+            eprintln!(
+                "    Installed Kotlin/Native {version} at {}",
+                result.konanc_path.display()
+            );
+            Ok(())
+        }
+        ToolchainAction::List => {
+            let versions = konvoy_konanc::toolchain::list_installed()?;
+            if versions.is_empty() {
+                eprintln!("No toolchains installed");
+                eprintln!();
+                eprintln!("  Install one with: konvoy toolchain install <version>");
+            } else {
+                eprintln!("Installed toolchains:");
+                for v in &versions {
+                    eprintln!("  {v}");
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1186,52 +1233,5 @@ mod tests {
     fn help_flag_on_lint() {
         let err = Cli::try_parse_from(["konvoy", "lint", "--help"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DisplayHelp);
-    }
-}
-
-fn cmd_toolchain(action: ToolchainAction) -> CliResult {
-    match action {
-        ToolchainAction::Install { version } => {
-            let version = if let Some(v) = version {
-                v
-            } else {
-                // Read version from konvoy.toml in current directory.
-                let cwd = std::env::current_dir()?;
-                let manifest_path = cwd.join("konvoy.toml");
-                let manifest = konvoy_config::Manifest::from_path(&manifest_path)?;
-                manifest.toolchain.kotlin
-            };
-
-            match konvoy_konanc::toolchain::is_installed(&version) {
-                Ok(true) => {
-                    eprintln!("    Kotlin/Native {version} is already installed");
-                    return Ok(());
-                }
-                Ok(false) => {}
-                Err(e) => return Err(e.into()),
-            }
-
-            eprintln!("    Installing Kotlin/Native {version}...");
-            let result = konvoy_konanc::toolchain::install(&version)?;
-            eprintln!(
-                "    Installed Kotlin/Native {version} at {}",
-                result.konanc_path.display()
-            );
-            Ok(())
-        }
-        ToolchainAction::List => {
-            let versions = konvoy_konanc::toolchain::list_installed()?;
-            if versions.is_empty() {
-                eprintln!("No toolchains installed");
-                eprintln!();
-                eprintln!("  Install one with: konvoy toolchain install <version>");
-            } else {
-                eprintln!("Installed toolchains:");
-                for v in &versions {
-                    eprintln!("  {v}");
-                }
-            }
-            Ok(())
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Moved the `cmd_toolchain` function from after the `#[cfg(test)] mod tests` block to just before it, alongside the other `cmd_*` functions
- Production code should not be split around test modules; the `#[cfg(test)] mod tests` block is now the last thing in the file
- Pure code movement with no logic changes

Closes #176

## Test plan
- [x] `cargo test -p konvoy-cli` -- all 56 tests pass
- [x] `cargo clippy -p konvoy-cli -- -D warnings` -- no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)