### PR TITLE
Add VS Code extension docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,28 @@ konvoy lint --config my-rules.yml  # use custom config
 konvoy lint --verbose              # show raw detekt output
 ```
 
+## Editor support
+
+### VS Code
+
+The [Konvoy for VS Code](editors/code) extension provides:
+
+- **Commands** — Build, Run, Test, Lint, Clean, Doctor, Update, and Toolchain management via `Ctrl+Shift+P`
+- **Run button** — Play button in the editor title bar for `.kt` files and `konvoy.toml`
+- **`konvoy.toml` support** — Syntax highlighting, validation on save, autocomplete, and hover docs
+- **Diagnostics** — Build errors and detekt findings in the Problems panel
+- **Tasks** — Auto-detected konvoy tasks via `Ctrl+Shift+B`
+
+Install from [Releases](https://github.com/arncore/konvoy/releases):
+
+```
+code --install-extension konvoy-vscode-1.0.0.vsix
+```
+
+Or in VS Code: `Ctrl+Shift+P` → "Extensions: Install from VSIX..."
+
+See the [extension README](editors/code/README.md) for full details.
+
 ## Roadmap (high level)
 
 1. ~~**MVP:** host-native executable build/run + cache~~ done


### PR DESCRIPTION
## Summary
- Add an "Editor support" section to the project README documenting the VS Code extension
- Links to the extension README, install instructions, and feature overview

## Test plan
- [x] Verify links resolve correctly
- [x] Markdown renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)