### PR TITLE
Add helper methods, deduplicate repeated patterns

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -490,7 +490,7 @@ fn check_maven_deps(manifest: &konvoy_config::Manifest, cwd: &std::path::Path) -
     let maven_deps: Vec<_> = manifest
         .dependencies
         .iter()
-        .filter(|(_, spec)| spec.maven.is_some() && spec.version.is_some())
+        .filter(|(_, spec)| spec.is_maven())
         .collect();
 
     if maven_deps.is_empty() {
@@ -516,11 +516,7 @@ fn check_maven_deps(manifest: &konvoy_config::Manifest, cwd: &std::path::Path) -
     match konvoy_config::lockfile::Lockfile::from_path(&lockfile_path) {
         Ok(lockfile) => {
             for (dep_name, _) in &maven_deps {
-                let has_entry = lockfile.dependencies.iter().any(|d| {
-                    d.name == **dep_name
-                        && matches!(&d.source, konvoy_config::lockfile::DepSource::Maven { .. })
-                });
-                if has_entry {
+                if lockfile.has_maven_entry(dep_name) {
                     eprintln!("  [ok] Lockfile entry: {}", dep_name);
                 } else {
                     eprintln!(

--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -155,6 +155,13 @@ impl Lockfile {
         })?;
         Ok(())
     }
+
+    /// Returns `true` if the lockfile contains a Maven dependency entry with the given name.
+    pub fn has_maven_entry(&self, dep_name: &str) -> bool {
+        self.dependencies
+            .iter()
+            .any(|d| d.name == dep_name && matches!(&d.source, DepSource::Maven { .. }))
+    }
 }
 
 /// Errors produced when reading, parsing, or writing a `konvoy.lock` lockfile.

--- a/crates/konvoy-config/src/manifest.rs
+++ b/crates/konvoy-config/src/manifest.rs
@@ -65,6 +65,13 @@ pub struct DependencySpec {
     pub maven: Option<String>,
 }
 
+impl DependencySpec {
+    /// Returns `true` if this is a Maven dependency (has both `maven` and `version` set).
+    pub fn is_maven(&self) -> bool {
+        self.maven.is_some() && self.version.is_some()
+    }
+}
+
 fn default_entrypoint() -> String {
     "src/main.kt".to_owned()
 }

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -711,18 +711,10 @@ pub(crate) fn resolve_maven_deps(
 /// Returns `true` if the manifest declares Maven deps that have no matching
 /// lockfile entry. Used to trigger automatic `konvoy update` during build.
 pub(crate) fn has_unresolved_maven_deps(manifest: &Manifest, lockfile: &Lockfile) -> bool {
-    for (dep_name, dep_spec) in &manifest.dependencies {
-        if dep_spec.maven.is_some() && dep_spec.version.is_some() {
-            let has_entry = lockfile
-                .dependencies
-                .iter()
-                .any(|d| d.name == *dep_name && matches!(&d.source, DepSource::Maven { .. }));
-            if !has_entry {
-                return true;
-            }
-        }
-    }
-    false
+    manifest
+        .dependencies
+        .iter()
+        .any(|(name, spec)| spec.is_maven() && !lockfile.has_maven_entry(name))
 }
 
 /// Check that the lockfile is complete and consistent with the manifest.
@@ -750,17 +742,10 @@ pub(crate) fn check_lockfile_staleness(
                 return Err(EngineError::LockfileUpdateRequired);
             }
 
-            // If detekt is configured in manifest, lockfile must have matching detekt entries.
+            // If detekt is configured in manifest, lockfile must have matching detekt version.
             if let Some(manifest_detekt) = &manifest.toolchain.detekt {
-                match &tc.detekt_version {
-                    Some(locked_detekt) => {
-                        if locked_detekt != manifest_detekt {
-                            return Err(EngineError::LockfileUpdateRequired);
-                        }
-                    }
-                    None => {
-                        return Err(EngineError::LockfileUpdateRequired);
-                    }
+                if tc.detekt_version.as_deref() != Some(manifest_detekt.as_str()) {
+                    return Err(EngineError::LockfileUpdateRequired);
                 }
             }
         }
@@ -782,14 +767,8 @@ pub(crate) fn check_lockfile_staleness(
     // If the manifest has Maven dependencies (maven + version set), the lockfile must
     // have matching Maven entries for each.
     for (dep_name, dep_spec) in &manifest.dependencies {
-        if dep_spec.maven.is_some() && dep_spec.version.is_some() {
-            let has_maven_entry = lockfile
-                .dependencies
-                .iter()
-                .any(|d| d.name == *dep_name && matches!(&d.source, DepSource::Maven { .. }));
-            if !has_maven_entry {
-                return Err(EngineError::LockfileUpdateRequired);
-            }
+        if dep_spec.is_maven() && !lockfile.has_maven_entry(dep_name) {
+            return Err(EngineError::LockfileUpdateRequired);
         }
     }
 
@@ -882,38 +861,13 @@ fn update_lockfile_if_needed(
     // different hashes are expected, so skip the check.
     if !toolchain_changed {
         if let Some(tc) = &lockfile.toolchain {
-            if let (Some(existing), Some(actual)) =
-                (&tc.konanc_tarball_sha256, konanc_tarball_sha256)
-            {
-                if !existing.is_empty() && existing != actual {
-                    if force {
-                        eprintln!(
-                        "warning: konanc tarball hash changed — expected {existing}, got {actual}; lockfile updated (--force)"
-                    );
-                    } else {
-                        return Err(EngineError::TarballHashMismatch {
-                            kind: "konanc".to_owned(),
-                            expected: existing.clone(),
-                            actual: actual.to_owned(),
-                        });
-                    }
-                }
-            }
-            if let (Some(existing), Some(actual)) = (&tc.jre_tarball_sha256, jre_tarball_sha256) {
-                if !existing.is_empty() && existing != actual {
-                    if force {
-                        eprintln!(
-                        "warning: jre tarball hash changed — expected {existing}, got {actual}; lockfile updated (--force)"
-                    );
-                    } else {
-                        return Err(EngineError::TarballHashMismatch {
-                            kind: "jre".to_owned(),
-                            expected: existing.clone(),
-                            actual: actual.to_owned(),
-                        });
-                    }
-                }
-            }
+            verify_tarball_hash(
+                "konanc",
+                &tc.konanc_tarball_sha256,
+                konanc_tarball_sha256,
+                force,
+            )?;
+            verify_tarball_hash("jre", &tc.jre_tarball_sha256, jre_tarball_sha256, force)?;
         }
     }
 
@@ -959,6 +913,35 @@ fn update_lockfile_if_needed(
     updated.plugins = plugin_locks.to_vec();
     updated.write_to(lockfile_path)?;
 
+    Ok(())
+}
+
+/// Check that a tarball hash from the lockfile matches a freshly downloaded hash.
+///
+/// If both are present, non-empty, and differ: emit a warning when `--force` is
+/// active, or return a hard error otherwise. This detects tampered or rotated
+/// upstream tarballs.
+fn verify_tarball_hash(
+    kind: &str,
+    existing: &Option<String>,
+    actual: Option<&str>,
+    force: bool,
+) -> Result<(), EngineError> {
+    if let (Some(existing), Some(actual)) = (existing, actual) {
+        if !existing.is_empty() && existing != actual {
+            if force {
+                eprintln!(
+                    "warning: {kind} tarball hash changed — expected {existing}, got {actual}; lockfile updated (--force)"
+                );
+            } else {
+                return Err(EngineError::TarballHashMismatch {
+                    kind: kind.to_owned(),
+                    expected: existing.clone(),
+                    actual: actual.to_owned(),
+                });
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -80,7 +80,7 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     let maven_deps: Vec<_> = manifest
         .dependencies
         .iter()
-        .filter(|(_, spec)| spec.maven.is_some() && spec.version.is_some())
+        .filter(|(_, spec)| spec.is_maven())
         .collect();
 
     if maven_deps.is_empty() {


### PR DESCRIPTION
## Summary

- **`DependencySpec::is_maven()`** — Replaces 4 scattered `maven.is_some() && version.is_some()` checks across `build.rs`, `update.rs`, and `main.rs`
- **`Lockfile::has_maven_entry(name)`** — Replaces 3 identical `lockfile.dependencies.iter().any(|d| d.name == X && matches!(Maven))` lookups in `build.rs` and `main.rs`
- **`verify_tarball_hash()` helper** — Deduplicates the konanc/JRE hash-verification block in `update_lockfile_if_needed` (was 2x 10 lines, now 2x 1 line)
- **Simplified detekt staleness check** — Replaces 8-line nested `match` on `tc.detekt_version` with single `as_deref()` comparison

## Test plan

- [x] `cargo test --workspace` — 760/760 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)