### PR TITLE
Scope konvoy clean to only remove .konvoy/build/ by default (#101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "konvoy-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "konvoy-config",
@@ -433,11 +433,12 @@ dependencies = [
  "konvoy-konanc",
  "konvoy-targets",
  "konvoy-util",
+ "tempfile",
 ]
 
 [[package]]
 name = "konvoy-config"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "proptest",
  "serde",
@@ -448,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-engine"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "konvoy-config",
  "konvoy-konanc",
@@ -464,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-konanc"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "flate2",
  "konvoy-util",
@@ -475,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-targets"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "proptest",
  "thiserror",
@@ -483,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-util"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "glob",
  "sha2",

--- a/crates/konvoy-cli/Cargo.toml
+++ b/crates/konvoy-cli/Cargo.toml
@@ -18,3 +18,6 @@ konvoy-engine.workspace = true
 konvoy-konanc.workspace = true
 konvoy-targets.workspace = true
 konvoy-util.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -102,7 +102,11 @@ enum Command {
     /// Resolve Maven dependencies and update konvoy.lock
     Update,
     /// Remove build artifacts
-    Clean,
+    Clean {
+        /// Remove the entire .konvoy/ directory, not just build artifacts
+        #[arg(long)]
+        all: bool,
+    },
     /// Check environment and toolchain setup
     Doctor,
     /// Manage Kotlin/Native toolchains
@@ -157,7 +161,7 @@ fn main() {
             locked,
         } => cmd_lint(verbose, config, locked),
         Command::Update => cmd_update(),
-        Command::Clean => cmd_clean(),
+        Command::Clean { all } => cmd_clean(all),
         Command::Doctor => cmd_doctor(),
         Command::Toolchain { action } => cmd_toolchain(action),
     };
@@ -393,13 +397,23 @@ fn cmd_update() -> CliResult {
     Ok(())
 }
 
-fn cmd_clean() -> CliResult {
+fn cmd_clean(all: bool) -> CliResult {
     let root = project_root()?;
+    clean_project(&root, all)
+}
+
+fn clean_project(root: &std::path::Path, all: bool) -> CliResult {
     let konvoy_dir = root.join(".konvoy");
 
-    konvoy_util::fs::remove_dir_all_if_exists(&konvoy_dir)?;
+    if all {
+        konvoy_util::fs::remove_dir_all_if_exists(&konvoy_dir)?;
+        eprintln!("    Removed .konvoy/");
+    } else {
+        let build_dir = konvoy_dir.join("build");
+        konvoy_util::fs::remove_dir_all_if_exists(&build_dir)?;
+        eprintln!("    Removed build artifacts");
+    }
 
-    eprintln!("    Cleaned build artifacts");
     Ok(())
 }
 
@@ -952,9 +966,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_clean() {
+    fn parse_clean_defaults() {
         let cli = Cli::try_parse_from(["konvoy", "clean"]).unwrap();
-        assert!(matches!(cli.command, Command::Clean));
+        match cli.command {
+            Command::Clean { all } => assert!(!all),
+            other => panic!("expected Clean, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_clean_all() {
+        let cli = Cli::try_parse_from(["konvoy", "clean", "--all"]).unwrap();
+        match cli.command {
+            Command::Clean { all } => assert!(all),
+            other => panic!("expected Clean, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1114,8 +1140,8 @@ mod tests {
     }
 
     #[test]
-    fn error_clean_takes_no_args() {
-        let err = Cli::try_parse_from(["konvoy", "clean", "--all"]).unwrap_err();
+    fn error_clean_unknown_flag() {
+        let err = Cli::try_parse_from(["konvoy", "clean", "--force"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::UnknownArgument);
     }
 
@@ -1334,5 +1360,81 @@ mod tests {
     fn help_flag_on_lint() {
         let err = Cli::try_parse_from(["konvoy", "lint", "--help"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+    }
+
+    // ── clean_project behavior ────────────────────────────────────────
+
+    /// Helper: create a temp project dir with .konvoy/build/ and .konvoy/cache/.
+    fn make_clean_fixture() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let build_dir = root.join(".konvoy").join("build");
+        let cache_dir = root.join(".konvoy").join("cache");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(build_dir.join("artifact.exe"), b"binary").unwrap();
+        std::fs::write(cache_dir.join("key.json"), b"{}").unwrap();
+
+        tmp
+    }
+
+    #[test]
+    fn clean_default_removes_only_build_dir() {
+        let tmp = make_clean_fixture();
+        let root = tmp.path();
+
+        clean_project(root, false).unwrap();
+
+        assert!(
+            !root.join(".konvoy").join("build").exists(),
+            "build dir should be removed"
+        );
+        assert!(
+            root.join(".konvoy").join("cache").exists(),
+            "cache dir should be preserved"
+        );
+        assert!(
+            root.join(".konvoy").exists(),
+            ".konvoy dir should be preserved"
+        );
+    }
+
+    #[test]
+    fn clean_all_removes_entire_konvoy_dir() {
+        let tmp = make_clean_fixture();
+        let root = tmp.path();
+
+        clean_project(root, true).unwrap();
+
+        assert!(
+            !root.join(".konvoy").exists(),
+            ".konvoy dir should be removed"
+        );
+    }
+
+    #[test]
+    fn clean_default_no_build_dir_is_ok() {
+        let tmp = make_clean_fixture();
+        let root = tmp.path();
+
+        std::fs::remove_dir_all(root.join(".konvoy").join("build")).unwrap();
+
+        clean_project(root, false).unwrap();
+
+        assert!(
+            root.join(".konvoy").join("cache").exists(),
+            "cache dir should be preserved"
+        );
+    }
+
+    #[test]
+    fn clean_all_no_konvoy_dir_is_ok() {
+        let tmp = make_clean_fixture();
+        let root = tmp.path();
+
+        std::fs::remove_dir_all(root.join(".konvoy")).unwrap();
+
+        clean_project(root, true).unwrap();
     }
 }

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -272,10 +272,12 @@ test_build_lifecycle() {
     run_output=$(konvoy run 2>/dev/null)
     assert_contains "$run_output" "Hello, lifecycle!"
 
-    # Clean removes artifacts.
+    # Clean removes build artifacts but preserves .konvoy/.
     assert_dir_exists .konvoy
+    assert_dir_exists .konvoy/build
     konvoy clean >/dev/null 2>&1
-    assert_dir_not_exists .konvoy
+    assert_dir_not_exists .konvoy/build
+    assert_dir_exists .konvoy
 
     # Rebuild after clean recompiles.
     local out3
@@ -294,6 +296,55 @@ test_clean_no_konvoy_dir_ok() {
     mkdir -p src
     printf '[package]\nname = "noop"\n\n[toolchain]\nkotlin = "2.1.0"\n' > konvoy.toml
     konvoy clean >/dev/null 2>&1
+}
+
+test_clean_default_preserves_cache() {
+    konvoy init --name clean-keep >/dev/null 2>&1
+    cd clean-keep
+    konvoy build >/dev/null 2>&1
+
+    # Create a cache dir to simulate non-build state.
+    mkdir -p .konvoy/cache
+    echo '{}' > .konvoy/cache/key.json
+
+    konvoy clean >/dev/null 2>&1
+
+    assert_dir_not_exists .konvoy/build
+    assert_dir_exists .konvoy/cache
+    assert_file_exists .konvoy/cache/key.json
+}
+
+test_clean_all_removes_everything() {
+    konvoy init --name clean-all >/dev/null 2>&1
+    cd clean-all
+    konvoy build >/dev/null 2>&1
+
+    mkdir -p .konvoy/cache
+    echo '{}' > .konvoy/cache/key.json
+
+    konvoy clean --all >/dev/null 2>&1
+
+    assert_dir_not_exists .konvoy
+}
+
+test_clean_all_no_konvoy_dir_ok() {
+    mkdir -p src
+    printf '[package]\nname = "noop"\n\n[toolchain]\nkotlin = "2.1.0"\n' > konvoy.toml
+    konvoy clean --all >/dev/null 2>&1
+}
+
+test_clean_rebuild_after_default() {
+    konvoy init --name clean-rebuild >/dev/null 2>&1
+    cd clean-rebuild
+    konvoy build >/dev/null 2>&1
+
+    konvoy clean >/dev/null 2>&1
+    assert_dir_not_exists .konvoy/build
+
+    # Rebuild should recompile.
+    local output
+    output=$(konvoy build 2>&1)
+    assert_contains "$output" "Compiling"
 }
 
 # ---------------------------------------------------------------------------
@@ -1118,6 +1169,10 @@ run_test test_init_includes_toolchain
 run_test test_build_lifecycle
 run_test test_build_release
 run_test test_clean_no_konvoy_dir_ok
+run_test test_clean_default_preserves_cache
+run_test test_clean_all_removes_everything
+run_test test_clean_all_no_konvoy_dir_ok
+run_test test_clean_rebuild_after_default
 
 # doctor (runs after build so toolchain is installed)
 run_test test_doctor_all_ok


### PR DESCRIPTION
## Summary
- Changes `konvoy clean` to only remove `.konvoy/build/` by default, preserving cache and other state
- Adds `--all` flag to restore the old behavior of removing the entire `.konvoy/` directory
- Both modes print what was removed
- Adds `clean_project` behavior tests covering default, `--all`, and idempotent edge cases
- Adds 4 new smoke tests: cache preservation, `--all` removal, `--all` idempotent, rebuild after default clean

Supersedes #126 (rebased on current main with `CliResult` and updated smoke test framework).

Closes #101

## Test plan
- [x] `cargo test --workspace` passes (547 tests including 4 new `clean_project` behavior tests)
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` passes
- [ ] Smoke tests pass in CI (4 new clean-specific tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)