### PR TITLE
Type-safety followups: typed errors, Profile/Target enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,9 @@ name = "konvoy-targets"
 version = "1.2.0"
 dependencies = [
  "proptest",
+ "serde",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -138,7 +138,7 @@ fn main() {
             verbose,
             force,
             locked,
-        } => cmd_build(target, release, verbose, force, locked),
+        } => cmd_build(target, profile_from_flag(release), verbose, force, locked),
         Command::Run {
             target,
             release,
@@ -146,7 +146,14 @@ fn main() {
             force,
             locked,
             args,
-        } => cmd_run(target, release, verbose, force, locked, &args),
+        } => cmd_run(
+            target,
+            profile_from_flag(release),
+            verbose,
+            force,
+            locked,
+            &args,
+        ),
         Command::Test {
             target,
             release,
@@ -154,7 +161,14 @@ fn main() {
             force,
             locked,
             filter,
-        } => cmd_test(target, release, verbose, force, locked, &filter),
+        } => cmd_test(
+            target,
+            profile_from_flag(release),
+            verbose,
+            force,
+            locked,
+            &filter,
+        ),
         Command::Lint {
             verbose,
             config,
@@ -225,44 +239,43 @@ fn cmd_init(name: Option<String>, lib: bool) -> CliResult {
     Ok(())
 }
 
+/// Map the `--release` CLI flag to a `Profile` at the boundary.
+fn profile_from_flag(release: bool) -> konvoy_config::Profile {
+    if release {
+        konvoy_config::Profile::Release
+    } else {
+        konvoy_config::Profile::Debug
+    }
+}
+
 fn build_options(
     target: Option<String>,
-    release: bool,
+    profile: konvoy_config::Profile,
     verbose: bool,
     force: bool,
     locked: bool,
 ) -> konvoy_engine::BuildOptions {
     konvoy_engine::BuildOptions {
         target,
-        release,
+        profile,
         verbose,
         force,
         locked,
     }
 }
 
-/// Return `"release"` or `"debug"` for display in build output.
-fn profile_label(release: bool) -> &'static str {
-    if release {
-        "release"
-    } else {
-        "debug"
-    }
-}
-
 fn cmd_build(
     target: Option<String>,
-    release: bool,
+    profile: konvoy_config::Profile,
     verbose: bool,
     force: bool,
     locked: bool,
 ) -> CliResult {
     let root = project_root()?;
-    let options = build_options(target, release, verbose, force, locked);
+    let options = build_options(target, profile, verbose, force, locked);
 
     let result = konvoy_engine::build(&root, &options)?;
 
-    let profile = profile_label(release);
     match result.outcome {
         konvoy_engine::BuildOutcome::Cached => {
             eprintln!(
@@ -283,7 +296,7 @@ fn cmd_build(
 
 fn cmd_run(
     target: Option<String>,
-    release: bool,
+    profile: konvoy_config::Profile,
     verbose: bool,
     force: bool,
     locked: bool,
@@ -300,11 +313,10 @@ fn cmd_run(
         );
     }
 
-    let options = build_options(target, release, verbose, force, locked);
+    let options = build_options(target, profile, verbose, force, locked);
 
     let result = konvoy_engine::build(&root, &options)?;
 
-    let profile = profile_label(release);
     eprintln!(
         "    Finished `{profile}` target in {:.2}s",
         result.duration.as_secs_f64()
@@ -326,18 +338,17 @@ fn cmd_run(
 
 fn cmd_test(
     target: Option<String>,
-    release: bool,
+    profile: konvoy_config::Profile,
     verbose: bool,
     force: bool,
     locked: bool,
     filter: &Option<String>,
 ) -> CliResult {
     let root = project_root()?;
-    let options = build_options(target, release, verbose, force, locked);
+    let options = build_options(target, profile, verbose, force, locked);
 
     let result = konvoy_engine::build_tests(&root, &options)?;
 
-    let profile = profile_label(release);
     eprintln!(
         "    Finished `{profile}` test target in {:.2}s",
         result.compile_duration.as_secs_f64()
@@ -1439,5 +1450,45 @@ mod tests {
         std::fs::remove_dir_all(root.join(".konvoy")).unwrap();
 
         clean_project(root, true).unwrap();
+    }
+
+    // ── Flag → Profile mapping ─────────────────────────────────────
+
+    #[test]
+    fn profile_from_flag_false_is_debug() {
+        assert_eq!(profile_from_flag(false), konvoy_config::Profile::Debug);
+    }
+
+    #[test]
+    fn profile_from_flag_true_is_release() {
+        assert_eq!(profile_from_flag(true), konvoy_config::Profile::Release);
+    }
+
+    // ── build_options constructor ──────────────────────────────────
+
+    #[test]
+    fn build_options_passes_fields_through() {
+        let opts = build_options(
+            Some("linux_x64".to_owned()),
+            konvoy_config::Profile::Release,
+            true,
+            true,
+            true,
+        );
+        assert_eq!(opts.target.as_deref(), Some("linux_x64"));
+        assert_eq!(opts.profile, konvoy_config::Profile::Release);
+        assert!(opts.verbose);
+        assert!(opts.force);
+        assert!(opts.locked);
+    }
+
+    #[test]
+    fn build_options_defaults_are_false() {
+        let opts = build_options(None, konvoy_config::Profile::Debug, false, false, false);
+        assert!(opts.target.is_none());
+        assert_eq!(opts.profile, konvoy_config::Profile::Debug);
+        assert!(!opts.verbose);
+        assert!(!opts.force);
+        assert!(!opts.locked);
     }
 }

--- a/crates/konvoy-cli/tests/cli_integration.rs
+++ b/crates/konvoy-cli/tests/cli_integration.rs
@@ -1,0 +1,140 @@
+//! Integration tests for the `konvoy` CLI binary.
+//!
+//! These exercise the `cmd_*` dispatch error paths so they show up in
+//! coverage without needing a working konanc toolchain. We never go far
+//! enough to invoke the compiler — instead we drive each `cmd_*` until
+//! it returns a controlled error.
+
+use std::path::Path;
+use std::process::Command;
+
+fn konvoy_bin() -> &'static str {
+    // Cargo sets CARGO_BIN_EXE_<bin-name> for integration tests.
+    env!("CARGO_BIN_EXE_konvoy")
+}
+
+fn run_in(dir: &Path, args: &[&str]) -> (bool, String, String) {
+    let output = Command::new(konvoy_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to spawn konvoy");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (output.status.success(), stdout, stderr)
+}
+
+fn write_manifest(dir: &Path, contents: &str) {
+    std::fs::write(dir.join("konvoy.toml"), contents).expect("write konvoy.toml");
+}
+
+// ── No-project error paths ────────────────────────────────────────────
+
+#[test]
+fn build_outside_project_reports_missing_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, stderr) = run_in(tmp.path(), &["build"]);
+    assert!(!ok, "build should fail without konvoy.toml");
+    assert!(
+        stderr.contains("no konvoy.toml") || stderr.contains("konvoy init"),
+        "expected missing-manifest error, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_outside_project_reports_missing_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, stderr) = run_in(tmp.path(), &["run"]);
+    assert!(!ok);
+    assert!(stderr.contains("no konvoy.toml"), "stderr was: {stderr}");
+}
+
+#[test]
+fn test_outside_project_reports_missing_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, stderr) = run_in(tmp.path(), &["test"]);
+    assert!(!ok);
+    assert!(stderr.contains("no konvoy.toml"), "stderr was: {stderr}");
+}
+
+// ── Profile flag dispatch (exercises profile_from_flag + dispatch arms) ─
+
+#[test]
+fn build_dispatches_with_release_profile() {
+    // Sends --release through the Build dispatch arm and profile_from_flag(true).
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, _stderr) = run_in(tmp.path(), &["build", "--release"]);
+    // Exits non-zero because there's no konvoy.toml, but the dispatch arm + profile
+    // mapping have already executed at that point.
+    assert!(!ok);
+}
+
+#[test]
+fn run_dispatches_with_release_and_extra_args() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, _stderr) = run_in(tmp.path(), &["run", "--release", "--", "foo", "bar"]);
+    assert!(!ok);
+}
+
+#[test]
+fn test_dispatches_with_filter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, _stderr) = run_in(tmp.path(), &["test", "--filter", "my_test_name"]);
+    assert!(!ok);
+}
+
+// ── `run` against a library project: the "cannot run a library" branch ─
+
+#[test]
+fn run_on_library_project_fails_with_actionable_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_manifest(
+        tmp.path(),
+        r#"
+[package]
+name = "my-lib"
+kind = "lib"
+
+[toolchain]
+kotlin = "2.1.0"
+"#,
+    );
+    // Need a src/ dir or the manifest parse may not be the only requirement.
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src").join("lib.kt"), "fun lib() {}").unwrap();
+
+    let (ok, _stdout, stderr) = run_in(tmp.path(), &["run"]);
+    assert!(!ok, "run on a lib project must fail");
+    assert!(
+        stderr.contains("cannot run a library project"),
+        "expected library-project error, got stderr: {stderr}"
+    );
+}
+
+// ── Help / version sanity (exercises clap dispatch fall-through) ──────
+
+#[test]
+fn version_flag_prints_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, stdout, _stderr) = run_in(tmp.path(), &["--version"]);
+    assert!(ok);
+    assert!(stdout.contains("konvoy"), "stdout was: {stdout}");
+}
+
+#[test]
+fn help_flag_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, stdout, _stderr) = run_in(tmp.path(), &["--help"]);
+    assert!(ok);
+    assert!(
+        stdout.to_lowercase().contains("usage"),
+        "expected `usage` in help text, got: {stdout}"
+    );
+}
+
+#[test]
+fn unknown_subcommand_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _stdout, _stderr) = run_in(tmp.path(), &["nonexistent-command"]);
+    assert!(!ok, "unknown subcommands should exit non-zero");
+}

--- a/crates/konvoy-config/src/lib.rs
+++ b/crates/konvoy-config/src/lib.rs
@@ -3,6 +3,8 @@
 
 pub mod lockfile;
 pub mod manifest;
+pub mod profile;
 
 pub use lockfile::Lockfile;
 pub use manifest::Manifest;
+pub use profile::Profile;

--- a/crates/konvoy-config/src/manifest.rs
+++ b/crates/konvoy-config/src/manifest.rs
@@ -68,7 +68,15 @@ pub struct DependencySpec {
 impl DependencySpec {
     /// Returns `true` if this is a Maven dependency (has both `maven` and `version` set).
     pub fn is_maven(&self) -> bool {
-        self.maven.is_some() && self.version.is_some()
+        self.as_maven_coord().is_some()
+    }
+
+    /// Return `(maven_coord, version)` if this spec is a complete Maven dependency.
+    pub fn as_maven_coord(&self) -> Option<(&str, &str)> {
+        match (&self.maven, &self.version) {
+            (Some(maven), Some(version)) => Some((maven.as_str(), version.as_str())),
+            _ => None,
+        }
     }
 }
 
@@ -1706,5 +1714,37 @@ version = "1.0"
             version: None,
         };
         assert!(!spec.is_maven());
+    }
+
+    #[test]
+    fn as_maven_coord_returns_pair_when_complete() {
+        let spec = DependencySpec {
+            path: None,
+            maven: Some("org.example:lib".to_owned()),
+            version: Some("1.0.0".to_owned()),
+        };
+        assert_eq!(spec.as_maven_coord(), Some(("org.example:lib", "1.0.0")));
+    }
+
+    #[test]
+    fn as_maven_coord_none_when_partial() {
+        let maven_only = DependencySpec {
+            path: None,
+            maven: Some("org.example:lib".to_owned()),
+            version: None,
+        };
+        let version_only = DependencySpec {
+            path: None,
+            maven: None,
+            version: Some("1.0.0".to_owned()),
+        };
+        let neither = DependencySpec {
+            path: None,
+            maven: None,
+            version: None,
+        };
+        assert_eq!(maven_only.as_maven_coord(), None);
+        assert_eq!(version_only.as_maven_coord(), None);
+        assert_eq!(neither.as_maven_coord(), None);
     }
 }

--- a/crates/konvoy-config/src/profile.rs
+++ b/crates/konvoy-config/src/profile.rs
@@ -1,0 +1,98 @@
+//! Build profile (debug vs release).
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Build profile.
+///
+/// Serialized as the wire strings `"debug"` / `"release"` via
+/// `#[serde(rename_all = "lowercase")]` so `metadata.toml` and any future
+/// config files stay compatible with the pre-enum stringly-typed format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Profile {
+    Debug,
+    Release,
+}
+
+impl Profile {
+    /// Returns the canonical wire string (`"debug"` or `"release"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Profile::Debug => "debug",
+            Profile::Release => "release",
+        }
+    }
+}
+
+impl fmt::Display for Profile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Errors returned when parsing a profile string.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+    #[error("unknown profile `{name}` — expected `debug` or `release`")]
+    Invalid { name: String },
+}
+
+impl FromStr for Profile {
+    type Err = ProfileError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "debug" => Ok(Profile::Debug),
+            "release" => Ok(Profile::Release),
+            other => Err(ProfileError::Invalid {
+                name: other.to_owned(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_wire_format() {
+        assert_eq!(Profile::Debug.to_string(), "debug");
+        assert_eq!(Profile::Release.to_string(), "release");
+    }
+
+    #[test]
+    fn parse_round_trips() {
+        assert_eq!("debug".parse::<Profile>().unwrap(), Profile::Debug);
+        assert_eq!("release".parse::<Profile>().unwrap(), Profile::Release);
+    }
+
+    #[test]
+    fn parse_rejects_unknown() {
+        assert!("opt".parse::<Profile>().is_err());
+        assert!("".parse::<Profile>().is_err());
+    }
+
+    #[test]
+    fn serializes_as_plain_string_via_toml() {
+        #[derive(Serialize, Deserialize)]
+        struct Wrap {
+            profile: Profile,
+        }
+        let s = toml::to_string(&Wrap {
+            profile: Profile::Release,
+        })
+        .unwrap();
+        assert!(
+            s.contains("profile = \"release\""),
+            "expected wire string `release`, got: {s}"
+        );
+
+        let back: Wrap = toml::from_str("profile = \"debug\"").unwrap();
+        assert_eq!(back.profile, Profile::Debug);
+    }
+}

--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -7,6 +7,9 @@ use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 
+use konvoy_config::Profile;
+use konvoy_targets::Target;
+
 use crate::cache::CacheKey;
 use crate::error::EngineError;
 
@@ -35,12 +38,16 @@ impl Drop for TempDirGuard {
 }
 
 /// Metadata stored alongside a cached artifact.
+///
+/// `target` and `profile` are serialized as their canonical wire strings
+/// (e.g. `"linux_x64"`, `"debug"`) to preserve on-disk format compatibility
+/// with existing `metadata.toml` files.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildMetadata {
-    /// Kotlin/Native target (e.g. "linux_x64").
-    pub target: String,
-    /// Build profile ("debug" or "release").
-    pub profile: String,
+    /// Kotlin/Native target.
+    pub target: Target,
+    /// Build profile.
+    pub profile: Profile,
     /// konanc version used for the build.
     pub konanc_version: String,
     /// Epoch seconds timestamp of when the build was produced (e.g. "1708646400s-since-epoch").
@@ -126,8 +133,9 @@ impl ArtifactStore {
         // Write metadata alongside the artifact.
         let metadata_path = tmp_dir.join("metadata.toml");
         let metadata_toml =
-            toml::to_string_pretty(metadata).map_err(|e| EngineError::Metadata {
-                message: e.to_string(),
+            toml::to_string_pretty(metadata).map_err(|source| EngineError::TomlSerialize {
+                what: "metadata.toml",
+                source,
             })?;
         konvoy_util::fs::write_file(&metadata_path, metadata_toml)?;
 
@@ -333,8 +341,8 @@ mod tests {
 
     fn test_metadata() -> BuildMetadata {
         BuildMetadata {
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             konanc_version: "2.1.0".to_owned(),
             built_at: "2026-02-21T00:00:00Z".to_owned(),
         }
@@ -352,8 +360,8 @@ mod tests {
             lockfile_content: "".to_owned(),
             konanc_version: "2.1.0".to_owned(),
             konanc_fingerprint: "abc123".to_owned(),
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             source_dir: tmp.path().to_path_buf(),
             source_glob: "**/*.kt".to_owned(),
             os: "linux".to_owned(),
@@ -394,6 +402,40 @@ mod tests {
         let content = fs::read_to_string(metadata_path).unwrap();
         assert!(content.contains("linux_x64"));
         assert!(content.contains("2.1.0"));
+    }
+
+    /// Verifies that metadata.toml on disk uses the canonical
+    /// `target = "linux_x64"` / `profile = "debug"` strings — and that
+    /// pre-typed-enum metadata files still deserialize cleanly. Guards the
+    /// on-disk format contract called out in issue #268.
+    #[test]
+    fn metadata_round_trips_with_canonical_strings() {
+        let meta = BuildMetadata {
+            target: Target::MacOsArm64,
+            profile: Profile::Release,
+            konanc_version: "2.1.0".to_owned(),
+            built_at: "12345s-since-epoch".to_owned(),
+        };
+        let serialized = toml::to_string_pretty(&meta).unwrap();
+        assert!(
+            serialized.contains("target = \"macos_arm64\""),
+            "expected canonical target wire string, got: {serialized}"
+        );
+        assert!(
+            serialized.contains("profile = \"release\""),
+            "expected canonical profile wire string, got: {serialized}"
+        );
+
+        // Old-style raw-string TOML must round-trip into the typed struct.
+        let legacy = r#"
+target = "linux_x64"
+profile = "debug"
+konanc_version = "2.1.0"
+built_at = "1s-since-epoch"
+"#;
+        let back: BuildMetadata = toml::from_str(legacy).unwrap();
+        assert_eq!(back.target, Target::LinuxX64);
+        assert_eq!(back.profile, Profile::Debug);
     }
 
     #[test]

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -8,6 +8,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
 use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile};
 use konvoy_config::manifest::{Manifest, PackageKind};
+use konvoy_config::Profile;
 use konvoy_konanc::detect::{resolve_konanc, KonancInfo};
 use konvoy_konanc::invoke::{KonancCommand, ProduceKind};
 use konvoy_targets::{host_target, Target};
@@ -22,14 +23,21 @@ use crate::resolve::{parallel_levels, resolve_dependencies, ResolvedGraph};
 pub struct BuildOptions {
     /// Explicit target triple, or `None` for host.
     pub target: Option<String>,
-    /// Whether to build in release mode.
-    pub release: bool,
+    /// Build profile (debug or release).
+    pub profile: Profile,
     /// Whether to show raw compiler output.
     pub verbose: bool,
     /// Force a rebuild, bypassing the cache.
     pub force: bool,
     /// Require the lockfile to be up-to-date; error on any mismatch.
     pub locked: bool,
+}
+
+impl BuildOptions {
+    /// Returns `true` when the build is in release mode.
+    pub fn is_release(&self) -> bool {
+        matches!(self.profile, Profile::Release)
+    }
 }
 
 /// Whether the build used a cached artifact or compiled fresh.
@@ -61,22 +69,18 @@ pub(crate) struct ResolvedBuildContext {
     pub manifest: Manifest,
     /// Original lockfile read from disk (before pre-stabilization).
     pub lockfile: Lockfile,
-    /// Path to `konvoy.lock` on disk.
-    pub lockfile_path: PathBuf,
     /// Serialized effective (pre-stabilized) lockfile content for cache key computation.
     pub lockfile_content: String,
     /// Resolved build target (host or explicit `--target`).
     pub target: Target,
-    /// Build profile (`"debug"` or `"release"`).
-    pub profile: String,
+    /// Build profile.
+    pub profile: Profile,
     /// Detected konanc compiler info (path, version, fingerprint).
     pub konanc: KonancInfo,
     /// JRE home directory from the managed toolchain, if available.
     pub jre_home: Option<PathBuf>,
-    /// SHA-256 of the konanc tarball (from a fresh download, or `None` if already installed).
-    pub konanc_tarball_sha256: Option<String>,
-    /// SHA-256 of the JRE tarball (from a fresh download, or `None` if already installed).
-    pub jre_tarball_sha256: Option<String>,
+    /// Inputs to `update_lockfile_if_needed` (fresh-download hashes).
+    pub lockfile_write_inputs: LockfileWriteInputs,
     /// Library paths from built path-deps and downloaded Maven klibs.
     pub library_paths: Vec<PathBuf>,
     /// Paths to downloaded compiler plugin JARs.
@@ -87,6 +91,14 @@ pub(crate) struct ResolvedBuildContext {
     pub dep_graph: ResolvedGraph,
     /// Content-addressed artifact store for this project.
     pub store: ArtifactStore,
+}
+
+/// Inputs that only flow into `update_lockfile_if_needed`.
+pub(crate) struct LockfileWriteInputs {
+    /// SHA-256 of the konanc tarball (from a fresh download, or `None` if already installed).
+    pub konanc_tarball_sha256: Option<String>,
+    /// SHA-256 of the JRE tarball (from a fresh download, or `None` if already installed).
+    pub jre_tarball_sha256: Option<String>,
 }
 
 /// Resolve the common build pipeline state (steps 1–7b).
@@ -132,7 +144,7 @@ pub(crate) fn resolve_build_context(
 
     // 4. Resolve target.
     let target = resolve_target(&options.target)?;
-    let profile = if options.release { "release" } else { "debug" };
+    let profile = options.profile;
 
     // 5. Resolve managed konanc toolchain.
     let resolved = resolve_konanc(&manifest.toolchain.kotlin)?;
@@ -244,14 +256,15 @@ pub(crate) fn resolve_build_context(
     Ok(ResolvedBuildContext {
         manifest,
         lockfile,
-        lockfile_path,
         lockfile_content,
         target,
-        profile: profile.to_owned(),
+        profile,
         konanc,
         jre_home,
-        konanc_tarball_sha256,
-        jre_tarball_sha256,
+        lockfile_write_inputs: LockfileWriteInputs {
+            konanc_tarball_sha256,
+            jre_tarball_sha256,
+        },
         library_paths,
         plugin_jars,
         plugin_locks,
@@ -294,20 +307,22 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
         project_root,
         &ctx.manifest,
         &cc,
-        &ctx.profile,
+        ctx.profile,
         &ctx.lockfile_content,
     )?;
+
+    let lockfile_path = project_root.join("konvoy.lock");
 
     // 9. Update lockfile if toolchain, dependencies, or plugins changed.
     update_lockfile_if_needed(
         &ctx.lockfile,
         &ctx.konanc,
-        ctx.konanc_tarball_sha256.as_deref(),
-        ctx.jre_tarball_sha256.as_deref(),
+        ctx.lockfile_write_inputs.konanc_tarball_sha256.as_deref(),
+        ctx.lockfile_write_inputs.jre_tarball_sha256.as_deref(),
         &ctx.dep_graph,
         &ctx.plugin_locks,
         project_root,
-        &ctx.lockfile_path,
+        &lockfile_path,
         options.force,
         options.locked,
     )?;
@@ -345,7 +360,7 @@ pub(crate) fn build_single(
     project_root: &Path,
     manifest: &Manifest,
     cc: &CompileContext<'_>,
-    profile: &str,
+    profile: Profile,
     lockfile_content: &str,
 ) -> Result<(PathBuf, BuildOutcome), EngineError> {
     // Collect source files, excluding test sources (src/test/).
@@ -371,8 +386,8 @@ pub(crate) fn build_single(
         lockfile_content: lockfile_content.to_owned(),
         konanc_version: cc.konanc.version.clone(),
         konanc_fingerprint: cc.konanc.fingerprint.clone(),
-        target: cc.target.to_string(),
-        profile: profile.to_owned(),
+        target: *cc.target,
+        profile,
         source_dir: project_root.join("src"),
         source_glob: "**/*.kt".to_owned(),
         os: std::env::consts::OS.to_owned(),
@@ -395,7 +410,7 @@ pub(crate) fn build_single(
         .join(".konvoy")
         .join("build")
         .join(cc.target.to_konanc_arg())
-        .join(profile)
+        .join(profile.as_str())
         .join(&output_name);
 
     let store = ArtifactStore::new(project_root);
@@ -423,8 +438,8 @@ pub(crate) fn build_single(
 
     // Store artifact in cache.
     let metadata = BuildMetadata {
-        target: cc.target.to_string(),
-        profile: profile.to_owned(),
+        target: *cc.target,
+        profile,
         konanc_version: cc.konanc.version.clone(),
         built_at: crate::common::now_epoch_secs(),
     };
@@ -483,7 +498,7 @@ fn compile_two_step(
         .sources(sources)
         .output(&klib_path)
         .target(cc.target.to_konanc_arg())
-        .release(cc.options.release)
+        .release(cc.options.is_release())
         .produce(ProduceKind::Library)
         .libraries(cc.library_paths)
         .plugins(cc.plugin_jars);
@@ -508,7 +523,7 @@ fn compile_two_step(
             .include(&klib_path)
             .output(output_path)
             .target(cc.target.to_konanc_arg())
-            .release(cc.options.release)
+            .release(cc.options.is_release())
             .libraries(cc.library_paths);
 
         if let Some(jh) = cc.jre_home {
@@ -547,7 +562,7 @@ fn compile_single_step(
         .sources(sources)
         .output(output_path)
         .target(cc.target.to_konanc_arg())
-        .release(cc.options.release)
+        .release(cc.options.is_release())
         .produce(produce)
         .libraries(cc.library_paths)
         .plugins(cc.plugin_jars);
@@ -596,8 +611,9 @@ fn compile(
 
 /// Serialize lockfile content for cache key computation.
 pub(crate) fn lockfile_toml_content(lockfile: &Lockfile) -> Result<String, EngineError> {
-    toml::to_string_pretty(lockfile).map_err(|e| EngineError::Metadata {
-        message: e.to_string(),
+    toml::to_string_pretty(lockfile).map_err(|source| EngineError::TomlSerialize {
+        what: "konvoy.lock",
+        source,
     })
 }
 
@@ -628,7 +644,7 @@ pub(crate) fn resolve_maven_deps(
     }
 
     let cache_root = crate::plugin::maven_cache_root()?;
-    let target_str = target.to_string();
+    let target_str = target.to_konanc_arg();
     let maven_suffix = target.to_maven_suffix();
 
     let klib_paths: Vec<Result<PathBuf, EngineError>> = maven_locks
@@ -668,10 +684,10 @@ pub(crate) fn resolve_maven_deps(
             // Extract the expected SHA-256 for this target from the lockfile.
             let expected_sha256 =
                 targets
-                    .get(&target_str)
+                    .get(target_str)
                     .ok_or_else(|| EngineError::MissingTargetHash {
                         name: dep_name.clone(),
-                        target: target_str.clone(),
+                        target: target_str.to_owned(),
                     })?;
 
             // Compute the cache path and download URL.
@@ -1031,7 +1047,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -1054,7 +1070,7 @@ mod tests {
 
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -1251,13 +1267,14 @@ mod tests {
     fn build_options_defaults() {
         let opts = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
         };
         assert!(opts.target.is_none());
-        assert!(!opts.release);
+        assert_eq!(opts.profile, Profile::Debug);
+        assert!(!opts.is_release());
         assert!(!opts.verbose);
         assert!(!opts.force);
         assert!(!opts.locked);
@@ -1337,11 +1354,11 @@ mod tests {
             version: "2.1.0".to_owned(),
             fingerprint: "abc123".to_owned(),
         };
-        let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
-        let profile = "debug";
+        let target = konvoy_targets::Target::LinuxX64;
+        let profile = Profile::Debug;
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -1356,8 +1373,8 @@ mod tests {
             lockfile_content: lockfile_content.clone(),
             konanc_version: konanc.version.clone(),
             konanc_fingerprint: konanc.fingerprint.clone(),
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             source_dir: project.join("src"),
             source_glob: "**/*.kt".to_owned(),
             os: std::env::consts::OS.to_owned(),
@@ -1373,8 +1390,8 @@ mod tests {
         let fake_artifact = staging.join("myapp");
         fs::write(&fake_artifact, "fake-binary-content").unwrap();
         let metadata = BuildMetadata {
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             konanc_version: konanc.version.clone(),
             built_at: crate::common::now_epoch_secs(),
         };
@@ -1424,11 +1441,11 @@ mod tests {
             version: "2.1.0".to_owned(),
             fingerprint: "abc123".to_owned(),
         };
-        let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
-        let profile = "debug";
+        let target = konvoy_targets::Target::LinuxX64;
+        let profile = Profile::Debug;
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -1443,8 +1460,8 @@ mod tests {
             lockfile_content: lockfile_content.clone(),
             konanc_version: konanc.version.clone(),
             konanc_fingerprint: konanc.fingerprint.clone(),
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             source_dir: project.join("src"),
             source_glob: "**/*.kt".to_owned(),
             os: std::env::consts::OS.to_owned(),
@@ -1460,8 +1477,8 @@ mod tests {
         let fake_artifact = staging.join("myapp");
         fs::write(&fake_artifact, "fake-binary-content").unwrap();
         let metadata = BuildMetadata {
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             konanc_version: konanc.version.clone(),
             built_at: crate::common::now_epoch_secs(),
         };
@@ -1506,11 +1523,11 @@ mod tests {
             version: "2.1.0".to_owned(),
             fingerprint: "abc123".to_owned(),
         };
-        let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
-        let profile = "debug";
+        let target = konvoy_targets::Target::LinuxX64;
+        let profile = Profile::Debug;
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -1525,8 +1542,8 @@ mod tests {
             lockfile_content: lockfile_content.clone(),
             konanc_version: konanc.version.clone(),
             konanc_fingerprint: konanc.fingerprint.clone(),
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             source_dir: project.join("src"),
             source_glob: "**/*.kt".to_owned(),
             os: std::env::consts::OS.to_owned(),
@@ -1542,8 +1559,8 @@ mod tests {
         let fake_artifact = staging.join("myapp");
         fs::write(&fake_artifact, "fake-binary-content").unwrap();
         let metadata = BuildMetadata {
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             konanc_version: konanc.version.clone(),
             built_at: crate::common::now_epoch_secs(),
         };
@@ -1566,8 +1583,8 @@ mod tests {
             lockfile_content: lockfile_content.clone(),
             konanc_version: konanc.version.clone(),
             konanc_fingerprint: konanc.fingerprint.clone(),
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             source_dir: project.join("src"),
             source_glob: "**/*.kt".to_owned(),
             os: std::env::consts::OS.to_owned(),
@@ -2125,8 +2142,8 @@ mod tests {
             version: "2.1.0".to_owned(),
             fingerprint: "abc123".to_owned(),
         };
-        let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
-        let profile = "debug";
+        let target = konvoy_targets::Target::LinuxX64;
+        let profile = Profile::Debug;
 
         // Compute the cache key that build_single would compute.
         let manifest_content = manifest.to_toml().unwrap();
@@ -2137,8 +2154,8 @@ mod tests {
             lockfile_content: lockfile_content.clone(),
             konanc_version: konanc.version.clone(),
             konanc_fingerprint: konanc.fingerprint.clone(),
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             source_dir: project.join("src"),
             source_glob: "**/*.kt".to_owned(),
             os: std::env::consts::OS.to_owned(),
@@ -2154,8 +2171,8 @@ mod tests {
         let fake_artifact = staging.join("myapp");
         fs::write(&fake_artifact, "fake-binary-content").unwrap();
         let metadata = BuildMetadata {
-            target: target.to_string(),
-            profile: profile.to_owned(),
+            target,
+            profile,
             konanc_version: konanc.version.clone(),
             built_at: crate::common::now_epoch_secs(),
         };
@@ -2165,7 +2182,7 @@ mod tests {
         // Verify that without force, we get a cache hit.
         let options_no_force = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -2193,7 +2210,7 @@ mod tests {
         // which proves it bypassed the cache.
         let options_force = BuildOptions {
             target: None,
-            release: false,
+            profile: Profile::Debug,
             verbose: false,
             force: true,
             locked: false,
@@ -3682,8 +3699,8 @@ url = "https://example.com/plugin.jar"
             lockfile_content,
             konanc_version: "2.1.0".to_owned(),
             konanc_fingerprint: "abc123".to_owned(),
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             source_dir: dir.path().to_path_buf(),
             source_glob: "**/*.kt".to_owned(),
             os: "linux".to_owned(),
@@ -3733,8 +3750,8 @@ url = "https://example.com/plugin.jar"
             lockfile_content: content,
             konanc_version: "2.1.0".to_owned(),
             konanc_fingerprint: "abc".to_owned(),
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             source_dir: dir.path().to_path_buf(),
             source_glob: "**/*.kt".to_owned(),
             os: "linux".to_owned(),
@@ -3875,8 +3892,8 @@ url = "https://example.com/plugin.jar"
             lockfile_content: content,
             konanc_version: "2.1.0".to_owned(),
             konanc_fingerprint: "abc".to_owned(),
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             source_dir: dir.path().to_path_buf(),
             source_glob: "**/*.kt".to_owned(),
             os: "linux".to_owned(),

--- a/crates/konvoy-engine/src/cache.rs
+++ b/crates/konvoy-engine/src/cache.rs
@@ -3,6 +3,9 @@
 use std::fmt;
 use std::path::Path;
 
+use konvoy_config::Profile;
+use konvoy_targets::Target;
+
 use crate::error::EngineError;
 
 /// All inputs that contribute to a deterministic cache key.
@@ -16,10 +19,10 @@ pub struct CacheInputs {
     pub konanc_version: String,
     /// SHA-256 fingerprint of the konanc binary.
     pub konanc_fingerprint: String,
-    /// Target triple (e.g. "linux_x64").
-    pub target: String,
-    /// Build profile ("debug" or "release").
-    pub profile: String,
+    /// Target triple.
+    pub target: Target,
+    /// Build profile.
+    pub profile: Profile,
     /// Root directory containing source files.
     pub source_dir: std::path::PathBuf,
     /// Glob pattern for source files (e.g. "**/*.kt").
@@ -47,13 +50,15 @@ impl CacheKey {
     pub fn compute(inputs: &CacheInputs) -> Result<Self, EngineError> {
         let source_hash = konvoy_util::hash::sha256_dir(&inputs.source_dir, &inputs.source_glob)?;
 
+        let target_str = inputs.target.to_konanc_arg();
+        let profile_str = inputs.profile.as_str();
         let mut parts: Vec<&str> = vec![
             &inputs.manifest_content,
             &inputs.lockfile_content,
             &inputs.konanc_version,
             &inputs.konanc_fingerprint,
-            &inputs.target,
-            &inputs.profile,
+            target_str,
+            profile_str,
             &source_hash,
             &inputs.os,
             &inputs.arch,
@@ -99,8 +104,8 @@ mod tests {
             lockfile_content: "".to_owned(),
             konanc_version: "2.1.0".to_owned(),
             konanc_fingerprint: "abc123".to_owned(),
-            target: "linux_x64".to_owned(),
-            profile: "debug".to_owned(),
+            target: Target::LinuxX64,
+            profile: Profile::Debug,
             source_dir: dir.to_path_buf(),
             source_glob: "**/*.kt".to_owned(),
             os: "linux".to_owned(),
@@ -182,7 +187,7 @@ mod tests {
         let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
 
         let mut inputs = make_inputs(tmp.path());
-        inputs.target = "macos_arm64".to_owned();
+        inputs.target = Target::MacOsArm64;
         let key2 = CacheKey::compute(&inputs).unwrap();
 
         assert_ne!(key1, key2);
@@ -196,7 +201,7 @@ mod tests {
         let key1 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
 
         let mut inputs = make_inputs(tmp.path());
-        inputs.profile = "release".to_owned();
+        inputs.profile = Profile::Release;
         let key2 = CacheKey::compute(&inputs).unwrap();
 
         assert_ne!(key1, key2);
@@ -383,16 +388,29 @@ mod tests {
         use super::*;
         use proptest::prelude::*;
 
+        fn arb_target() -> impl Strategy<Value = Target> {
+            prop_oneof![
+                Just(Target::LinuxX64),
+                Just(Target::LinuxArm64),
+                Just(Target::MacOsX64),
+                Just(Target::MacOsArm64),
+            ]
+        }
+
+        fn arb_profile() -> impl Strategy<Value = Profile> {
+            prop_oneof![Just(Profile::Debug), Just(Profile::Release)]
+        }
+
         fn arb_cache_inputs(dir: &Path) -> impl Strategy<Value = CacheInputs> + use<'_> {
             (
-                "[a-zA-Z0-9 =\n.]{1,100}",                            // manifest_content
-                "[a-zA-Z0-9 =\n.]{0,100}",                            // lockfile_content
-                "[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}",               // konanc_version
-                "[a-f0-9]{8,16}",                                     // konanc_fingerprint
-                prop_oneof!["linux_x64", "macos_arm64", "macos_x64"], // target
-                prop_oneof!["debug", "release"],                      // profile
-                prop_oneof!["linux", "macos", "windows"],             // os
-                prop_oneof!["x86_64", "aarch64"],                     // arch
+                "[a-zA-Z0-9 =\n.]{1,100}",                // manifest_content
+                "[a-zA-Z0-9 =\n.]{0,100}",                // lockfile_content
+                "[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}",   // konanc_version
+                "[a-f0-9]{8,16}",                         // konanc_fingerprint
+                arb_target(),                             // target
+                arb_profile(),                            // profile
+                prop_oneof!["linux", "macos", "windows"], // os
+                prop_oneof!["x86_64", "aarch64"],         // arch
             )
                 .prop_map(
                     move |(
@@ -442,8 +460,8 @@ mod tests {
                     lockfile_content: inputs1.lockfile_content.clone(),
                     konanc_version: inputs1.konanc_version.clone(),
                     konanc_fingerprint: inputs1.konanc_fingerprint.clone(),
-                    target: inputs1.target.clone(),
-                    profile: inputs1.profile.clone(),
+                    target: inputs1.target,
+                    profile: inputs1.profile,
                     source_dir: tmp.path().to_path_buf(),
                     source_glob: "**/*.kt".to_owned(),
                     os: inputs1.os.clone(),

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -8,9 +8,12 @@ use crate::error::EngineError;
 ///
 /// Returns an error if the string does not contain exactly one colon.
 pub(crate) fn split_maven_coordinate(maven: &str) -> Result<(&str, &str), EngineError> {
-    maven.split_once(':').ok_or_else(|| EngineError::Metadata {
-        message: format!("invalid maven coordinate `{maven}` — expected `groupId:artifactId`"),
-    })
+    maven
+        .split_once(':')
+        .ok_or_else(|| EngineError::InvalidMavenCoordinate {
+            coordinate: maven.to_owned(),
+            reason: "expected `groupId:artifactId`".to_owned(),
+        })
 }
 
 /// Truncate a hex hash string to `len` characters for display.

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -15,9 +15,21 @@ pub enum EngineError {
     #[error("konvoy.toml already exists at {path} — cannot initialize over an existing project")]
     ProjectExists { path: String },
 
-    /// Metadata serialization/deserialization failed.
-    #[error("cannot process metadata: {message}")]
-    Metadata { message: String },
+    /// A Maven coordinate (`groupId:artifactId`) failed to parse.
+    #[error("invalid maven coordinate `{coordinate}`: {reason}")]
+    InvalidMavenCoordinate { coordinate: String, reason: String },
+
+    /// A dependency declaration is missing a required field.
+    #[error("dependency `{name}` is missing `{field}` field")]
+    MissingDependencyField { name: String, field: &'static str },
+
+    /// A TOML document (lockfile, metadata, etc.) failed to serialize.
+    #[error("failed to serialize {what}: {source}")]
+    TomlSerialize {
+        what: &'static str,
+        #[source]
+        source: toml::ser::Error,
+    },
 
     /// A compiler operation failed.
     #[error("{0}")]
@@ -220,5 +232,75 @@ mod tests {
             msg.contains("home directory"),
             "other errors should pass through: {msg}"
         );
+    }
+
+    #[test]
+    fn invalid_maven_coordinate_display_includes_coordinate_and_reason() {
+        let err = EngineError::InvalidMavenCoordinate {
+            coordinate: "org.example:no-version:".to_owned(),
+            reason: "expected `groupId:artifactId`".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("org.example:no-version:"), "got: {msg}");
+        assert!(msg.contains("expected `groupId:artifactId`"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_dependency_field_display_includes_name_and_field() {
+        let err = EngineError::MissingDependencyField {
+            name: "ktor-core".to_owned(),
+            field: "version",
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("ktor-core"), "got: {msg}");
+        assert!(msg.contains("version"), "got: {msg}");
+    }
+
+    #[test]
+    fn missing_dependency_field_static_field_is_preserved() {
+        // The `field: &'static str` typing means callers can't accidentally
+        // pass a runtime string — pin that with a test the compiler enforces.
+        let err = EngineError::MissingDependencyField {
+            name: "x".to_owned(),
+            field: "maven",
+        };
+        assert!(err.to_string().contains("maven"));
+    }
+
+    #[test]
+    fn toml_serialize_display_includes_what_and_source() {
+        // Build a `toml::ser::Error` via a value that fails to serialize: TOML
+        // does not allow strings as map keys with a mix of nested tables, but
+        // the cleanest reliable trigger is serializing a top-level non-table
+        // value (e.g. just an integer) which TOML rejects.
+        let ser_err: toml::ser::Error =
+            toml::to_string_pretty(&42_i64).expect_err("top-level int not valid TOML");
+        let err = EngineError::TomlSerialize {
+            what: "konvoy.lock",
+            source: ser_err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("konvoy.lock"), "got: {msg}");
+        assert!(msg.contains("failed to serialize"), "got: {msg}");
+    }
+
+    #[test]
+    fn toml_serialize_preserves_source_chain() {
+        use std::error::Error as _;
+        let ser_err: toml::ser::Error =
+            toml::to_string_pretty(&7_i64).expect_err("top-level int not valid TOML");
+        let err = EngineError::TomlSerialize {
+            what: "metadata.toml",
+            source: ser_err,
+        };
+        // `#[source]` should expose the underlying toml error so callers can
+        // walk the chain (e.g. anyhow, eyre, miette).
+        assert!(err.source().is_some(), "expected a source on TomlSerialize");
+    }
+
+    #[test]
+    fn engine_error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<EngineError>();
     }
 }

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -19,10 +19,6 @@ pub enum EngineError {
     #[error("invalid maven coordinate `{coordinate}`: {reason}")]
     InvalidMavenCoordinate { coordinate: String, reason: String },
 
-    /// A dependency declaration is missing a required field.
-    #[error("dependency `{name}` is missing `{field}` field")]
-    MissingDependencyField { name: String, field: &'static str },
-
     /// A TOML document (lockfile, metadata, etc.) failed to serialize.
     #[error("failed to serialize {what}: {source}")]
     TomlSerialize {
@@ -243,28 +239,6 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("org.example:no-version:"), "got: {msg}");
         assert!(msg.contains("expected `groupId:artifactId`"), "got: {msg}");
-    }
-
-    #[test]
-    fn missing_dependency_field_display_includes_name_and_field() {
-        let err = EngineError::MissingDependencyField {
-            name: "ktor-core".to_owned(),
-            field: "version",
-        };
-        let msg = err.to_string();
-        assert!(msg.contains("ktor-core"), "got: {msg}");
-        assert!(msg.contains("version"), "got: {msg}");
-    }
-
-    #[test]
-    fn missing_dependency_field_static_field_is_preserved() {
-        // The `field: &'static str` typing means callers can't accidentally
-        // pass a runtime string — pin that with a test the compiler enforces.
-        let err = EngineError::MissingDependencyField {
-            name: "x".to_owned(),
-            field: "maven",
-        };
-        assert!(err.to_string().contains("maven"));
     }
 
     #[test]

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -66,16 +66,18 @@ pub fn build_tests(
         .collect();
     sources.extend(test_sources);
 
-    // Compute cache key (includes test sources via source hashing).
+    // Compute cache key. The test-binary build must produce a distinct cache
+    // key from a regular build of the same source tree, so we tag the lockfile
+    // content with a "test" marker (the lockfile_content is already a free-form
+    // hashed input). Keeps Profile cleanly debug/release.
     let manifest_content = ctx.manifest.to_toml()?;
     let cache_inputs = CacheInputs {
         manifest_content,
-        lockfile_content: ctx.lockfile_content,
+        lockfile_content: format!("{}\n# konvoy-test-build\n", ctx.lockfile_content),
         konanc_version: ctx.konanc.version.clone(),
         konanc_fingerprint: ctx.konanc.fingerprint.clone(),
-        target: ctx.target.to_string(),
-        // Use "debug-test" / "release-test" to differentiate from regular builds.
-        profile: format!("{}-test", ctx.profile),
+        target: ctx.target,
+        profile: ctx.profile,
         source_dir: project_root.join("src"),
         source_glob: "**/*.kt".to_owned(),
         os: std::env::consts::OS.to_owned(),
@@ -93,7 +95,7 @@ pub fn build_tests(
         .join(".konvoy")
         .join("build")
         .join(ctx.target.to_konanc_arg())
-        .join(&ctx.profile)
+        .join(ctx.profile.as_str())
         .join(&output_name);
 
     // Check cache (respecting --force).
@@ -123,7 +125,7 @@ pub fn build_tests(
         .sources(&sources)
         .output(&output_path)
         .target(ctx.target.to_konanc_arg())
-        .release(options.release)
+        .release(options.is_release())
         .produce(ProduceKind::Program)
         .generate_test_runner(true)
         .libraries(&ctx.library_paths)
@@ -148,7 +150,7 @@ pub fn build_tests(
 
     // Store in cache.
     let metadata = BuildMetadata {
-        target: ctx.target.to_string(),
+        target: ctx.target,
         profile: ctx.profile,
         konanc_version: ctx.konanc.version,
         built_at: now_epoch_secs(),
@@ -182,7 +184,7 @@ mod tests {
 
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: konvoy_config::Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -211,7 +213,7 @@ mod tests {
 
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: konvoy_config::Profile::Debug,
             verbose: false,
             force: false,
             locked: false,
@@ -231,7 +233,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let options = BuildOptions {
             target: None,
-            release: false,
+            profile: konvoy_config::Profile::Debug,
             verbose: false,
             force: false,
             locked: false,

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -94,15 +94,18 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         let maven = dep_spec
             .maven
             .as_ref()
-            .ok_or_else(|| EngineError::Metadata {
-                message: format!("dependency `{dep_name}` is missing `maven` field"),
+            .ok_or_else(|| EngineError::MissingDependencyField {
+                name: (*dep_name).clone(),
+                field: "maven",
             })?;
-        let version = dep_spec
-            .version
-            .as_ref()
-            .ok_or_else(|| EngineError::Metadata {
-                message: format!("dependency `{dep_name}` is missing `version` field"),
-            })?;
+        let version =
+            dep_spec
+                .version
+                .as_ref()
+                .ok_or_else(|| EngineError::MissingDependencyField {
+                    name: (*dep_name).clone(),
+                    field: "version",
+                })?;
 
         let (group_id, artifact_id) = crate::common::split_maven_coordinate(maven)?;
 
@@ -148,64 +151,62 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         }
 
         // For each known target, download and hash (in parallel).
-        let known_targets = konvoy_targets::known_targets();
+        let known_targets = konvoy_targets::KNOWN_TARGETS;
 
         let pid = std::process::id();
         let tmp_base = std::env::temp_dir().join(format!("konvoy-update-{pid}"));
         konvoy_util::fs::ensure_dir(&tmp_base)?;
 
-        let target_results: Vec<Result<(String, String), EngineError>> = known_targets
-            .par_iter()
-            .map(|target_name| {
-                let target = target_name
-                    .parse::<konvoy_targets::Target>()
-                    .map_err(EngineError::Target)?;
-                let maven_suffix = target.to_maven_suffix();
-                let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
+        let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> =
+            known_targets
+                .par_iter()
+                .map(|&target| {
+                    let maven_suffix = target.to_maven_suffix();
+                    let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
 
-                let mut coord = konvoy_util::maven::MavenCoordinate::new(
-                    &dep.group_id,
-                    &per_target_artifact_id,
-                    &dep.version,
-                )
-                .with_packaging("klib");
-                if let Some(cls) = &dep.classifier {
-                    coord = coord.with_classifier(cls);
-                }
-                let url = coord.to_url(MAVEN_CENTRAL);
-
-                let tmp_file = tmp_base.join(coord.filename());
-
-                let result = konvoy_util::artifact::ensure_artifact(
-                    &url,
-                    &tmp_file,
-                    None,
-                    &format!("{}:{}", dep.name, target_name),
-                    &dep.version,
-                )
-                .map_err(|e| match e {
-                    konvoy_util::error::UtilError::Download { message } => {
-                        EngineError::LibraryDownloadFailed {
-                            name: dep.name.clone(),
-                            url: url.clone(),
-                            message,
-                        }
+                    let mut coord = konvoy_util::maven::MavenCoordinate::new(
+                        &dep.group_id,
+                        &per_target_artifact_id,
+                        &dep.version,
+                    )
+                    .with_packaging("klib");
+                    if let Some(cls) = &dep.classifier {
+                        coord = coord.with_classifier(cls);
                     }
-                    other => EngineError::Util(other),
-                })?;
+                    let url = coord.to_url(MAVEN_CENTRAL);
 
-                let _ = std::fs::remove_file(&tmp_file);
+                    let tmp_file = tmp_base.join(coord.filename());
 
-                Ok(((*target_name).to_owned(), result.sha256))
-            })
-            .collect();
+                    let result = konvoy_util::artifact::ensure_artifact(
+                        &url,
+                        &tmp_file,
+                        None,
+                        &format!("{}:{}", dep.name, target),
+                        &dep.version,
+                    )
+                    .map_err(|e| match e {
+                        konvoy_util::error::UtilError::Download { message } => {
+                            EngineError::LibraryDownloadFailed {
+                                name: dep.name.clone(),
+                                url: url.clone(),
+                                message,
+                            }
+                        }
+                        other => EngineError::Util(other),
+                    })?;
+
+                    let _ = std::fs::remove_file(&tmp_file);
+
+                    Ok((target, result.sha256))
+                })
+                .collect();
 
         let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
         for result in target_results {
-            let (target_name, sha256) = result?;
+            let (target, sha256) = result?;
             let display_hash = crate::common::truncate_hash(&sha256, 16);
-            eprintln!("    {target_name}: {display_hash}...");
-            targets_map.insert(target_name, sha256);
+            eprintln!("    {target}: {display_hash}...");
+            targets_map.insert(target.to_string(), sha256);
         }
 
         konvoy_util::fs::remove_dir_all_if_exists(&tmp_base)?;
@@ -425,17 +426,10 @@ fn resolve_transitive(
 ) -> Result<Vec<ResolvedMavenDep>, EngineError> {
     // Use the first known target for metadata fetching — the transitive graph is
     // identical across targets since every Kotlin/Native artifact publishes
-    // the same set of dependencies in each per-target variant.
-    let probe_target =
-        konvoy_targets::known_targets()
-            .first()
-            .ok_or_else(|| EngineError::Metadata {
-                message: "no known targets available".to_owned(),
-            })?;
-    let probe_target_parsed = probe_target
-        .parse::<konvoy_targets::Target>()
-        .map_err(EngineError::Target)?;
-    let maven_suffix = probe_target_parsed.to_maven_suffix();
+    // the same set of dependencies in each per-target variant. The enum
+    // discriminant gives us a probe target without any fallible lookup.
+    let probe_target = konvoy_targets::Target::LinuxX64;
+    let maven_suffix = probe_target.to_maven_suffix();
 
     let mut state = BfsState {
         user_versions: HashMap::new(),
@@ -476,7 +470,7 @@ fn resolve_transitive(
             &group_id,
             &per_target_artifact_id,
             &version,
-            &maven_suffix,
+            maven_suffix,
             &mut state.metadata_cache,
         )?;
 
@@ -488,7 +482,7 @@ fn resolve_transitive(
                 continue;
             }
 
-            let base_artifact_id = strip_target_suffix(&meta_dep.artifact_id, &maven_suffix);
+            let base_artifact_id = strip_target_suffix(&meta_dep.artifact_id, maven_suffix);
             let dep_key = format!("{}:{}", meta_dep.group_id, base_artifact_id);
 
             let resolved_version = state
@@ -565,7 +559,7 @@ fn resolve_transitive(
     finalize_required_by(&mut state.resolved, &state.required_by_map, direct_deps);
 
     let cinterop_deps =
-        discover_cinterop_deps(&state.resolved, &state.metadata_cache, &maven_suffix);
+        discover_cinterop_deps(&state.resolved, &state.metadata_cache, maven_suffix);
 
     let mut result: Vec<ResolvedMavenDep> = Vec::with_capacity(state.resolved.len());
     result.extend(state.resolved.into_values());

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -77,10 +77,10 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     }
 
     // 2. Collect Maven deps (those with `maven` + `version` set).
-    let maven_deps: Vec<_> = manifest
+    let maven_deps: Vec<(&String, &str, &str)> = manifest
         .dependencies
         .iter()
-        .filter(|(_, spec)| spec.is_maven())
+        .filter_map(|(name, spec)| spec.as_maven_coord().map(|(m, v)| (name, m, v)))
         .collect();
 
     if maven_deps.is_empty() {
@@ -90,30 +90,14 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
 
     // 3. Build the set of direct deps with their maven coordinates.
     let mut direct_deps: Vec<ResolvedMavenDep> = Vec::new();
-    for (dep_name, dep_spec) in &maven_deps {
-        let maven = dep_spec
-            .maven
-            .as_ref()
-            .ok_or_else(|| EngineError::MissingDependencyField {
-                name: (*dep_name).clone(),
-                field: "maven",
-            })?;
-        let version =
-            dep_spec
-                .version
-                .as_ref()
-                .ok_or_else(|| EngineError::MissingDependencyField {
-                    name: (*dep_name).clone(),
-                    field: "version",
-                })?;
-
+    for (dep_name, maven, version) in &maven_deps {
         let (group_id, artifact_id) = crate::common::split_maven_coordinate(maven)?;
 
         direct_deps.push(ResolvedMavenDep {
             name: (*dep_name).clone(),
             group_id: group_id.to_owned(),
             artifact_id: artifact_id.to_owned(),
-            version: version.clone(),
+            version: (*version).to_owned(),
             required_by: Vec::new(),
             classifier: None,
         });

--- a/crates/konvoy-targets/Cargo.toml
+++ b/crates/konvoy-targets/Cargo.toml
@@ -8,7 +8,9 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+toml.workspace = true

--- a/crates/konvoy-targets/src/lib.rs
+++ b/crates/konvoy-targets/src/lib.rs
@@ -7,47 +7,58 @@
 use std::fmt;
 use std::str::FromStr;
 
-/// All known Kotlin/Native targets supported by Konvoy.
-const KNOWN_TARGETS: &[&str] = &["linux_x64", "linux_arm64", "macos_x64", "macos_arm64"];
-
-/// Returns the list of all known Kotlin/Native target names.
-pub fn known_targets() -> &'static [&'static str] {
-    KNOWN_TARGETS
-}
-
 /// A Kotlin/Native compilation target.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Target {
-    triple: String,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Target {
+    LinuxX64,
+    LinuxArm64,
+    MacOsX64,
+    MacOsArm64,
 }
+
+/// All known Kotlin/Native targets supported by Konvoy.
+pub const KNOWN_TARGETS: &[Target] = &[
+    Target::LinuxX64,
+    Target::LinuxArm64,
+    Target::MacOsX64,
+    Target::MacOsArm64,
+];
 
 impl Target {
-    /// Returns the string passed to `konanc -target`.
-    pub fn to_konanc_arg(&self) -> &str {
-        &self.triple
-    }
-
-    /// Returns `true` if this target matches the current host platform.
-    ///
-    /// # Errors
-    /// Returns an error if the current host platform is unsupported.
-    pub fn is_host(&self) -> Result<bool, TargetError> {
-        let host = host_target()?;
-        Ok(self == &host)
+    /// Returns the string passed to `konanc -target` (e.g. `"linux_x64"`).
+    pub fn to_konanc_arg(self) -> &'static str {
+        match self {
+            Target::LinuxX64 => "linux_x64",
+            Target::LinuxArm64 => "linux_arm64",
+            Target::MacOsX64 => "macos_x64",
+            Target::MacOsArm64 => "macos_arm64",
+        }
     }
 
     /// Returns the Maven artifact name suffix (underscores stripped).
     ///
     /// Kotlin/Native klibs published to Maven repositories use target names
     /// without underscores: `linux_x64` → `linuxx64`, `macos_arm64` → `macosarm64`.
-    pub fn to_maven_suffix(&self) -> String {
-        self.triple.replace('_', "")
+    pub fn to_maven_suffix(self) -> &'static str {
+        match self {
+            Target::LinuxX64 => "linuxx64",
+            Target::LinuxArm64 => "linuxarm64",
+            Target::MacOsX64 => "macosx64",
+            Target::MacOsArm64 => "macosarm64",
+        }
+    }
+
+    /// Returns `true` if this target matches the current host platform.
+    ///
+    /// Returns `false` on unsupported hosts (where `host_target()` would error).
+    pub fn is_host(self) -> bool {
+        matches!(host_target(), Ok(host) if host == self)
     }
 }
 
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.triple)
+        f.write_str(self.to_konanc_arg())
     }
 }
 
@@ -59,38 +70,54 @@ impl FromStr for Target {
     /// # Errors
     /// Returns `TargetError::InvalidTarget` if the string is not a known Kotlin/Native target.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if KNOWN_TARGETS.contains(&s) {
-            Ok(Target {
-                triple: s.to_owned(),
-            })
-        } else {
-            Err(TargetError::InvalidTarget { name: s.to_owned() })
+        match s {
+            "linux_x64" => Ok(Target::LinuxX64),
+            "linux_arm64" => Ok(Target::LinuxArm64),
+            "macos_x64" => Ok(Target::MacOsX64),
+            "macos_arm64" => Ok(Target::MacOsArm64),
+            _ => Err(TargetError::InvalidTarget { name: s.to_owned() }),
         }
+    }
+}
+
+impl serde::Serialize for Target {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.to_konanc_arg())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Target {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 
 /// Detect the host target triple for Kotlin/Native.
 ///
-/// Maps the Rust compile-time target to the Kotlin/Native target name.
-///
 /// # Errors
-/// Returns an error if the current OS/arch is not supported by Kotlin/Native.
+/// Returns `TargetError::UnsupportedHost` if the current OS/arch is not one of
+/// the four Kotlin/Native host targets Konvoy supports.
 pub fn host_target() -> Result<Target, TargetError> {
-    let triple = match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => "linux_x64",
-        ("linux", "aarch64") => "linux_arm64",
-        ("macos", "x86_64") => "macos_x64",
-        ("macos", "aarch64") => "macos_arm64",
-        (os, arch) => {
-            return Err(TargetError::UnsupportedHost {
-                os: os.to_owned(),
-                arch: arch.to_owned(),
-            })
-        }
-    };
-    Ok(Target {
-        triple: triple.to_owned(),
-    })
+    target_for_host(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// Internal helper: map a `(os, arch)` pair to a `Target`.
+///
+/// Split out from `host_target` so unit tests can exercise every match arm
+/// without spawning subprocesses or cross-compiling. Production callers should
+/// use `host_target()` which fills in the compile-time `OS` and `ARCH`.
+fn target_for_host(os: &str, arch: &str) -> Result<Target, TargetError> {
+    match (os, arch) {
+        ("linux", "x86_64") => Ok(Target::LinuxX64),
+        ("linux", "aarch64") => Ok(Target::LinuxArm64),
+        ("macos", "x86_64") => Ok(Target::MacOsX64),
+        ("macos", "aarch64") => Ok(Target::MacOsArm64),
+        (os, arch) => Err(TargetError::UnsupportedHost {
+            os: os.to_owned(),
+            arch: arch.to_owned(),
+        }),
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -99,195 +126,249 @@ pub enum TargetError {
     UnsupportedHost { os: String, arch: String },
 
     #[error(
-        "unknown target `{name}`, supported targets: host, {}",
-        KNOWN_TARGETS.join(", ")
+        "unknown target `{name}`, supported targets: host, linux_x64, linux_arm64, macos_x64, macos_arm64"
     )]
     InvalidTarget { name: String },
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
+    /// Resolve the host target for tests. Konvoy only supports the four
+    /// Kotlin/Native host triples, so any CI/dev machine running this suite
+    /// must already be one of them — `host_target()` succeeding is part of
+    /// the project contract, not best-effort.
+    fn require_host() -> Target {
+        host_target().expect("konvoy only supports linux_x64/arm64 and macos_x64/arm64 hosts")
+    }
+
     #[test]
-    fn host_target_returns_valid_known_target() {
-        let target = host_target();
-        // On any supported CI/dev machine this should succeed
-        let target = match target {
-            Ok(t) => t,
-            Err(_) => return, // skip on unsupported platforms
-        };
-        assert!(
-            KNOWN_TARGETS.contains(&target.to_konanc_arg()),
-            "host_target() returned `{}` which is not in KNOWN_TARGETS",
-            target
+    fn target_for_host_maps_every_supported_pair() {
+        assert_eq!(
+            target_for_host("linux", "x86_64").ok(),
+            Some(Target::LinuxX64)
+        );
+        assert_eq!(
+            target_for_host("linux", "aarch64").ok(),
+            Some(Target::LinuxArm64)
+        );
+        assert_eq!(
+            target_for_host("macos", "x86_64").ok(),
+            Some(Target::MacOsX64)
+        );
+        assert_eq!(
+            target_for_host("macos", "aarch64").ok(),
+            Some(Target::MacOsArm64)
         );
     }
 
     #[test]
-    fn host_target_display_matches_triple() {
-        let target = match host_target() {
-            Ok(t) => t,
-            Err(_) => return,
-        };
+    fn target_for_host_rejects_unknown_os() {
+        let err = target_for_host("windows", "x86_64").expect_err("windows is not supported");
+        let msg = err.to_string();
+        assert!(msg.contains("windows"));
+        assert!(msg.contains("x86_64"));
+    }
+
+    #[test]
+    fn target_for_host_rejects_unknown_arch_on_supported_os() {
+        let err = target_for_host("linux", "riscv64").expect_err("riscv64 is not supported");
+        let msg = err.to_string();
+        assert!(msg.contains("linux"));
+        assert!(msg.contains("riscv64"));
+    }
+
+    #[test]
+    fn target_for_host_rejects_empty_strings() {
+        assert!(target_for_host("", "").is_err());
+        assert!(target_for_host("linux", "").is_err());
+        assert!(target_for_host("", "x86_64").is_err());
+    }
+
+    #[test]
+    fn host_target_returns_valid_known_target() {
+        let target = require_host();
+        assert!(KNOWN_TARGETS.contains(&target));
+    }
+
+    #[test]
+    fn host_target_display_matches_konanc_arg() {
+        let target = require_host();
         assert_eq!(target.to_string(), target.to_konanc_arg());
     }
 
     #[test]
+    fn unsupported_host_error_displays_components() {
+        // We can't actually swap out compile-time OS/ARCH, but exercising the
+        // error constructor and Display keeps the variant from rotting.
+        let err = TargetError::UnsupportedHost {
+            os: "plan9".to_owned(),
+            arch: "riscv64".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("plan9"));
+        assert!(msg.contains("riscv64"));
+        assert!(msg.contains("Kotlin/Native"));
+    }
+
+    #[test]
     fn from_str_accepts_all_known_targets() {
-        for &name in KNOWN_TARGETS {
-            let target = Target::from_str(name);
-            assert!(target.is_ok(), "from_str rejected known target `{name}`");
-            let target = match target {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-            assert_eq!(target.to_konanc_arg(), name);
+        for &t in KNOWN_TARGETS {
+            let parsed = Target::from_str(t.to_konanc_arg());
+            assert_eq!(parsed.ok(), Some(t));
         }
     }
 
     #[test]
     fn from_str_rejects_invalid_target() {
-        let result = Target::from_str("windows_x64");
-        assert!(result.is_err());
+        assert!(Target::from_str("windows_x64").is_err());
     }
 
     #[test]
     fn from_str_rejects_empty_string() {
-        let result = Target::from_str("");
-        assert!(result.is_err());
+        assert!(Target::from_str("").is_err());
     }
 
     #[test]
     fn invalid_target_error_lists_supported_targets() {
-        let err = Target::from_str("bsd_x64");
-        let msg = match err {
-            Err(e) => e.to_string(),
-            Ok(_) => panic!("expected error"), // only in test code
-        };
-        for &name in KNOWN_TARGETS {
+        let err = Target::from_str("bsd_x64").expect_err("bsd_x64 should not parse");
+        let msg = err.to_string();
+        for t in KNOWN_TARGETS {
             assert!(
-                msg.contains(name),
-                "error message should list `{name}`, got: {msg}"
+                msg.contains(t.to_konanc_arg()),
+                "error message should list `{t}`, got: {msg}"
             );
         }
     }
 
     #[test]
     fn invalid_target_error_mentions_host_alias() {
-        let err = Target::from_str("bsd_x64");
-        let msg = match err {
-            Err(e) => e.to_string(),
-            Ok(_) => panic!("expected error"), // only in test code
-        };
+        let err = Target::from_str("bsd_x64").expect_err("bsd_x64 should not parse");
+        assert!(err.to_string().contains("host"));
+    }
+
+    #[test]
+    fn invalid_target_error_includes_user_supplied_name() {
+        let err = Target::from_str("aix_power").expect_err("aix_power should not parse");
         assert!(
-            msg.contains("host"),
-            "error message should mention `host` alias, got: {msg}"
+            err.to_string().contains("aix_power"),
+            "error should echo the user-supplied name, got: {err}"
         );
     }
 
     #[test]
-    fn display_format_matches_triple() {
-        let target = match Target::from_str("linux_x64") {
-            Ok(t) => t,
-            Err(_) => return,
+    fn invalid_target_error_debug_format_succeeds() {
+        // Exercise the auto-derived Debug impl on `TargetError` so refactors
+        // that swap variants don't accidentally drop the bound.
+        let err = TargetError::InvalidTarget {
+            name: "weird".to_owned(),
         };
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("InvalidTarget"));
+        assert!(dbg.contains("weird"));
+    }
+
+    #[test]
+    fn unsupported_host_error_debug_format_succeeds() {
+        let err = TargetError::UnsupportedHost {
+            os: "plan9".to_owned(),
+            arch: "riscv64".to_owned(),
+        };
+        let dbg = format!("{err:?}");
+        assert!(dbg.contains("UnsupportedHost"));
+        assert!(dbg.contains("plan9"));
+        assert!(dbg.contains("riscv64"));
+    }
+
+    #[test]
+    fn unsupported_host_error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<TargetError>();
+    }
+
+    #[test]
+    fn display_format_matches_konanc_arg() {
+        let target = Target::LinuxX64;
         assert_eq!(format!("{target}"), "linux_x64");
     }
 
     #[test]
     fn to_konanc_arg_returns_triple() {
-        let target = match Target::from_str("macos_arm64") {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        assert_eq!(target.to_konanc_arg(), "macos_arm64");
+        assert_eq!(Target::MacOsArm64.to_konanc_arg(), "macos_arm64");
     }
 
     #[test]
     fn is_host_matches_host_target() {
-        let host = match host_target() {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        let result = match host.is_host() {
-            Ok(v) => v,
-            Err(_) => return,
-        };
-        assert!(result, "is_host() should return true for host_target()");
+        let host = require_host();
+        assert!(host.is_host());
     }
 
     #[test]
     fn is_host_returns_false_for_non_host() {
-        // Pick a target that definitely isn't the host on at least one platform
-        let non_host_name = if cfg!(target_os = "linux") {
-            "macos_arm64"
-        } else {
-            "linux_x64"
-        };
-        let target = match Target::from_str(non_host_name) {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        let result = match target.is_host() {
-            Ok(v) => v,
-            Err(_) => return,
-        };
-        assert!(
-            !result,
-            "is_host() should return false for `{non_host_name}` on this platform"
-        );
+        let host = require_host();
+        // Pick any target that isn't the host so we exercise the `false` arm
+        // without baking in a host-specific branch (which would leave one of
+        // the alternative arms permanently uncovered on a fixed CI host).
+        let non_host = KNOWN_TARGETS
+            .iter()
+            .copied()
+            .find(|t| *t != host)
+            .expect("KNOWN_TARGETS has more than one entry");
+        assert!(!non_host.is_host());
     }
 
     #[test]
     fn target_equality() {
-        let a = match Target::from_str("linux_x64") {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        let b = match Target::from_str("linux_x64") {
-            Ok(t) => t,
-            Err(_) => return,
-        };
+        let a: Target = "linux_x64".parse().expect("valid");
+        let b: Target = "linux_x64".parse().expect("valid");
         assert_eq!(a, b);
     }
 
     #[test]
     fn target_inequality() {
-        let a = match Target::from_str("linux_x64") {
-            Ok(t) => t,
-            Err(_) => return,
-        };
-        let b = match Target::from_str("macos_arm64") {
-            Ok(t) => t,
-            Err(_) => return,
-        };
+        let a: Target = "linux_x64".parse().expect("valid");
+        let b: Target = "macos_arm64".parse().expect("valid");
         assert_ne!(a, b);
     }
 
     #[test]
     fn to_maven_suffix_linux_x64() {
-        let target = Target::from_str("linux_x64").unwrap();
-        assert_eq!(target.to_maven_suffix(), "linuxx64");
+        assert_eq!(Target::LinuxX64.to_maven_suffix(), "linuxx64");
     }
 
     #[test]
     fn to_maven_suffix_macos_arm64() {
-        let target = Target::from_str("macos_arm64").unwrap();
-        assert_eq!(target.to_maven_suffix(), "macosarm64");
+        assert_eq!(Target::MacOsArm64.to_maven_suffix(), "macosarm64");
     }
 
     #[test]
     fn to_maven_suffix_no_underscores() {
-        for &name in KNOWN_TARGETS {
-            let target = Target::from_str(name).unwrap();
-            let suffix = target.to_maven_suffix();
+        for &t in KNOWN_TARGETS {
+            let suffix = t.to_maven_suffix();
             assert!(
                 !suffix.contains('_'),
-                "to_maven_suffix() for `{name}` should not contain underscores, got `{suffix}`"
+                "to_maven_suffix() for `{t}` should not contain underscores, got `{suffix}`"
             );
         }
+    }
+
+    #[test]
+    fn serde_serializes_as_konanc_arg() {
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+        struct Wrap {
+            target: Target,
+        }
+        let s = toml::to_string(&Wrap {
+            target: Target::LinuxX64,
+        })
+        .expect("serialize");
+        assert!(
+            s.contains("target = \"linux_x64\""),
+            "expected wire `linux_x64`, got: {s}"
+        );
+        let back: Wrap = toml::from_str("target = \"macos_arm64\"").expect("deserialize");
+        assert_eq!(back.target, Target::MacOsArm64);
     }
 
     mod proptests {
@@ -296,79 +377,32 @@ mod tests {
 
         proptest! {
             #[test]
-            #[allow(clippy::unwrap_used)]
             fn arbitrary_target_never_panics(s in "\\PC*") {
                 let result = Target::from_str(&s);
                 prop_assert!(result.is_ok() || result.is_err());
             }
 
             #[test]
-            #[allow(clippy::unwrap_used)]
             fn known_targets_always_parse(idx in 0usize..4) {
-                let known = ["linux_x64", "linux_arm64", "macos_x64", "macos_arm64"];
-                let name = known[idx];
-                let target = Target::from_str(name);
-                prop_assert!(target.is_ok(), "from_str rejected known target `{}`", name);
-                let target = target.unwrap();
-                prop_assert_eq!(target.to_string(), name);
+                let t = KNOWN_TARGETS[idx];
+                let parsed = Target::from_str(t.to_konanc_arg());
+                prop_assert_eq!(parsed.ok(), Some(t));
             }
 
             #[test]
-            #[allow(clippy::unwrap_used)]
             fn maven_suffix_never_contains_underscore(idx in 0usize..4) {
-                let known = ["linux_x64", "linux_arm64", "macos_x64", "macos_arm64"];
-                let name = known[idx];
-                let target = Target::from_str(name).unwrap();
-                let suffix = target.to_maven_suffix();
-                prop_assert!(!suffix.contains('_'), "maven suffix `{}` contains underscore", suffix);
+                let t = KNOWN_TARGETS[idx];
+                prop_assert!(!t.to_maven_suffix().contains('_'));
             }
 
             #[test]
-            #[allow(clippy::unwrap_used)]
             fn unknown_targets_always_error(s in "\\PC*") {
-                let known = ["linux_x64", "linux_arm64", "macos_x64", "macos_arm64"];
+                let known: Vec<&'static str> =
+                    KNOWN_TARGETS.iter().map(|t| t.to_konanc_arg()).collect();
                 prop_assume!(!known.contains(&s.as_str()));
                 let result = Target::from_str(&s);
-                prop_assert!(result.is_err(), "from_str accepted unknown target `{}`", s);
+                prop_assert!(result.is_err());
             }
-        }
-    }
-
-    #[test]
-    fn is_host_returns_true_for_host_target() {
-        // host_target() succeeds on all supported CI platforms.
-        if let Ok(host) = host_target() {
-            assert!(
-                host.is_host().unwrap_or(false),
-                "host target should match itself"
-            );
-        }
-    }
-
-    #[test]
-    fn is_host_returns_false_for_other_target() {
-        // Pick a target that's not the current host.
-        let host = match host_target() {
-            Ok(h) => h,
-            Err(_) => return, // skip on unsupported platforms
-        };
-        let other_name = if host.to_konanc_arg() == "linux_x64" {
-            "macos_arm64"
-        } else {
-            "linux_x64"
-        };
-        let other: Target = other_name.parse().unwrap();
-        assert!(
-            !other.is_host().unwrap_or(true),
-            "non-host target should not match host"
-        );
-    }
-
-    #[test]
-    fn display_matches_konanc_arg() {
-        for &name in KNOWN_TARGETS {
-            let target: Target = name.parse().unwrap();
-            assert_eq!(target.to_string(), target.to_konanc_arg());
         }
     }
 }


### PR DESCRIPTION
Closes #268.

## Summary

Refactor that closes #268 across three orthogonal concerns. No behavior changes beyond the intended typed-error and enum improvements; on-disk format for `metadata.toml` and `konvoy.lock` is preserved (verified by round-trip tests).

### EngineError
- Split `Metadata { message: String }` catch-all into typed variants: `InvalidMavenCoordinate { coordinate, reason }`, `MissingDependencyField { name, field: &'static str }`, `TomlSerialize { what: &'static str, source }`.
- Dropped the dead "no known targets available" branch — `KNOWN_TARGETS` is hard-coded non-empty.

### Profile enum
- New `konvoy-config/src/profile.rs`: `enum Profile { Debug, Release }` with `Display`/`FromStr`/`as_str` and derived serde via `#[serde(rename_all = "lowercase")]` so the on-disk form stays `"debug"`/`"release"`.
- Replaces `release: bool` in `BuildOptions` and `profile: String` in `ResolvedBuildContext`, `CacheInputs`, `BuildMetadata`.
- CLI maps `--release` to `Profile` at the boundary (`profile_from_flag`) and uses `Display` directly; the old `profile_label` helper is gone.

### Target enum
- Rewritten from `struct { triple: String }` to `Copy` enum (`LinuxX64`/`LinuxArm64`/`MacOsX64`/`MacOsArm64`) with `to_konanc_arg` and `to_maven_suffix` returning `&'static str` (no per-call alloc).
- Custom serde preserves the existing `"linux_x64"`/etc. wire format.
- `host_target()` returns `Result<Target, TargetError>` with `TargetError::UnsupportedHost { os, arch }` — restoring fail-fast in `doctor` and `build`.
- Kept `pub const KNOWN_TARGETS`; removed the redundant `Target::all()` fn.

### ResolvedBuildContext
- Dropped `lockfile_path` (now computed inline at the one use site).
- Moved `konanc_tarball_sha256`/`jre_tarball_sha256` into a new `LockfileWriteInputs` substruct used only by lockfile writes.

### Test-build cache key
- The `format!("{}-test", profile)` hack is gone (can't shove `"debug-test"` into a `Profile` enum). Test vs. non-test builds are now separated by appending `# konvoy-test-build` to the `lockfile_content` hash input. **Existing test-build caches will miss once** on first run after this lands; main caches are unaffected.

## Process

Multi-agent: coder → reviewer → coder fix-ups → reviewer converged → tester for coverage. Two review rounds — first round flagged a real fail-fast regression in `host_target()` and CLI `Profile` plumbing, both fixed before this PR. See thread.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 805 passing (was 787; +18 new tests)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo llvm-cov` — patch coverage 82%; remaining ~80 lines are integration paths (konanc compile, Maven download loop, `fn main()`, `toml::ser::Error` closures over infallible types)
- [ ] Smoke tests (triggering after open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)