### PR TITLE
Add #[from] for KonancError and TargetError in EngineError

### DIFF
--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -92,7 +92,7 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
     let profile = if options.release { "release" } else { "debug" };
 
     // 5. Resolve managed konanc toolchain.
-    let resolved = resolve_konanc(&manifest.toolchain.kotlin).map_err(EngineError::Konanc)?;
+    let resolved = resolve_konanc(&manifest.toolchain.kotlin)?;
     let konanc = resolved.info;
     let jre_home = resolved.jre_home.clone();
 
@@ -366,9 +366,9 @@ pub(crate) fn build_single(
 /// or if host detection fails on an unsupported platform.
 pub(crate) fn resolve_target(target_opt: &Option<String>) -> Result<Target, EngineError> {
     match target_opt {
-        Some(name) if name == "host" => host_target().map_err(EngineError::Target),
-        Some(name) => name.parse::<Target>().map_err(EngineError::Target),
-        None => host_target().map_err(EngineError::Target),
+        Some(name) if name == "host" => Ok(host_target()?),
+        Some(name) => Ok(name.parse::<Target>()?),
+        None => Ok(host_target()?),
     }
 }
 
@@ -403,7 +403,7 @@ fn compile(
         cmd = cmd.java_home(jh);
     }
 
-    let result = cmd.execute(konanc).map_err(EngineError::Konanc)?;
+    let result = cmd.execute(konanc)?;
 
     crate::diagnostics::print_diagnostics(&result, options.verbose);
 

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -251,13 +251,12 @@ fn persist_detekt_hash(
 ///
 /// Auto-installs the toolchain if it is not yet present.
 fn resolve_java_bin(kotlin_version: &str) -> Result<(PathBuf, PathBuf), EngineError> {
-    if !konvoy_konanc::toolchain::is_installed(kotlin_version).map_err(EngineError::Konanc)? {
+    if !konvoy_konanc::toolchain::is_installed(kotlin_version)? {
         eprintln!("    Installing Kotlin/Native {kotlin_version} (for JRE)...");
-        konvoy_konanc::toolchain::install(kotlin_version).map_err(EngineError::Konanc)?;
+        konvoy_konanc::toolchain::install(kotlin_version)?;
     }
 
-    let jre_home =
-        konvoy_konanc::toolchain::jre_home_path(kotlin_version).map_err(EngineError::Konanc)?;
+    let jre_home = konvoy_konanc::toolchain::jre_home_path(kotlin_version)?;
 
     let java_bin = jre_home.join("bin").join("java");
     if !java_bin.exists() {

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -28,11 +28,11 @@ pub enum EngineError {
 
     /// A compiler operation failed.
     #[error("{0}")]
-    Konanc(konvoy_konanc::error::KonancError),
+    Konanc(#[from] konvoy_konanc::error::KonancError),
 
     /// A target resolution failed.
     #[error("{0}")]
-    Target(konvoy_targets::TargetError),
+    Target(#[from] konvoy_targets::TargetError),
 
     /// Lockfile error.
     #[error("lockfile error: {0}")]

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -65,7 +65,7 @@ pub fn build_tests(
     let target = resolve_target(&options.target)?;
     let profile = if options.release { "release" } else { "debug" };
 
-    let resolved = resolve_konanc(&manifest.toolchain.kotlin).map_err(EngineError::Konanc)?;
+    let resolved = resolve_konanc(&manifest.toolchain.kotlin)?;
     let jre_home = resolved.jre_home;
     let konanc = resolved.info;
 
@@ -187,7 +187,7 @@ pub fn build_tests(
         cmd = cmd.java_home(jh);
     }
 
-    let result = cmd.execute(&konanc).map_err(EngineError::Konanc)?;
+    let result = cmd.execute(&konanc)?;
 
     crate::diagnostics::print_diagnostics(&result, options.verbose);
 


### PR DESCRIPTION
## Summary
- Add `#[from]` attribute to `EngineError::Konanc` and `EngineError::Target` variants, enabling automatic `From` conversions via thiserror
- Remove 10 manual `.map_err(EngineError::Konanc)` and `.map_err(EngineError::Target)` calls across `build.rs`, `detekt.rs`, and `test_build.rs`, replacing them with idiomatic `?` operator usage

Closes #172

## Test plan
- [x] `cargo test -p konvoy-engine` -- all 185 tests pass
- [x] `cargo clippy -p konvoy-engine -- -D warnings` -- no warnings
- [x] `cargo test --workspace` -- all 439 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)