### PR TITLE
Add Marketplace coming soon note to editor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ konvoy lint --verbose              # show raw detekt output
 
 ### VS Code
 
+> **VS Code Marketplace listing coming soon.** For now, install manually from [Releases](https://github.com/arncore/konvoy/releases).
+
 The [Konvoy for VS Code](editors/code) extension provides:
 
 - **Commands** — Build, Run, Test, Lint, Clean, Doctor, Update, and Toolchain management via `Ctrl+Shift+P`


### PR DESCRIPTION
## Summary
- Add a note in the VS Code editor support section that the Marketplace listing is coming soon

🤖 Generated with [Claude Code](https://claude.com/claude-code)