### PR TITLE
Consolidate duplicate NoHomeDir error variants

### DIFF
--- a/crates/konvoy-konanc/src/error.rs
+++ b/crates/konvoy-konanc/src/error.rs
@@ -47,9 +47,9 @@ pub enum KonancError {
         fix_command: String,
     },
 
-    /// Could not determine user home directory.
-    #[error("cannot determine home directory — set the HOME environment variable")]
-    NoHomeDir,
+    /// An error propagated from konvoy-util.
+    #[error("{0}")]
+    Util(#[from] konvoy_util::error::UtilError),
 
     /// The host platform is not supported for managed toolchain downloads.
     #[error("unsupported platform {os}/{arch} — Kotlin/Native prebuilt binaries are not available for this platform")]

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -42,7 +42,7 @@ pub struct InstallResult {
 /// # Errors
 /// Returns an error if the home directory cannot be determined.
 pub fn toolchains_dir() -> Result<PathBuf, KonancError> {
-    let konvoy_home = konvoy_util::fs::konvoy_home().map_err(|_| KonancError::NoHomeDir)?;
+    let konvoy_home = konvoy_util::fs::konvoy_home()?;
     Ok(konvoy_home.join("toolchains"))
 }
 


### PR DESCRIPTION
## Summary
- Removes the duplicate `KonancError::NoHomeDir` variant from `konvoy-konanc`
- Adds a generic `KonancError::Util(#[from] UtilError)` variant that auto-converts `UtilError` into `KonancError`
- Simplifies `toolchains_dir()` to use `?` instead of manual `.map_err(|_| KonancError::NoHomeDir)`

Closes #177

## Test plan
- [x] `cargo test -p konvoy-konanc` — all 63 tests pass
- [x] `cargo clippy -p konvoy-konanc -- -D warnings` — no warnings
- [x] `cargo test --workspace` — all 439 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)