### PR TITLE
Simplify fs wrappers, validation, toolchain install, and formatting

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -241,6 +241,15 @@ fn build_options(
     }
 }
 
+/// Return `"release"` or `"debug"` for display in build output.
+fn profile_label(release: bool) -> &'static str {
+    if release {
+        "release"
+    } else {
+        "debug"
+    }
+}
+
 fn cmd_build(
     target: Option<String>,
     release: bool,
@@ -253,7 +262,7 @@ fn cmd_build(
 
     let result = konvoy_engine::build(&root, &options)?;
 
-    let profile = if release { "release" } else { "debug" };
+    let profile = profile_label(release);
     match result.outcome {
         konvoy_engine::BuildOutcome::Cached => {
             eprintln!(
@@ -295,7 +304,7 @@ fn cmd_run(
 
     let result = konvoy_engine::build(&root, &options)?;
 
-    let profile = if release { "release" } else { "debug" };
+    let profile = profile_label(release);
     eprintln!(
         "    Finished `{profile}` target in {:.2}s",
         result.duration.as_secs_f64()
@@ -328,7 +337,7 @@ fn cmd_test(
 
     let result = konvoy_engine::build_tests(&root, &options)?;
 
-    let profile = if release { "release" } else { "debug" };
+    let profile = profile_label(release);
     eprintln!(
         "    Finished `{profile}` test target in {:.2}s",
         result.compile_duration.as_secs_f64()

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -369,15 +369,10 @@ fn cmd_lint(verbose: bool, config: Option<PathBuf>, locked: bool) -> CliResult {
 
     if !verbose {
         for diag in &result.diagnostics {
-            let location = match (&diag.file, diag.line) {
-                (Some(f), Some(l)) => format!("{f}:{l}"),
-                (Some(f), None) => f.clone(),
-                _ => String::new(),
-            };
-            if location.is_empty() {
-                eprintln!("  {}: {}", diag.rule, diag.message);
-            } else {
-                eprintln!("  {location}: {}: {}", diag.rule, diag.message);
+            match (&diag.file, diag.line) {
+                (Some(f), Some(l)) => eprintln!("  {f}:{l}: {}: {}", diag.rule, diag.message),
+                (Some(f), None) => eprintln!("  {f}: {}: {}", diag.rule, diag.message),
+                _ => eprintln!("  {}: {}", diag.rule, diag.message),
             }
         }
     }

--- a/crates/konvoy-config/src/manifest.rs
+++ b/crates/konvoy-config/src/manifest.rs
@@ -131,46 +131,35 @@ fn validate_plugins(
     path: &str,
 ) -> Result<(), ManifestError> {
     for (name, spec) in plugins {
-        // Plugins must use Maven coordinates, not path dependencies.
+        let err = |reason: String| ManifestError::InvalidPluginConfig {
+            path: path.to_owned(),
+            name: name.clone(),
+            reason,
+        };
+
         if spec.path.is_some() {
-            return Err(ManifestError::InvalidPluginConfig {
-                path: path.to_owned(),
-                name: name.clone(),
-                reason: "plugins must use `maven` coordinates, not `path`".to_owned(),
-            });
+            return Err(err(
+                "plugins must use `maven` coordinates, not `path`".to_owned()
+            ));
         }
         if spec.maven.is_none() {
-            return Err(ManifestError::InvalidPluginConfig {
-                path: path.to_owned(),
-                name: name.clone(),
-                reason: "plugin must have `maven` set to a `groupId:artifactId` coordinate"
-                    .to_owned(),
-            });
+            return Err(err(
+                "plugin must have `maven` set to a `groupId:artifactId` coordinate".to_owned(),
+            ));
         }
         if spec.version.is_none() {
-            return Err(ManifestError::InvalidPluginConfig {
-                path: path.to_owned(),
-                name: name.clone(),
-                reason: "plugin must have `version` set".to_owned(),
-            });
+            return Err(err("plugin must have `version` set".to_owned()));
         }
         if spec.version.as_ref().is_some_and(|v| v.trim().is_empty()) {
-            return Err(ManifestError::InvalidPluginConfig {
-                path: path.to_owned(),
-                name: name.clone(),
-                reason: "plugin `version` must not be empty or whitespace".to_owned(),
-            });
+            return Err(err(
+                "plugin `version` must not be empty or whitespace".to_owned()
+            ));
         }
-        // Validate maven coordinate format (reuse same colon-check as deps).
         if let Some(ref maven) = spec.maven {
             if !is_valid_maven_coordinate(maven) {
-                return Err(ManifestError::InvalidPluginConfig {
-                    path: path.to_owned(),
-                    name: name.clone(),
-                    reason: format!(
-                        "invalid maven coordinate `{maven}` — expected `groupId:artifactId`"
-                    ),
-                });
+                return Err(err(format!(
+                    "invalid maven coordinate `{maven}` — expected `groupId:artifactId`"
+                )));
             }
         }
     }

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -735,31 +735,25 @@ pub(crate) fn check_lockfile_staleness(
     manifest: &Manifest,
     lockfile: &Lockfile,
 ) -> Result<(), EngineError> {
-    match &lockfile.toolchain {
-        Some(tc) => {
-            // Toolchain version must match.
-            if tc.konanc_version != manifest.toolchain.kotlin {
-                return Err(EngineError::LockfileUpdateRequired);
-            }
+    let Some(tc) = &lockfile.toolchain else {
+        // Lockfile has no toolchain section at all — it's stale.
+        return Err(EngineError::LockfileUpdateRequired);
+    };
 
-            // If detekt is configured in manifest, lockfile must have matching detekt version.
-            if let Some(manifest_detekt) = &manifest.toolchain.detekt {
-                if tc.detekt_version.as_deref() != Some(manifest_detekt.as_str()) {
-                    return Err(EngineError::LockfileUpdateRequired);
-                }
-            }
-        }
-        None => {
-            // Lockfile has no toolchain section at all — it's stale.
+    if tc.konanc_version != manifest.toolchain.kotlin {
+        return Err(EngineError::LockfileUpdateRequired);
+    }
+
+    // If detekt is configured in manifest, lockfile must have matching detekt version.
+    if let Some(manifest_detekt) = &manifest.toolchain.detekt {
+        if tc.detekt_version.as_deref() != Some(manifest_detekt.as_str()) {
             return Err(EngineError::LockfileUpdateRequired);
         }
     }
 
-    // If the manifest has plugins, the lockfile must have at least one plugin entry
-    // for each declared plugin name.
+    // Each declared plugin must have a matching lockfile entry.
     for plugin_name in manifest.plugins.keys() {
-        let has_plugin = lockfile.plugins.iter().any(|p| p.name == *plugin_name);
-        if !has_plugin {
+        if !lockfile.plugins.iter().any(|p| p.name == *plugin_name) {
             return Err(EngineError::LockfileUpdateRequired);
         }
     }

--- a/crates/konvoy-konanc/src/invoke.rs
+++ b/crates/konvoy-konanc/src/invoke.rs
@@ -341,14 +341,8 @@ fn parse_file_and_line(s: &str) -> Option<FileLocation> {
     parts.reverse();
 
     match parts.len() {
-        3 => {
-            // file:line:col
-            let file = (*parts.first()?).to_owned();
-            let line: u32 = parts.get(1)?.parse().ok()?;
-            Some(FileLocation { file, line })
-        }
-        2 => {
-            // file:line
+        // file:line or file:line:col (column is ignored)
+        2 | 3 => {
             let file = (*parts.first()?).to_owned();
             let line: u32 = parts.get(1)?.parse().ok()?;
             Some(FileLocation { file, line })

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -183,22 +183,11 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
     } else {
         let url = download_url(version)?;
         let toolchains_root = toolchains_dir()?;
-
-        // Ensure the toolchains directory exists.
         konvoy_util::fs::ensure_dir(&toolchains_root)?;
 
-        // Create secure temp file and directory for download and extraction.
-        let tmp_tarball_handle = tempfile::Builder::new()
-            .prefix(&format!(".tmp-{version}-"))
-            .suffix(".tar.gz")
-            .tempfile_in(&toolchains_root)
-            .map_err(|source| KonancError::Io {
-                path: toolchains_root.display().to_string(),
-                source,
-            })?;
-        let tmp_tarball = tmp_tarball_handle.path().to_path_buf();
+        let prefix = format!(".tmp-{version}-");
+        let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
-        // Download to the temp file, computing SHA-256 as we go.
         let sha256 = konvoy_util::download::download_with_progress(
             &url,
             &tmp_tarball,
@@ -207,45 +196,13 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         )
         .map_err(|e| map_download_err(version, e))?;
 
-        // Extract to a temp directory, then rename atomically.
-        let tmp_extract_handle = tempfile::Builder::new()
-            .prefix(&format!(".tmp-{version}-"))
-            .suffix("-extract")
-            .tempdir_in(&toolchains_root)
-            .map_err(|source| KonancError::Io {
-                path: toolchains_root.display().to_string(),
-                source,
-            })?;
-        let tmp_extract = tmp_extract_handle.path().to_path_buf();
-
+        let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
         extract_tarball(&tmp_tarball, &tmp_extract, "Kotlin/Native", version)?;
-
-        // Clean up tarball.
         let _ = std::fs::remove_file(&tmp_tarball);
 
-        // The tarball extracts to a subdirectory like `kotlin-native-prebuilt-linux-x86_64-2.1.0/`.
         let extracted_root = find_extracted_root(&tmp_extract, version)?;
+        atomic_rename_into(&extracted_root, &dest, &tmp_extract)?;
 
-        // Atomically move into place. If another process raced us, rename
-        // will fail and we verify the existing installation instead.
-        match std::fs::rename(&extracted_root, &dest) {
-            Ok(()) => {
-                let _ = std::fs::remove_dir_all(&tmp_extract);
-            }
-            Err(_) if dest.exists() => {
-                // Another process installed while we were downloading.
-                let _ = std::fs::remove_dir_all(&tmp_extract);
-            }
-            Err(source) => {
-                let _ = std::fs::remove_dir_all(&tmp_extract);
-                return Err(KonancError::Io {
-                    path: dest.display().to_string(),
-                    source,
-                });
-            }
-        }
-
-        // Verify the installation.
         let final_konanc = dest.join("bin").join("konanc");
         if !final_konanc.exists() {
             return Err(KonancError::CorruptToolchain {
@@ -253,23 +210,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
                 version: version.to_owned(),
             });
         }
-
-        // Ensure konanc is executable on Unix.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let metadata = std::fs::metadata(&final_konanc).map_err(|source| KonancError::Io {
-                path: final_konanc.display().to_string(),
-                source,
-            })?;
-            let mut perms = metadata.permissions();
-            let mode = perms.mode() | 0o755;
-            perms.set_mode(mode);
-            std::fs::set_permissions(&final_konanc, perms).map_err(|source| KonancError::Io {
-                path: final_konanc.display().to_string(),
-                source,
-            })?;
-        }
+        ensure_executable(&final_konanc)?;
 
         Some(sha256)
     };
@@ -301,55 +242,18 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let url = jre_download_url()?;
     let toolchains_root = toolchains_dir()?;
 
-    // Create secure temp file and directory for download and extraction.
-    let tmp_tarball_handle = tempfile::Builder::new()
-        .prefix(&format!(".tmp-{version}-jre-"))
-        .suffix(".tar.gz")
-        .tempfile_in(&toolchains_root)
-        .map_err(|source| KonancError::Io {
-            path: toolchains_root.display().to_string(),
-            source,
-        })?;
-    let tmp_tarball = tmp_tarball_handle.path().to_path_buf();
+    let prefix = format!(".tmp-{version}-jre-");
+    let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
-    // Download JRE tarball.
     let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, "JRE", version)
         .map_err(|e| map_download_err(version, e))?;
 
-    // Extract to temp directory.
-    let tmp_extract_handle = tempfile::Builder::new()
-        .prefix(&format!(".tmp-{version}-jre-"))
-        .suffix("-extract")
-        .tempdir_in(&toolchains_root)
-        .map_err(|source| KonancError::Io {
-            path: toolchains_root.display().to_string(),
-            source,
-        })?;
-    let tmp_extract = tmp_extract_handle.path().to_path_buf();
-
+    let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
     extract_tarball(&tmp_tarball, &tmp_extract, "JRE", version)?;
-
-    // Clean up tarball.
     let _ = std::fs::remove_file(&tmp_tarball);
 
-    // Atomically move into place. If another process raced us, rename
-    // will fail and we verify the existing installation instead.
-    match std::fs::rename(&tmp_extract, &jre_root) {
-        Ok(()) => {}
-        Err(_) if jre_root.exists() => {
-            // Another process installed while we were downloading.
-            let _ = std::fs::remove_dir_all(&tmp_extract);
-        }
-        Err(source) => {
-            let _ = std::fs::remove_dir_all(&tmp_extract);
-            return Err(KonancError::Io {
-                path: jre_root.display().to_string(),
-                source,
-            });
-        }
-    }
+    atomic_rename_into(&tmp_extract, &jre_root, &tmp_extract)?;
 
-    // Verify java binary exists.
     let home = jre_home_path(version)?;
     let java_bin = home.join("bin").join("java");
     if !java_bin.exists() {
@@ -360,25 +264,86 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
             ),
         });
     }
-
-    // Ensure java is executable on Unix.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let metadata = std::fs::metadata(&java_bin).map_err(|source| KonancError::Io {
-            path: java_bin.display().to_string(),
-            source,
-        })?;
-        let mut perms = metadata.permissions();
-        let mode = perms.mode() | 0o755;
-        perms.set_mode(mode);
-        std::fs::set_permissions(&java_bin, perms).map_err(|source| KonancError::Io {
-            path: java_bin.display().to_string(),
-            source,
-        })?;
-    }
+    ensure_executable(&java_bin)?;
 
     Ok((home, Some(sha256)))
+}
+
+/// Atomically move `src` to `dest`, handling the race where another process
+/// may have already placed the target. Cleans up `cleanup_dir` on all paths.
+fn atomic_rename_into(src: &Path, dest: &Path, cleanup_dir: &Path) -> Result<(), KonancError> {
+    match std::fs::rename(src, dest) {
+        Ok(()) => {
+            let _ = std::fs::remove_dir_all(cleanup_dir);
+            Ok(())
+        }
+        Err(_) if dest.exists() => {
+            let _ = std::fs::remove_dir_all(cleanup_dir);
+            Ok(())
+        }
+        Err(source) => {
+            let _ = std::fs::remove_dir_all(cleanup_dir);
+            Err(KonancError::Io {
+                path: dest.display().to_string(),
+                source,
+            })
+        }
+    }
+}
+
+/// Ensure a binary is executable on Unix (no-op on other platforms).
+#[cfg(unix)]
+fn ensure_executable(path: &Path) -> Result<(), KonancError> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = std::fs::metadata(path).map_err(|source| KonancError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let mut perms = metadata.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    std::fs::set_permissions(path, perms).map_err(|source| KonancError::Io {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+#[cfg(not(unix))]
+fn ensure_executable(_path: &Path) -> Result<(), KonancError> {
+    Ok(())
+}
+
+/// Create a secure temp file in the given directory.
+fn temp_tarball(
+    toolchains_root: &Path,
+    prefix: &str,
+) -> Result<(tempfile::TempPath, PathBuf), KonancError> {
+    let handle = tempfile::Builder::new()
+        .prefix(prefix)
+        .suffix(".tar.gz")
+        .tempfile_in(toolchains_root)
+        .map_err(|source| KonancError::Io {
+            path: toolchains_root.display().to_string(),
+            source,
+        })?;
+    let path = handle.path().to_path_buf();
+    Ok((handle.into_temp_path(), path))
+}
+
+/// Create a secure temp directory in the given directory.
+fn temp_extract_dir(
+    toolchains_root: &Path,
+    prefix: &str,
+) -> Result<(tempfile::TempDir, PathBuf), KonancError> {
+    let handle = tempfile::Builder::new()
+        .prefix(prefix)
+        .suffix("-extract")
+        .tempdir_in(toolchains_root)
+        .map_err(|source| KonancError::Io {
+            path: toolchains_root.display().to_string(),
+            source,
+        })?;
+    let path = handle.path().to_path_buf();
+    Ok((handle, path))
 }
 
 /// Find the extracted JRE root directory inside the jre/ directory.

--- a/crates/konvoy-util/src/fs.rs
+++ b/crates/konvoy-util/src/fs.rs
@@ -4,15 +4,23 @@ use std::path::{Path, PathBuf};
 
 use crate::error::UtilError;
 
+/// Build a `UtilError::Io` mapping closure for the given path.
+///
+/// Avoids repeating `map_err(|source| UtilError::Io { path: ..., source })`
+/// across every filesystem wrapper.
+fn io_err(path: &Path) -> impl FnOnce(std::io::Error) -> UtilError + '_ {
+    move |source| UtilError::Io {
+        path: path.display().to_string(),
+        source,
+    }
+}
+
 /// Create a directory and all parent directories if they do not exist.
 ///
 /// # Errors
 /// Returns an error if the directory cannot be created.
 pub fn ensure_dir(path: &Path) -> Result<(), UtilError> {
-    std::fs::create_dir_all(path).map_err(|source| UtilError::Io {
-        path: path.display().to_string(),
-        source,
-    })
+    std::fs::create_dir_all(path).map_err(io_err(path))
 }
 
 /// Copy `src` to `dest`, preferring a hard link for speed.
@@ -22,27 +30,15 @@ pub fn ensure_dir(path: &Path) -> Result<(), UtilError> {
 /// # Errors
 /// Returns an error if both hard linking and copying fail.
 pub fn materialize(src: &Path, dest: &Path) -> Result<(), UtilError> {
-    // Ensure the parent directory exists.
     if let Some(parent) = dest.parent() {
         ensure_dir(parent)?;
     }
-
-    // Remove existing destination if present, so hard_link doesn't fail.
     if dest.exists() {
-        std::fs::remove_file(dest).map_err(|source| UtilError::Io {
-            path: dest.display().to_string(),
-            source,
-        })?;
+        std::fs::remove_file(dest).map_err(io_err(dest))?;
     }
-
-    // Try hard link first, fall back to copy.
     if std::fs::hard_link(src, dest).is_err() {
-        std::fs::copy(src, dest).map_err(|source| UtilError::Io {
-            path: dest.display().to_string(),
-            source,
-        })?;
+        std::fs::copy(src, dest).map_err(io_err(dest))?;
     }
-
     Ok(())
 }
 
@@ -51,10 +47,7 @@ pub fn materialize(src: &Path, dest: &Path) -> Result<(), UtilError> {
 /// # Errors
 /// Returns an error if the file cannot be written.
 pub fn write_file(path: &Path, contents: impl AsRef<[u8]>) -> Result<(), UtilError> {
-    std::fs::write(path, contents).map_err(|source| UtilError::Io {
-        path: path.display().to_string(),
-        source,
-    })
+    std::fs::write(path, contents).map_err(io_err(path))
 }
 
 /// Read the entire contents of a file into a byte vector.
@@ -62,10 +55,7 @@ pub fn write_file(path: &Path, contents: impl AsRef<[u8]>) -> Result<(), UtilErr
 /// # Errors
 /// Returns an error if the file cannot be read.
 pub fn read_file(path: &Path) -> Result<Vec<u8>, UtilError> {
-    std::fs::read(path).map_err(|source| UtilError::Io {
-        path: path.display().to_string(),
-        source,
-    })
+    std::fs::read(path).map_err(io_err(path))
 }
 
 /// Copy a file from `src` to `dest`.
@@ -73,10 +63,7 @@ pub fn read_file(path: &Path) -> Result<Vec<u8>, UtilError> {
 /// # Errors
 /// Returns an error if the copy fails.
 pub fn copy_file(src: &Path, dest: &Path) -> Result<u64, UtilError> {
-    std::fs::copy(src, dest).map_err(|source| UtilError::Io {
-        path: dest.display().to_string(),
-        source,
-    })
+    std::fs::copy(src, dest).map_err(io_err(dest))
 }
 
 /// Rename (move) a file or directory from `from` to `to`.
@@ -84,10 +71,7 @@ pub fn copy_file(src: &Path, dest: &Path) -> Result<u64, UtilError> {
 /// # Errors
 /// Returns an error if the rename fails.
 pub fn rename(from: &Path, to: &Path) -> Result<(), UtilError> {
-    std::fs::rename(from, to).map_err(|source| UtilError::Io {
-        path: to.display().to_string(),
-        source,
-    })
+    std::fs::rename(from, to).map_err(io_err(to))
 }
 
 /// Remove a directory and all its contents. No error if the directory is absent.
@@ -98,10 +82,7 @@ pub fn remove_dir_all_if_exists(path: &Path) -> Result<(), UtilError> {
     match std::fs::remove_dir_all(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(source) => Err(UtilError::Io {
-            path: path.display().to_string(),
-            source,
-        }),
+        Err(source) => Err(io_err(path)(source)),
     }
 }
 
@@ -130,29 +111,27 @@ pub fn collect_files(dir: &Path, extension: &str) -> Result<Vec<PathBuf>, UtilEr
     Ok(files)
 }
 
+/// Check whether a path has the given file extension (case-sensitive).
+fn has_extension(path: &Path, ext: &str) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e == ext)
+}
+
 fn collect_files_recursive(
     dir: &Path,
     extension: &str,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), UtilError> {
-    let entries = std::fs::read_dir(dir).map_err(|source| UtilError::Io {
-        path: dir.display().to_string(),
-        source,
-    })?;
+    let entries = std::fs::read_dir(dir).map_err(io_err(dir))?;
 
     for entry in entries {
-        let entry = entry.map_err(|source| UtilError::Io {
-            path: dir.display().to_string(),
-            source,
-        })?;
+        let entry = entry.map_err(io_err(dir))?;
 
         // Use entry.file_type() which does NOT follow symlinks, unlike
         // path.is_dir()/path.metadata(). This prevents infinite recursion
         // when symlink cycles exist (e.g. a -> b, b -> a).
-        let file_type = entry.file_type().map_err(|source| UtilError::Io {
-            path: entry.path().display().to_string(),
-            source,
-        })?;
+        let file_type = entry.file_type().map_err(io_err(&entry.path()))?;
 
         if file_type.is_symlink() {
             // Follow the symlink to determine what it points to.
@@ -165,12 +144,7 @@ fn collect_files_recursive(
 
             // Only include symlinked regular files; skip directory symlinks
             // to prevent infinite recursion from symlink cycles.
-            if target_meta.is_file()
-                && path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .is_some_and(|e| e == extension)
-            {
+            if target_meta.is_file() && has_extension(&path, extension) {
                 out.push(path);
             }
             continue;
@@ -180,11 +154,7 @@ fn collect_files_recursive(
 
         if file_type.is_dir() {
             collect_files_recursive(&path, extension, out)?;
-        } else if path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|e| e == extension)
-        {
+        } else if has_extension(&path, extension) {
             out.push(path);
         }
     }


### PR DESCRIPTION
## Summary

### Commit 1: Filesystem & validation
- **`io_err()` helper in `fs.rs`** — Replaces 10 repeated `map_err` closures (-52 lines)
- **`has_extension()` helper** — Replaces 2 duplicated file extension checks
- **`validate_plugins` error closure** — Eliminates 5 repeated error constructions
- **`check_lockfile_staleness` let-else** — Per code-style.md
- **Lint diagnostic formatting** — Direct match arms, no intermediate allocation

### Commit 2: Toolchain & CLI
- **`atomic_rename_into()`** — Replaces 2 identical 12-line rename blocks
- **`ensure_executable()`** — Replaces 2 identical `#[cfg(unix)]` blocks
- **`temp_tarball()` / `temp_extract_dir()`** — Replaces 2 pairs of Builder chains
- **Collapsed `2 | 3` match arms** in `parse_file_and_line()` — identical bodies
- **`profile_label()`** — Replaces 3 repeated profile expressions

### Commit 3: Dead code & deduplication
- **Removed `process.rs`** — `run_command`/`CommandOutput` never imported outside module (-77 lines)
- **Removed `derive_dep_name()`** — Identity function that just returned its input
- **Removed `split_maven_coordinate` wrapper** in update.rs — dead indirection
- **`cache_path` delegates to `repository_path`** — Eliminated duplicated path computation
- **`maven_artifact_url()` helper** — Shared by `pom_url` and `module_metadata_url`

**13 files changed, net -202 lines**

## Test plan

- [x] `cargo test --workspace` — 755/755 tests pass (5 fewer = removed dead code tests)
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)