### PR TITLE
Add tests for fs.rs and download.rs (#182)

### DIFF
--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -189,8 +189,7 @@ mod tests {
     fn download_malformed_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result =
-            super::download_with_progress("not-a-valid-url", &dest, "test", "0.0");
+        let result = super::download_with_progress("not-a-valid-url", &dest, "test", "0.0");
         assert!(result.is_err());
     }
 

--- a/crates/konvoy-util/src/fs.rs
+++ b/crates/konvoy-util/src/fs.rs
@@ -353,13 +353,7 @@ mod tests {
     #[test]
     fn ensure_dir_deeply_nested() {
         let tmp = tempfile::tempdir().unwrap();
-        let deep = tmp
-            .path()
-            .join("x")
-            .join("y")
-            .join("z")
-            .join("w")
-            .join("v");
+        let deep = tmp.path().join("x").join("y").join("z").join("w").join("v");
         ensure_dir(&deep).unwrap();
         assert!(deep.is_dir());
         // Calling again on the same path is a no-op.
@@ -387,7 +381,11 @@ mod tests {
         let src = tmp.path().join("src.txt");
         let dest = tmp.path().join("dest.txt");
         // Write a large old file, then a small new source.
-        fs::write(&dest, b"this is a much longer old content that should be replaced").unwrap();
+        fs::write(
+            &dest,
+            b"this is a much longer old content that should be replaced",
+        )
+        .unwrap();
         fs::write(&src, b"short").unwrap();
 
         materialize(&src, &dest).unwrap();


### PR DESCRIPTION
## Summary
- Adds additional unit tests for `crates/konvoy-util/src/fs.rs`: deeply nested `ensure_dir`, `materialize` content matching and overwrite of larger files, deeply nested `remove_dir_all_if_exists`, `konvoy_home` with custom HOME variable, `collect_files` edge cases (deeply nested, no matching extension), and `materialize` error on nonexistent source
- Adds additional unit tests for `crates/konvoy-util/src/download.rs`: `pct_u8` rounding, exact multiples of ten, large values, single-byte edge cases, `u64_from_usize` max value, and error paths for malformed URLs and unwritable destinations
- All tests run without network access; no HTTP mocking required

Closes #182

## Test plan
- [x] `cargo test -p konvoy-util` — all 71 tests pass
- [x] `cargo clippy -p konvoy-util --tests -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)