### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,27 @@ env:
   BINARY_NAME: konvoy
 
 jobs:
+  smoke:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build smoke test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tests/smoke/Dockerfile
+          load: true
+          tags: konvoy-smoke:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run smoke tests
+        run: docker run --rm konvoy-smoke:latest bash /build/tests/smoke/tests.sh
+
   build:
     name: Build - ${{ matrix.target }}
+    needs: smoke
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.1.0 to 1.0.0
- Add smoke test gate to release workflow — smoke tests must pass before release builds start

## Test plan
- [x] `cargo build` compiles cleanly
- [x] All 56 smoke tests pass locally
- [x] Release workflow runs smoke tests before build matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)