### PR TITLE
Fix license field from MIT to Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 version = "1.0.0"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Corrects `license` in workspace `Cargo.toml` from `MIT` to `Apache-2.0` to match the actual `LICENSE` file