### PR TITLE
Update lockfile format for transitive Maven dependencies

### DIFF
--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -61,8 +61,13 @@ pub enum DepSource {
     },
     Maven {
         version: String,
-        maven_coordinate: String,
+        /// The canonical `groupId:artifactId` coordinate (no template placeholders).
+        maven: String,
         targets: std::collections::BTreeMap<String, String>,
+        /// Names of dependencies that pulled this one in transitively.
+        /// Empty for direct deps declared in `konvoy.toml`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        required_by: Vec<String>,
     },
 }
 
@@ -455,9 +460,9 @@ konanc_version = "2.1.0"
             name: "kotlinx-coroutines".to_owned(),
             source: DepSource::Maven {
                 version: "1.8.0".to_owned(),
-                maven_coordinate:
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:1.8.0:klib".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
                 targets,
+                required_by: Vec::new(),
             },
             source_hash: "maven-hash-1234".to_owned(),
         });
@@ -473,14 +478,16 @@ konanc_version = "2.1.0"
         match &dep.source {
             DepSource::Maven {
                 version,
-                maven_coordinate,
+                maven,
                 targets,
+                required_by,
             } => {
                 assert_eq!(version, "1.8.0");
-                assert!(maven_coordinate.contains("kotlinx-coroutines"));
+                assert_eq!(maven, "org.jetbrains.kotlinx:kotlinx-coroutines-core");
                 assert_eq!(targets.len(), 2);
                 assert_eq!(targets.get("linux_x64").unwrap(), "aabbccdd");
                 assert_eq!(targets.get("macos_arm64").unwrap(), "11223344");
+                assert!(required_by.is_empty());
             }
             other => panic!("expected Maven source, got: {other:?}"),
         }
@@ -495,9 +502,9 @@ konanc_version = "2.1.0"
             name: "kotlinx-datetime".to_owned(),
             source: DepSource::Maven {
                 version: "0.6.0".to_owned(),
-                maven_coordinate: "org.jetbrains.kotlinx:kotlinx-datetime-{target}:0.6.0:klib"
-                    .to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-datetime".to_owned(),
                 targets,
+                required_by: Vec::new(),
             },
             source_hash: "hash-5678".to_owned(),
         });
@@ -511,8 +518,12 @@ konanc_version = "2.1.0"
             "content was: {content}"
         );
         assert!(
-            content.contains("maven_coordinate"),
+            content.contains("maven = \"org.jetbrains.kotlinx:kotlinx-datetime\""),
             "content was: {content}"
+        );
+        assert!(
+            !content.contains("required_by"),
+            "required_by should be omitted for direct deps, content was: {content}"
         );
         assert!(
             content.contains("[dependencies.targets]")
@@ -553,6 +564,129 @@ source_hash = "abcdef1234"
             }
             other => panic!("expected Path source, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn round_trip_with_required_by() {
+        let dir = make_test_dir();
+        let path = dir.path().join("konvoy.lock");
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        let mut targets = std::collections::BTreeMap::new();
+        targets.insert("linux_x64".to_owned(), "789xyz".to_owned());
+        targets.insert("macos_arm64".to_owned(), "uvw012".to_owned());
+        lockfile.dependencies.push(DependencyLock {
+            name: "atomicfu".to_owned(),
+            source: DepSource::Maven {
+                version: "0.23.1".to_owned(),
+                maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                targets,
+                required_by: vec!["kotlinx-coroutines".to_owned()],
+            },
+            source_hash: "transitive-hash".to_owned(),
+        });
+        lockfile.write_to(&path).unwrap_or_else(|e| panic!("{e}"));
+        let reparsed = Lockfile::from_path(&path).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(lockfile, reparsed);
+        let dep = reparsed
+            .dependencies
+            .first()
+            .unwrap_or_else(|| panic!("missing dep"));
+        match &dep.source {
+            DepSource::Maven {
+                version,
+                maven,
+                required_by,
+                ..
+            } => {
+                assert_eq!(version, "0.23.1");
+                assert_eq!(maven, "org.jetbrains.kotlinx:atomicfu");
+                assert_eq!(required_by, &["kotlinx-coroutines"]);
+            }
+            other => panic!("expected Maven source, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn required_by_omitted_for_direct_deps() {
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        let mut targets = std::collections::BTreeMap::new();
+        targets.insert("linux_x64".to_owned(), "aabb".to_owned());
+        lockfile.dependencies.push(DependencyLock {
+            name: "kotlinx-coroutines".to_owned(),
+            source: DepSource::Maven {
+                version: "1.8.0".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
+                targets,
+                required_by: Vec::new(),
+            },
+            source_hash: "direct-hash".to_owned(),
+        });
+        let content = toml::to_string_pretty(&lockfile).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            !content.contains("required_by"),
+            "required_by should not appear for direct deps, content was: {content}"
+        );
+    }
+
+    #[test]
+    fn required_by_present_for_transitive_deps() {
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        let mut targets = std::collections::BTreeMap::new();
+        targets.insert("linux_x64".to_owned(), "ccdd".to_owned());
+        lockfile.dependencies.push(DependencyLock {
+            name: "atomicfu".to_owned(),
+            source: DepSource::Maven {
+                version: "0.23.1".to_owned(),
+                maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                targets,
+                required_by: vec!["kotlinx-coroutines".to_owned()],
+            },
+            source_hash: "transitive-hash".to_owned(),
+        });
+        let content = toml::to_string_pretty(&lockfile).unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            content.contains("required_by"),
+            "required_by should appear for transitive deps, content was: {content}"
+        );
+        assert!(
+            content.contains("kotlinx-coroutines"),
+            "required_by should contain parent dep name, content was: {content}"
+        );
+    }
+
+    #[test]
+    fn maven_field_is_plain_group_artifact() {
+        let dir = make_test_dir();
+        let path = dir.path().join("konvoy.lock");
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        let mut targets = std::collections::BTreeMap::new();
+        targets.insert("linux_x64".to_owned(), "eeff".to_owned());
+        lockfile.dependencies.push(DependencyLock {
+            name: "kotlinx-coroutines".to_owned(),
+            source: DepSource::Maven {
+                version: "1.8.0".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
+                targets,
+                required_by: Vec::new(),
+            },
+            source_hash: "some-hash".to_owned(),
+        });
+        lockfile.write_to(&path).unwrap_or_else(|e| panic!("{e}"));
+        let content = fs::read_to_string(&path).unwrap();
+        // The maven field should not contain template placeholders.
+        assert!(
+            !content.contains("{target}"),
+            "maven field should not contain {{target}}, content was: {content}"
+        );
+        assert!(
+            !content.contains("{version}"),
+            "maven field should not contain {{version}}, content was: {content}"
+        );
+        // It should be plain groupId:artifactId.
+        assert!(
+            content.contains("maven = \"org.jetbrains.kotlinx:kotlinx-coroutines-core\""),
+            "maven field should be plain groupId:artifactId, content was: {content}"
+        );
     }
 
     mod property_tests {

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -2562,9 +2562,9 @@ mod tests {
             name: "kotlinx-coroutines".to_owned(),
             source: DepSource::Maven {
                 version: "1.8.0".to_owned(),
-                maven_coordinate:
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:1.8.0:klib".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
                 targets,
+                required_by: Vec::new(),
             },
             source_hash: "maven-hash".to_owned(),
         });
@@ -2627,9 +2627,9 @@ mod tests {
             name: "kotlinx-coroutines".to_owned(),
             source: DepSource::Maven {
                 version: "1.8.0".to_owned(),
-                maven_coordinate:
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:1.8.0:klib".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
                 targets,
+                required_by: Vec::new(),
             },
             source_hash: "maven-hash".to_owned(),
         });

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -142,8 +142,10 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         // Clean up the temp directory.
         let _ = std::fs::remove_dir_all(&tmp_base);
 
-        // Build the maven coordinate template (with {target} placeholder) for the lockfile.
-        let maven_coordinate = descriptor.maven.replace("{version}", version);
+        // Extract the canonical groupId:artifactId from the descriptor template.
+        // Template format: "groupId:artifactId-{target}:{version}:klib"
+        // We take the first two colon-separated segments and strip placeholders.
+        let maven = extract_maven_group_artifact(&descriptor.maven);
 
         // Compute a deterministic source_hash from the target hashes.
         let hash_input: String = targets_map
@@ -157,8 +159,9 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
             name: (*dep_name).clone(),
             source: DepSource::Maven {
                 version: version.clone(),
-                maven_coordinate,
+                maven,
                 targets: targets_map,
+                required_by: Vec::new(),
             },
             source_hash,
         });
@@ -185,6 +188,25 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     Ok(UpdateResult {
         updated_count: maven_deps.len(),
     })
+}
+
+/// Extract the canonical `groupId:artifactId` from a Maven coordinate template.
+///
+/// The template looks like `"org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:{version}:klib"`.
+/// This function takes the first two colon-separated segments and strips placeholder
+/// fragments (`{target}`, `{version}`) and any resulting trailing hyphens.
+fn extract_maven_group_artifact(template: &str) -> String {
+    let mut parts = template.split(':');
+    match (parts.next(), parts.next()) {
+        (Some(group_id), Some(artifact_segment)) => {
+            let artifact_raw = artifact_segment
+                .replace("{target}", "")
+                .replace("{version}", "");
+            let artifact_id = artifact_raw.trim_end_matches('-');
+            format!("{group_id}:{artifact_id}")
+        }
+        _ => template.to_owned(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -387,9 +409,9 @@ kotlinx-coroutines = { version = "1.8.0" }
             name: "kotlinx-coroutines".to_owned(),
             source: DepSource::Maven {
                 version: "1.8.0".to_owned(),
-                maven_coordinate:
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:1.8.0:klib".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
                 targets: targets.clone(),
+                required_by: Vec::new(),
             },
             source_hash: "existing-hash".to_owned(),
         });
@@ -411,5 +433,32 @@ kotlinx-coroutines = { version = "1.8.0" }
             DepSource::Maven { version, .. } => assert_eq!(version, "1.8.0"),
             other => panic!("expected Maven source, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn extract_group_artifact_from_template() {
+        assert_eq!(
+            super::extract_maven_group_artifact(
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-{target}:{version}:klib"
+            ),
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+        );
+    }
+
+    #[test]
+    fn extract_group_artifact_no_target_suffix() {
+        assert_eq!(
+            super::extract_maven_group_artifact("org.jetbrains.kotlinx:atomicfu:{version}:klib"),
+            "org.jetbrains.kotlinx:atomicfu"
+        );
+    }
+
+    #[test]
+    fn extract_group_artifact_single_segment() {
+        // Edge case: if template has no colon, return as-is.
+        assert_eq!(
+            super::extract_maven_group_artifact("no-colon-here"),
+            "no-colon-here"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Rename `maven_coordinate` to `maven` in `DepSource::Maven` — now stores plain `groupId:artifactId` (e.g. `org.jetbrains.kotlinx:kotlinx-coroutines-core`) with no template placeholders
- Add `required_by: Vec<String>` field for tracking transitive dependency provenance; empty for direct deps, omitted from TOML via `skip_serializing_if`
- Add `extract_maven_group_artifact()` helper in `update.rs` to derive canonical `groupId:artifactId` from descriptor templates
- Update all consumers in `build.rs`, `update.rs`, and their tests

Closes #204

## Test plan
- [x] Round-trip serialize/deserialize with `required_by` populated (transitive dep)
- [x] Round-trip serialize/deserialize with `required_by` empty (direct dep — field omitted from TOML)
- [x] Verify `maven` field uses plain `groupId:artifactId` format (no `{target}`, no `{version}`)
- [x] Existing lockfile tests updated and passing
- [x] `extract_maven_group_artifact` tested with template, no-target, and edge cases
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes (all 71 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)