### PR TITLE
Add tests for toolchain download/install edge cases (#181)

### DIFF
--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -1089,10 +1089,7 @@ mod tests {
         std::fs::create_dir(dir.path().join("bar")).unwrap();
 
         let result = find_extracted_root(dir.path(), "2.1.0");
-        assert!(
-            result.is_err(),
-            "multiple non-matching dirs should error"
-        );
+        assert!(result.is_err(), "multiple non-matching dirs should error");
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("found 2 entries"),


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for `find_extracted_root` edge cases: empty directory, files-only directory, single entry, multiple entries with/without matching names, and version mismatch
- Add tests for `managed_konanc_path` and `version_dir` structural path assertions (e.g., ends-with checks)
- Add tests for JRE home path layout detection (Linux vs macOS `Contents/Home`)
- Add tests for `map_download_err` covering all three mapping branches (Download, Io, other-to-Download)
- Add tests for `list_installed` sort order and `is_installed` with nonexistent version
- Document the unreachable `unwrap_or_else` fallback in both `find_jre_root` and `find_extracted_root` with explanatory comments

Closes #181

## Test plan
- [x] `cargo test -p konvoy-konanc` -- all 80 tests pass
- [x] `cargo clippy -p konvoy-konanc -- -D warnings` -- zero warnings
- [x] Only `toolchain.rs` was modified; no changes to `error.rs` (avoids conflict with #177)

🤖 Generated with [Claude Code](https://claude.com/claude-code)