### PR TITLE
Improve hash mismatch errors with actionable diagnostics

### DIFF
--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -166,8 +166,12 @@ pub enum EngineError {
     #[error("no hash for target `{target}` in lockfile for dependency `{name}` — run `konvoy update` to resolve")]
     MissingTargetHash { name: String, target: String },
 
-    /// A library klib hash mismatch was detected after download.
-    #[error("library `{name}` klib hash mismatch — expected {expected}, got {actual}; run `konvoy update` to refresh")]
+    /// A library klib hash mismatch was detected after a fresh download.
+    ///
+    /// Unlike `ArtifactHashMismatch` (cached file mismatch), this fires when
+    /// the just-downloaded content doesn't match the lockfile. This points at
+    /// a network-level issue (MITM, CDN corruption) or a stale lockfile.
+    #[error("library `{name}` hash mismatch after download\n  expected: {expected}\n  got:      {actual}\n\n  This can happen if:\n    - the download was intercepted or corrupted in transit\n    - the lockfile hashes are stale (e.g. the upstream artifact was republished)\n\n  To fix: run `konvoy update` to re-resolve and re-hash all dependencies.\n  If this keeps happening, check your network connection for interference.")]
     LibraryHashMismatch {
         name: String,
         expected: String,

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -214,7 +214,21 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("artifact hash mismatch"), "error was: {err}");
+        assert!(err.contains("hash mismatch"), "error was: {err}");
+        // Error must explain possible causes so the user understands what happened.
+        assert!(
+            err.contains("corrupted on disk"),
+            "error should mention disk corruption: {err}"
+        );
+        assert!(
+            err.contains("tampered with"),
+            "error should mention tampering: {err}"
+        );
+        // Error must tell the user what to do.
+        assert!(
+            err.contains("inspect or delete"),
+            "error should tell the user to inspect/delete the file: {err}"
+        );
     }
 
     #[test]

--- a/crates/konvoy-util/src/error.rs
+++ b/crates/konvoy-util/src/error.rs
@@ -31,7 +31,7 @@ pub enum UtilError {
     InvalidVersion { version: String },
 
     /// An artifact hash does not match the expected value.
-    #[error("artifact hash mismatch for {path} — expected {expected}, got {actual}")]
+    #[error("artifact hash mismatch for {path}\n  expected: {expected}\n  got:      {actual}\n\n  This can happen if:\n    - the file was corrupted on disk (e.g. interrupted download, disk error)\n    - the file was tampered with (e.g. malware or unauthorized modification)\n    - the lockfile hashes are stale (e.g. manual edits to konvoy.lock)\n\n  To fix: inspect or delete the file above, then re-run the build.\n  If the problem persists, run `konvoy update` to re-resolve all dependencies.")]
     ArtifactHashMismatch {
         path: String,
         expected: String,


### PR DESCRIPTION
## Summary
- When a cached klib or artifact has a SHA-256 mismatch, the error now tells the user to delete the corrupted file and re-run, or run `konvoy update` to re-resolve
- Previously the error just showed raw hash values with no remediation hint
- A hash mismatch may indicate disk corruption or file tampering, so we intentionally do not auto-recover — the user should investigate

## Test plan
- [x] Existing `ensure_artifact_errors_on_hash_mismatch` test updated to verify the error contains actionable text ("delete the file")
- [x] Full test suite passes (596 tests)
- [x] Manual verification: corrupting a cached klib produces a clear error with the file path and remediation steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)