### PR TITLE
Add code coverage with cargo-llvm-cov and Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace -- -D warnings
 
+  coverage:
+    name: Coverage
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   # Smoke tests: only run on manual trigger (workflow_dispatch with smoke=true).
   # Takes ~10min due to Docker build + konanc download. Can also be run locally
   # via `bash tests/smoke/run.sh`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Konvoy
 
+[![CI](https://github.com/arncore/konvoy/actions/workflows/ci.yml/badge.svg)](https://github.com/arncore/konvoy/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/arncore/konvoy/branch/main/graph/badge.svg)](https://codecov.io/gh/arncore/konvoy)
+
 Konvoy is a native-first Kotlin build tool focused on making Kotlin/Native compilation as easy, fast, and painless as Cargo.
 
 Konvoy avoids Gradle/Maven-style complexity by providing:


### PR DESCRIPTION
## Summary

Adds LLVM source-based code coverage to CI using `cargo-llvm-cov`, with reports uploaded to Codecov.

- New `coverage` job in CI workflow using `cargo-llvm-cov` with `llvm-tools-preview`
- Uploads lcov reports to Codecov via `codecov/codecov-action@v4`
- Adds CI and coverage badges to README

## Setup required

1. Enable the repo on [codecov.io](https://codecov.io)
2. Add `CODECOV_TOKEN` as a repository secret in Settings > Secrets > Actions

## Test plan

- [ ] CI runs the coverage job without failing (even before Codecov token is set, `fail_ci_if_error: false`)
- [ ] After adding the token, coverage reports appear on Codecov
- [ ] Badges render correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)