### PR TITLE
Perf followups + truck-themed progress bars + UI layering (#267)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +179,19 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -244,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +328,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -412,6 +461,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +484,18 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "konvoy-cli"
@@ -451,6 +525,7 @@ dependencies = [
 name = "konvoy-engine"
 version = "1.2.0"
 dependencies = [
+ "indicatif",
  "konvoy-config",
  "konvoy-konanc",
  "konvoy-targets",
@@ -468,6 +543,7 @@ name = "konvoy-konanc"
 version = "1.2.0"
 dependencies = [
  "flate2",
+ "indicatif",
  "konvoy-util",
  "tar",
  "tempfile",
@@ -489,6 +565,7 @@ name = "konvoy-util"
 version = "1.2.0"
 dependencies = [
  "glob",
+ "indicatif",
  "rayon",
  "roxmltree",
  "serde",
@@ -560,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +659,18 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -787,6 +882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +979,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -1006,6 +1113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1211,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1319,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ license = "Apache-2.0"
 clap = { version = "4", features = ["derive"] }
 flate2 = "1"
 glob = "0.3"
+indicatif = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -404,7 +404,7 @@ fn cmd_update() -> CliResult {
     let root = project_root()?;
     let result = konvoy_engine::update(&root)?;
     eprintln!(
-        "    Updated {} dependencies in konvoy.lock",
+        "  Updated {} dependencies in konvoy.lock",
         result.updated_count
     );
     Ok(())

--- a/crates/konvoy-engine/Cargo.toml
+++ b/crates/konvoy-engine/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+indicatif.workspace = true
 konvoy-config.workspace = true
 konvoy-konanc.workspace = true
 konvoy-targets.workspace = true

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -847,15 +847,13 @@ fn download_one_klib(
     maybe_bar: Option<&konvoy_util::progress::DownloadBar>,
 ) -> Result<LibraryInput, EngineError> {
     let dep_name = p.entry.name.to_owned();
-    let result = konvoy_util::progress::run_with_optional_bar(maybe_bar, |pb| {
-        konvoy_util::artifact::ensure_artifact(
-            &p.url,
-            &p.dest,
-            Some(p.expected_sha256),
-            &dep_name,
-            pb,
-        )
-    })
+    let result = konvoy_util::progress::fetch(
+        &p.url,
+        &p.dest,
+        Some(p.expected_sha256),
+        &dep_name,
+        maybe_bar,
+    )
     .map_err(|e| EngineError::LibraryDownloadFailed {
         name: dep_name.clone(),
         url: p.url.clone(),

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -771,12 +771,13 @@ pub(crate) fn resolve_maven_deps(
             let url = coord.to_url(konvoy_util::maven::MAVEN_CENTRAL);
 
             // Download (or use cached) and verify hash.
+            let progress = konvoy_util::progress::new_download_bar(format!("{dep_name} {version}"));
             let result = konvoy_util::artifact::ensure_artifact(
                 &url,
                 &dest,
                 Some(expected_sha256),
                 &dep_name,
-                version,
+                &progress,
             )
             .map_err(|e| EngineError::LibraryDownloadFailed {
                 name: dep_name.clone(),

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -715,15 +715,24 @@ struct MavenLockView<'a> {
     classifier: Option<&'a str>,
 }
 
+/// Everything needed to download a single Maven klib for one target.
+/// Computed sequentially upfront so we can decide which entries actually
+/// need a network fetch before creating any progress bars.
+struct PreparedKlib<'a> {
+    entry: &'a MavenLockView<'a>,
+    dest: PathBuf,
+    url: String,
+    expected_sha256: &'a str,
+    needs_download: bool,
+}
+
 pub(crate) fn resolve_maven_deps(
     lockfile: &Lockfile,
     target: &Target,
 ) -> Result<Vec<LibraryInput>, EngineError> {
     use rayon::prelude::IndexedParallelIterator;
 
-    // Filter to Maven entries AND extract their fields in one pass — the
-    // par_iter loop below then sees a flat view and never has to match on
-    // `DepSource` again.
+    // Filter to Maven entries AND extract their fields in one pass.
     let maven_locks: Vec<MavenLockView> = lockfile
         .dependencies
         .iter()
@@ -753,25 +762,15 @@ pub(crate) fn resolve_maven_deps(
     let target_str = target.to_konanc_arg();
     let maven_suffix = target.to_maven_suffix();
 
-    // Pre-allocate one bar per Maven dep in stable order so the parallel
-    // downloads render as a clean vertical stack.
-    let labels: Vec<String> = maven_locks
-        .iter()
-        .map(|m| format!("{} {}", m.name, m.version))
-        .collect();
-    let (_multi, bars) = konvoy_util::progress::pre_allocate_bars(labels);
-
-    let klib_inputs: Vec<Result<LibraryInput, EngineError>> =
+    // Compute coord/dest/url/expected-hash and check existence for every
+    // entry. Sequential because the input is small and these are cheap;
+    // doing it upfront lets us skip bar creation for cached items.
+    let prepared: Vec<PreparedKlib> =
         maven_locks
-            .par_iter()
-            .zip(bars.par_iter())
-            .map(|(entry, progress)| {
-                let dep_name = entry.name.to_owned();
+            .iter()
+            .map(|entry| {
                 let (group_id, artifact_id) = crate::common::split_maven_coordinate(entry.maven)?;
-
-                // Build the per-target artifact ID (e.g. "kotlinx-coroutines-core-linuxx64").
                 let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
-
                 let mut coord = konvoy_util::maven::MavenCoordinate::new(
                     group_id,
                     &per_target_artifact_id,
@@ -781,54 +780,106 @@ pub(crate) fn resolve_maven_deps(
                 if let Some(cls) = entry.classifier {
                     coord = coord.with_classifier(cls);
                 }
-
-                // Extract the expected SHA-256 for this target from the lockfile.
                 let expected_sha256 = entry.targets.get(target_str).ok_or_else(|| {
                     EngineError::MissingTargetHash {
-                        name: dep_name.clone(),
+                        name: entry.name.to_owned(),
                         target: target_str.to_owned(),
                     }
                 })?;
-
-                // Compute the cache path and download URL.
                 let dest = coord.cache_path(&cache_root);
                 let url = coord.to_url(konvoy_util::maven::MAVEN_CENTRAL);
-
-                // Download (or use cached) and verify hash.
-                let result = progress
-                    .finish(konvoy_util::artifact::ensure_artifact(
-                        &url,
-                        &dest,
-                        Some(expected_sha256),
-                        &dep_name,
-                        progress.inner(),
-                    ))
-                    .map_err(|e| EngineError::LibraryDownloadFailed {
-                        name: dep_name.clone(),
-                        url: url.clone(),
-                        message: e.to_string(),
-                    })?;
-
-                // Double-check the hash matches the lockfile expectation.
-                if result.sha256 != *expected_sha256 {
-                    return Err(EngineError::LibraryHashMismatch {
-                        name: dep_name,
-                        expected: expected_sha256.clone(),
-                        actual: result.sha256,
-                    });
-                }
-
-                // Carry the freshly-verified hash through so `build_single` can
-                // reuse it for the cache key without re-reading the file.
-                Ok(LibraryInput::with_hash(result.path, result.sha256))
+                let needs_download = !dest.exists();
+                Ok(PreparedKlib {
+                    entry,
+                    dest,
+                    url,
+                    expected_sha256,
+                    needs_download,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, EngineError>>()?;
 
-    // Trailing newline so the next eprintln status line isn't concatenated
-    // onto the last bar's row.
-    eprintln!();
+    // Only allocate bars for entries that actually need a network fetch;
+    // cached entries are silent. The `aligned_bars` Vec parallels `prepared`
+    // so the par_iter zip pairs each entry with its bar (or None).
+    let download_labels: Vec<String> = prepared
+        .iter()
+        .filter(|p| p.needs_download)
+        .map(|p| format!("{} {}", p.entry.name, p.entry.version))
+        .collect();
+    let any_downloads = !download_labels.is_empty();
+    let bars: Vec<konvoy_util::progress::DownloadBar> = if any_downloads {
+        konvoy_util::progress::pre_allocate_bars(download_labels).1
+    } else {
+        Vec::new()
+    };
+    let mut bar_iter = bars.iter();
+    let aligned_bars: Vec<Option<&konvoy_util::progress::DownloadBar>> = prepared
+        .iter()
+        .map(|p| {
+            if p.needs_download {
+                bar_iter.next()
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let klib_inputs: Vec<Result<LibraryInput, EngineError>> = prepared
+        .par_iter()
+        .zip(aligned_bars.par_iter())
+        .map(|(p, maybe_bar)| download_one_klib(p, *maybe_bar))
+        .collect();
+
+    // Trailing newline only if we actually rendered any bars.
+    if any_downloads {
+        eprintln!();
+    }
 
     klib_inputs.into_iter().collect()
+}
+
+/// Run `ensure_artifact` for a single prepared klib. Uses the supplied
+/// progress bar when present (download path); silently uses a hidden bar
+/// when absent (cache-hit path that needs only a hash re-verify).
+fn download_one_klib(
+    p: &PreparedKlib<'_>,
+    maybe_bar: Option<&konvoy_util::progress::DownloadBar>,
+) -> Result<LibraryInput, EngineError> {
+    let dep_name = p.entry.name.to_owned();
+    let raw = if let Some(bar) = maybe_bar {
+        bar.finish(konvoy_util::artifact::ensure_artifact(
+            &p.url,
+            &p.dest,
+            Some(p.expected_sha256),
+            &dep_name,
+            bar.inner(),
+        ))
+    } else {
+        let hidden = konvoy_util::progress::hidden_bar();
+        konvoy_util::artifact::ensure_artifact(
+            &p.url,
+            &p.dest,
+            Some(p.expected_sha256),
+            &dep_name,
+            &hidden,
+        )
+    };
+    let result = raw.map_err(|e| EngineError::LibraryDownloadFailed {
+        name: dep_name.clone(),
+        url: p.url.clone(),
+        message: e.to_string(),
+    })?;
+    if result.sha256 != *p.expected_sha256 {
+        return Err(EngineError::LibraryHashMismatch {
+            name: dep_name,
+            expected: p.expected_sha256.to_owned(),
+            actual: result.sha256,
+        });
+    }
+    // Carry the freshly-verified hash through so `build_single` can reuse
+    // it for the cache key without re-reading the file.
+    Ok(LibraryInput::with_hash(result.path, result.sha256))
 }
 
 /// Returns `true` if the manifest declares Maven deps that have no matching

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -67,7 +67,7 @@ pub struct BuildResult {
 /// hash instead of re-hashing the file. The pre-computed value MUST match
 /// what `konvoy_util::hash::sha256_file` would return for the same file —
 /// i.e. it must be a SHA-256 over the file contents. Maven dependency klibs
-/// satisfy this because `ensure_artifact` hashes the file bytes.
+/// satisfy this because `download_artifact` hashes the file bytes.
 ///
 /// Path-deps and plugin jars use `None` because their hash is computed at
 /// a different layer (path-dep source hash) or not at all (plugins are pinned
@@ -93,7 +93,7 @@ impl LibraryInput {
 
     /// Construct a library input with a pre-computed SHA-256 hash.
     ///
-    /// Used by Maven klib downloads where `ensure_artifact` already hashed
+    /// Used by Maven klib downloads where `download_artifact` already hashed
     /// the file bytes, so the cache-key code can reuse that value instead
     /// of re-reading the file.
     pub(crate) fn with_hash(path: PathBuf, sha256: String) -> Self {
@@ -307,7 +307,7 @@ pub(crate) fn resolve_build_context(
 
     // 7b. Resolve and download Maven dependency klibs for the current target.
     //     Each Maven klib comes back with a precomputed sha256 from
-    //     `ensure_artifact`, which the cache-key code reuses to skip rehashing.
+    //     `download_artifact`, which the cache-key code reuses to skip rehashing.
     let maven_klibs = resolve_maven_deps(&effective_lockfile, &target)?;
     library_inputs.extend(maven_klibs);
 
@@ -458,7 +458,7 @@ pub(crate) fn build_single(
             .library_inputs
             .iter()
             .map(|lib| match &lib.precomputed_sha256 {
-                // Reuse the hash that `ensure_artifact` already computed for
+                // Reuse the hash that `download_artifact` already computed for
                 // this file's bytes — it's value-equivalent to sha256_file.
                 Some(h) => Ok(h.clone()),
                 None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
@@ -696,7 +696,7 @@ pub(crate) fn lockfile_toml_content(lockfile: &Lockfile) -> Result<String, Engin
 /// SHA-256 hash, and returns the list of klib inputs to pass to the build.
 ///
 /// Each returned [`LibraryInput`] carries the file path plus the SHA-256 of
-/// its contents (produced by `ensure_artifact`), so the cache-key code does
+/// its contents (produced by `download_artifact`), so the cache-key code does
 /// not rehash the file.
 ///
 /// Only the klib for the current build target is downloaded (lazy download).
@@ -839,7 +839,7 @@ pub(crate) fn resolve_maven_deps(
     klib_inputs.into_iter().collect()
 }
 
-/// Run `ensure_artifact` for a single prepared klib. Uses the supplied
+/// Run `download_artifact` for a single prepared klib. Uses the supplied
 /// progress bar when present (download path); silently uses a hidden bar
 /// when absent (cache-hit path that needs only a hash re-verify).
 fn download_one_klib(
@@ -855,19 +855,14 @@ fn download_one_klib(
         maybe_bar,
     )
     .map_err(|e| EngineError::LibraryDownloadFailed {
-        name: dep_name.clone(),
+        name: dep_name,
         url: p.url.clone(),
         message: e.to_string(),
     })?;
-    if result.sha256 != *p.expected_sha256 {
-        return Err(EngineError::LibraryHashMismatch {
-            name: dep_name,
-            expected: p.expected_sha256.to_owned(),
-            actual: result.sha256,
-        });
-    }
-    // Carry the freshly-verified hash through so `build_single` can reuse
-    // it for the cache key without re-reading the file.
+    // `progress::fetch` already enforces `expected_sha256` (via
+    // `check_cached` on hit, `download_artifact` on miss), so `result.sha256`
+    // is guaranteed to match. Carry the freshly-verified hash through so
+    // `build_single` can reuse it for the cache key without re-reading.
     Ok(LibraryInput::with_hash(result.path, result.sha256))
 }
 
@@ -4755,7 +4750,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
 
     #[test]
     fn library_input_with_hash_carries_both_path_and_hash() {
-        // `with_hash` is used by Maven downloads where `ensure_artifact`
+        // `with_hash` is used by Maven downloads where `download_artifact`
         // already hashed the file — the cache-key code reuses that value.
         let p = PathBuf::from("/tmp/dep.klib");
         let h = "deadbeef".to_owned();

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -839,9 +839,9 @@ pub(crate) fn resolve_maven_deps(
     klib_inputs.into_iter().collect()
 }
 
-/// Run `download_artifact` for a single prepared klib. Uses the supplied
-/// progress bar when present (download path); silently uses a hidden bar
-/// when absent (cache-hit path that needs only a hash re-verify).
+/// Resolve a single prepared klib via [`konvoy_util::progress::fetch`]
+/// (cache check + atomic download). The supplied bar renders progress on
+/// the download path; cache-hit entries pass `None` and produce no UI.
 fn download_one_klib(
     p: &PreparedKlib<'_>,
     maybe_bar: Option<&konvoy_util::progress::DownloadBar>,

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -772,14 +772,18 @@ pub(crate) fn resolve_maven_deps(
 
             // Download (or use cached) and verify hash.
             let progress = konvoy_util::progress::new_download_bar(format!("{dep_name} {version}"));
-            let result = konvoy_util::artifact::ensure_artifact(
+            let ensure_result = konvoy_util::artifact::ensure_artifact(
                 &url,
                 &dest,
                 Some(expected_sha256),
                 &dep_name,
-                &progress,
-            )
-            .map_err(|e| EngineError::LibraryDownloadFailed {
+                &progress.bar,
+            );
+            match &ensure_result {
+                Ok(_) => progress.mark_success(),
+                Err(_) => progress.mark_failure(),
+            }
+            let result = ensure_result.map_err(|e| EngineError::LibraryDownloadFailed {
                 name: dep_name.clone(),
                 url: url.clone(),
                 message: e.to_string(),

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -704,18 +704,45 @@ pub(crate) fn lockfile_toml_content(lockfile: &Lockfile) -> Result<String, Engin
 /// # Errors
 /// Returns an error if a Maven dependency is missing from the lockfile, the
 /// target hash is not present, or the download/hash verification fails.
+/// View into the Maven-specific fields of a `DependencyLock`. Built once
+/// upfront so the inner par_iter loop doesn't have to match on the source
+/// variant again.
+struct MavenLockView<'a> {
+    name: &'a str,
+    version: &'a str,
+    maven: &'a str,
+    targets: &'a std::collections::BTreeMap<String, String>,
+    classifier: Option<&'a str>,
+}
+
 pub(crate) fn resolve_maven_deps(
     lockfile: &Lockfile,
     target: &Target,
 ) -> Result<Vec<LibraryInput>, EngineError> {
-    use indicatif::MultiProgress;
     use rayon::prelude::IndexedParallelIterator;
 
-    // Collect all Maven dependency entries from the lockfile (direct + transitive).
-    let maven_locks: Vec<&DependencyLock> = lockfile
+    // Filter to Maven entries AND extract their fields in one pass — the
+    // par_iter loop below then sees a flat view and never has to match on
+    // `DepSource` again.
+    let maven_locks: Vec<MavenLockView> = lockfile
         .dependencies
         .iter()
-        .filter(|d| matches!(&d.source, DepSource::Maven { .. }))
+        .filter_map(|d| match &d.source {
+            DepSource::Maven {
+                version,
+                maven,
+                targets,
+                classifier,
+                ..
+            } => Some(MavenLockView {
+                name: &d.name,
+                version,
+                maven,
+                targets,
+                classifier: classifier.as_deref(),
+            }),
+            DepSource::Path { .. } => None,
+        })
         .collect();
 
     if maven_locks.is_empty() {
@@ -726,102 +753,76 @@ pub(crate) fn resolve_maven_deps(
     let target_str = target.to_konanc_arg();
     let maven_suffix = target.to_maven_suffix();
 
-    // Pre-allocate one bar per Maven dep in stable order with uniform prefix
-    // width so the parallel downloads render as a clean vertical stack.
-    let multi = MultiProgress::new();
+    // Pre-allocate one bar per Maven dep in stable order so the parallel
+    // downloads render as a clean vertical stack.
     let labels: Vec<String> = maven_locks
         .iter()
-        .map(|lock| {
-            let version = match &lock.source {
-                DepSource::Maven { version, .. } => version.as_str(),
-                DepSource::Path { .. } => "",
-            };
-            format!("{} {}", lock.name, version)
-        })
+        .map(|m| format!("{} {}", m.name, m.version))
         .collect();
-    let prefix_width = labels.iter().map(String::len).max().unwrap_or(0);
-    let bars: Vec<konvoy_util::progress::DownloadBar> = labels
-        .into_iter()
-        .map(|label| konvoy_util::progress::add_download_bar(&multi, label, prefix_width))
-        .collect();
+    let (_multi, bars) = konvoy_util::progress::pre_allocate_bars(labels);
 
-    let klib_inputs: Vec<Result<LibraryInput, EngineError>> = maven_locks
-        .par_iter()
-        .zip(bars.par_iter())
-        .map(|(lock_entry, progress)| {
-            let dep_name = lock_entry.name.clone();
+    let klib_inputs: Vec<Result<LibraryInput, EngineError>> =
+        maven_locks
+            .par_iter()
+            .zip(bars.par_iter())
+            .map(|(entry, progress)| {
+                let dep_name = entry.name.to_owned();
+                let (group_id, artifact_id) = crate::common::split_maven_coordinate(entry.maven)?;
 
-            let (version, maven_coord, targets, classifier) = match &lock_entry.source {
-                DepSource::Maven {
-                    version,
-                    maven,
-                    targets,
-                    classifier,
-                    ..
-                } => (version, maven, targets, classifier),
-                DepSource::Path { .. } => {
-                    return Err(EngineError::MissingLockfileEntry { name: dep_name });
+                // Build the per-target artifact ID (e.g. "kotlinx-coroutines-core-linuxx64").
+                let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
+
+                let mut coord = konvoy_util::maven::MavenCoordinate::new(
+                    group_id,
+                    &per_target_artifact_id,
+                    entry.version,
+                )
+                .with_packaging("klib");
+                if let Some(cls) = entry.classifier {
+                    coord = coord.with_classifier(cls);
                 }
-            };
 
-            // Split "groupId:artifactId" into parts.
-            let (group_id, artifact_id) = crate::common::split_maven_coordinate(maven_coord)?;
-
-            // Build the per-target artifact ID (e.g. "kotlinx-coroutines-core-linuxx64").
-            let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
-
-            let mut coord = konvoy_util::maven::MavenCoordinate::new(
-                group_id,
-                &per_target_artifact_id,
-                version,
-            )
-            .with_packaging("klib");
-            if let Some(cls) = classifier {
-                coord = coord.with_classifier(cls);
-            }
-
-            // Extract the expected SHA-256 for this target from the lockfile.
-            let expected_sha256 =
-                targets
-                    .get(target_str)
-                    .ok_or_else(|| EngineError::MissingTargetHash {
+                // Extract the expected SHA-256 for this target from the lockfile.
+                let expected_sha256 = entry.targets.get(target_str).ok_or_else(|| {
+                    EngineError::MissingTargetHash {
                         name: dep_name.clone(),
                         target: target_str.to_owned(),
-                    })?;
-
-            // Compute the cache path and download URL.
-            let dest = coord.cache_path(&cache_root);
-            let url = coord.to_url(konvoy_util::maven::MAVEN_CENTRAL);
-
-            // Download (or use cached) and verify hash.
-            let result = progress
-                .finish(konvoy_util::artifact::ensure_artifact(
-                    &url,
-                    &dest,
-                    Some(expected_sha256),
-                    &dep_name,
-                    progress.inner(),
-                ))
-                .map_err(|e| EngineError::LibraryDownloadFailed {
-                    name: dep_name.clone(),
-                    url: url.clone(),
-                    message: e.to_string(),
+                    }
                 })?;
 
-            // Double-check the hash matches the lockfile expectation.
-            if result.sha256 != *expected_sha256 {
-                return Err(EngineError::LibraryHashMismatch {
-                    name: dep_name,
-                    expected: expected_sha256.clone(),
-                    actual: result.sha256,
-                });
-            }
+                // Compute the cache path and download URL.
+                let dest = coord.cache_path(&cache_root);
+                let url = coord.to_url(konvoy_util::maven::MAVEN_CENTRAL);
 
-            // Carry the freshly-verified hash through so `build_single` can
-            // reuse it for the cache key without re-reading the file.
-            Ok(LibraryInput::with_hash(result.path, result.sha256))
-        })
-        .collect();
+                // Download (or use cached) and verify hash.
+                let result = progress
+                    .finish(konvoy_util::artifact::ensure_artifact(
+                        &url,
+                        &dest,
+                        Some(expected_sha256),
+                        &dep_name,
+                        progress.inner(),
+                    ))
+                    .map_err(|e| EngineError::LibraryDownloadFailed {
+                        name: dep_name.clone(),
+                        url: url.clone(),
+                        message: e.to_string(),
+                    })?;
+
+                // Double-check the hash matches the lockfile expectation.
+                if result.sha256 != *expected_sha256 {
+                    return Err(EngineError::LibraryHashMismatch {
+                        name: dep_name,
+                        expected: expected_sha256.clone(),
+                        actual: result.sha256,
+                    });
+                }
+
+                // Carry the freshly-verified hash through so `build_single` can
+                // reuse it for the cache key without re-reading the file.
+                Ok(LibraryInput::with_hash(result.path, result.sha256))
+            })
+            .collect();
 
     // Trailing newline so the next eprintln status line isn't concatenated
     // onto the last bar's row.

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -708,6 +708,9 @@ pub(crate) fn resolve_maven_deps(
     lockfile: &Lockfile,
     target: &Target,
 ) -> Result<Vec<LibraryInput>, EngineError> {
+    use indicatif::MultiProgress;
+    use rayon::prelude::IndexedParallelIterator;
+
     // Collect all Maven dependency entries from the lockfile (direct + transitive).
     let maven_locks: Vec<&DependencyLock> = lockfile
         .dependencies
@@ -723,9 +726,29 @@ pub(crate) fn resolve_maven_deps(
     let target_str = target.to_konanc_arg();
     let maven_suffix = target.to_maven_suffix();
 
+    // Pre-allocate one bar per Maven dep in stable order with uniform prefix
+    // width so the parallel downloads render as a clean vertical stack.
+    let multi = MultiProgress::new();
+    let labels: Vec<String> = maven_locks
+        .iter()
+        .map(|lock| {
+            let version = match &lock.source {
+                DepSource::Maven { version, .. } => version.as_str(),
+                DepSource::Path { .. } => "",
+            };
+            format!("{} {}", lock.name, version)
+        })
+        .collect();
+    let prefix_width = labels.iter().map(String::len).max().unwrap_or(0);
+    let bars: Vec<konvoy_util::progress::DownloadBar> = labels
+        .into_iter()
+        .map(|label| konvoy_util::progress::add_download_bar(&multi, label, prefix_width))
+        .collect();
+
     let klib_inputs: Vec<Result<LibraryInput, EngineError>> = maven_locks
         .par_iter()
-        .map(|lock_entry| {
+        .zip(bars.par_iter())
+        .map(|(lock_entry, progress)| {
             let dep_name = lock_entry.name.clone();
 
             let (version, maven_coord, targets, classifier) = match &lock_entry.source {
@@ -771,7 +794,6 @@ pub(crate) fn resolve_maven_deps(
             let url = coord.to_url(konvoy_util::maven::MAVEN_CENTRAL);
 
             // Download (or use cached) and verify hash.
-            let progress = konvoy_util::progress::new_download_bar(format!("{dep_name} {version}"));
             let result = progress
                 .finish(konvoy_util::artifact::ensure_artifact(
                     &url,
@@ -800,6 +822,10 @@ pub(crate) fn resolve_maven_deps(
             Ok(LibraryInput::with_hash(result.path, result.sha256))
         })
         .collect();
+
+    // Trailing newline so the next eprintln status line isn't concatenated
+    // onto the last bar's row.
+    eprintln!();
 
     klib_inputs.into_iter().collect()
 }

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -772,22 +772,19 @@ pub(crate) fn resolve_maven_deps(
 
             // Download (or use cached) and verify hash.
             let progress = konvoy_util::progress::new_download_bar(format!("{dep_name} {version}"));
-            let ensure_result = konvoy_util::artifact::ensure_artifact(
-                &url,
-                &dest,
-                Some(expected_sha256),
-                &dep_name,
-                &progress.bar,
-            );
-            match &ensure_result {
-                Ok(_) => progress.mark_success(),
-                Err(_) => progress.mark_failure(),
-            }
-            let result = ensure_result.map_err(|e| EngineError::LibraryDownloadFailed {
-                name: dep_name.clone(),
-                url: url.clone(),
-                message: e.to_string(),
-            })?;
+            let result = progress
+                .finish(konvoy_util::artifact::ensure_artifact(
+                    &url,
+                    &dest,
+                    Some(expected_sha256),
+                    &dep_name,
+                    progress.inner(),
+                ))
+                .map_err(|e| EngineError::LibraryDownloadFailed {
+                    name: dep_name.clone(),
+                    url: url.clone(),
+                    message: e.to_string(),
+                })?;
 
             // Double-check the hash matches the lockfile expectation.
             if result.sha256 != *expected_sha256 {

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -847,25 +847,16 @@ fn download_one_klib(
     maybe_bar: Option<&konvoy_util::progress::DownloadBar>,
 ) -> Result<LibraryInput, EngineError> {
     let dep_name = p.entry.name.to_owned();
-    let raw = if let Some(bar) = maybe_bar {
-        bar.finish(konvoy_util::artifact::ensure_artifact(
-            &p.url,
-            &p.dest,
-            Some(p.expected_sha256),
-            &dep_name,
-            bar.inner(),
-        ))
-    } else {
-        let hidden = konvoy_util::progress::hidden_bar();
+    let result = konvoy_util::progress::run_with_optional_bar(maybe_bar, |pb| {
         konvoy_util::artifact::ensure_artifact(
             &p.url,
             &p.dest,
             Some(p.expected_sha256),
             &dep_name,
-            &hidden,
+            pb,
         )
-    };
-    let result = raw.map_err(|e| EngineError::LibraryDownloadFailed {
+    })
+    .map_err(|e| EngineError::LibraryDownloadFailed {
         name: dep_name.clone(),
         url: p.url.clone(),
         message: e.to_string(),

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -60,6 +60,56 @@ pub struct BuildResult {
     pub duration: std::time::Duration,
 }
 
+/// A klib (or plugin jar) input to a compilation, with an optional
+/// pre-computed SHA-256.
+///
+/// When `precomputed_sha256` is `Some`, the build cache-key code reuses that
+/// hash instead of re-hashing the file. The pre-computed value MUST match
+/// what `konvoy_util::hash::sha256_file` would return for the same file —
+/// i.e. it must be a SHA-256 over the file contents. Maven dependency klibs
+/// satisfy this because `ensure_artifact` hashes the file bytes.
+///
+/// Path-deps and plugin jars use `None` because their hash is computed at
+/// a different layer (path-dep source hash) or not at all (plugins are pinned
+/// in the lockfile separately).
+#[derive(Debug, Clone)]
+pub(crate) struct LibraryInput {
+    /// Filesystem path to the `.klib` file.
+    pub path: PathBuf,
+    /// Pre-computed SHA-256 hex of the file's contents, when available.
+    pub precomputed_sha256: Option<String>,
+}
+
+impl LibraryInput {
+    /// Construct a library input without a pre-computed hash.
+    ///
+    /// The cache-key code will read the file to compute the SHA-256 on demand.
+    pub(crate) fn unhashed(path: PathBuf) -> Self {
+        Self {
+            path,
+            precomputed_sha256: None,
+        }
+    }
+
+    /// Construct a library input with a pre-computed SHA-256 hash.
+    ///
+    /// Used by Maven klib downloads where `ensure_artifact` already hashed
+    /// the file bytes, so the cache-key code can reuse that value instead
+    /// of re-reading the file.
+    pub(crate) fn with_hash(path: PathBuf, sha256: String) -> Self {
+        Self {
+            path,
+            precomputed_sha256: Some(sha256),
+        }
+    }
+}
+
+/// Extract bare paths from a slice of [`LibraryInput`] for passing to the
+/// compiler (`konanc -library` only needs paths, not hashes).
+pub(crate) fn library_paths_of(libs: &[LibraryInput]) -> Vec<PathBuf> {
+    libs.iter().map(|l| l.path.clone()).collect()
+}
+
 /// Common state resolved during steps 1–7b of the build pipeline.
 ///
 /// Shared between `build()` and `build_tests()` to avoid duplicating the
@@ -81,8 +131,9 @@ pub(crate) struct ResolvedBuildContext {
     pub jre_home: Option<PathBuf>,
     /// Inputs to `update_lockfile_if_needed` (fresh-download hashes).
     pub lockfile_write_inputs: LockfileWriteInputs,
-    /// Library paths from built path-deps and downloaded Maven klibs.
-    pub library_paths: Vec<PathBuf>,
+    /// Library inputs (path + optional pre-computed hash) from built path-deps
+    /// and downloaded Maven klibs.
+    pub library_inputs: Vec<LibraryInput>,
     /// Paths to downloaded compiler plugin JARs.
     pub plugin_jars: Vec<PathBuf>,
     /// Lockfile entries for resolved plugins (used by `update_lockfile_if_needed`).
@@ -197,7 +248,13 @@ pub(crate) fn resolve_build_context(
     let mut completed: HashMap<String, PathBuf> = HashMap::new();
 
     for level in &levels {
-        let lib_paths: Vec<PathBuf> = completed.values().cloned().collect();
+        // Path-deps don't carry a pre-computed hash through the build pipeline,
+        // so the cache-key code rehashes them as needed.
+        let lib_inputs: Vec<LibraryInput> = completed
+            .values()
+            .cloned()
+            .map(LibraryInput::unhashed)
+            .collect();
         let results: Vec<Result<(String, PathBuf, BuildOutcome), EngineError>> = level
             .par_iter()
             .map(|dep| {
@@ -206,7 +263,7 @@ pub(crate) fn resolve_build_context(
                     jre_home: jre_home.as_deref(),
                     target: &target,
                     options,
-                    library_paths: &lib_paths,
+                    library_inputs: &lib_inputs,
                     plugin_jars: &[],
                 };
                 let (output, outcome) = build_single(
@@ -226,10 +283,11 @@ pub(crate) fn resolve_build_context(
         }
     }
 
-    let mut library_paths: Vec<PathBuf> = dep_graph
+    let mut library_inputs: Vec<LibraryInput> = dep_graph
         .order
         .iter()
         .filter_map(|dep| completed.get(&dep.name).cloned())
+        .map(LibraryInput::unhashed)
         .collect();
 
     // 7a. Resolve and download plugin artifacts.
@@ -248,8 +306,10 @@ pub(crate) fn resolve_build_context(
     };
 
     // 7b. Resolve and download Maven dependency klibs for the current target.
+    //     Each Maven klib comes back with a precomputed sha256 from
+    //     `ensure_artifact`, which the cache-key code reuses to skip rehashing.
     let maven_klibs = resolve_maven_deps(&effective_lockfile, &target)?;
-    library_paths.extend(maven_klibs);
+    library_inputs.extend(maven_klibs);
 
     let store = ArtifactStore::new(project_root);
 
@@ -265,7 +325,7 @@ pub(crate) fn resolve_build_context(
             konanc_tarball_sha256,
             jre_tarball_sha256,
         },
-        library_paths,
+        library_inputs,
         plugin_jars,
         plugin_locks,
         dep_graph,
@@ -300,7 +360,7 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
         jre_home: ctx.jre_home.as_deref(),
         target: &ctx.target,
         options,
-        library_paths: &ctx.library_paths,
+        library_inputs: &ctx.library_inputs,
         plugin_jars: &ctx.plugin_jars,
     };
     let (output_path, outcome) = build_single(
@@ -347,8 +407,10 @@ pub(crate) struct CompileContext<'a> {
     pub target: &'a Target,
     /// Build options (release, verbose, force, locked).
     pub options: &'a BuildOptions,
-    /// Dependency `.klib` paths to pass as `-library` args.
-    pub library_paths: &'a [PathBuf],
+    /// Dependency `.klib` inputs (path + optional pre-computed hash).
+    ///
+    /// The compiler only consumes the paths; the hashes feed the cache key.
+    pub library_inputs: &'a [LibraryInput],
     /// Compiler plugin JAR paths to pass as `-Xplugin` args.
     pub plugin_jars: &'a [PathBuf],
 }
@@ -393,9 +455,14 @@ pub(crate) fn build_single(
         os: std::env::consts::OS.to_owned(),
         arch: std::env::consts::ARCH.to_owned(),
         dependency_hashes: cc
-            .library_paths
+            .library_inputs
             .iter()
-            .map(|p| konvoy_util::hash::sha256_file(p).map_err(EngineError::from))
+            .map(|lib| match &lib.precomputed_sha256 {
+                // Reuse the hash that `ensure_artifact` already computed for
+                // this file's bytes — it's value-equivalent to sha256_file.
+                Some(h) => Ok(h.clone()),
+                None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
+            })
             .collect::<Result<Vec<_>, _>>()?,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
@@ -494,13 +561,16 @@ fn compile_two_step(
     // Step 1: compile sources → temporary klib (with plugins active).
     let klib_path = output_path.with_extension("klib");
 
+    // konanc only consumes paths — strip the precomputed hashes here.
+    let lib_paths = library_paths_of(cc.library_inputs);
+
     let mut compile_cmd = KonancCommand::new()
         .sources(sources)
         .output(&klib_path)
         .target(cc.target.to_konanc_arg())
         .release(cc.options.is_release())
         .produce(ProduceKind::Library)
-        .libraries(cc.library_paths)
+        .libraries(&lib_paths)
         .plugins(cc.plugin_jars);
 
     if let Some(jh) = cc.jre_home {
@@ -524,7 +594,7 @@ fn compile_two_step(
             .output(output_path)
             .target(cc.target.to_konanc_arg())
             .release(cc.options.is_release())
-            .libraries(cc.library_paths);
+            .libraries(&lib_paths);
 
         if let Some(jh) = cc.jre_home {
             link_cmd = link_cmd.java_home(jh);
@@ -558,13 +628,15 @@ fn compile_single_step(
     output_path: &Path,
     produce: ProduceKind,
 ) -> Result<PathBuf, EngineError> {
+    let lib_paths = library_paths_of(cc.library_inputs);
+
     let mut cmd = KonancCommand::new()
         .sources(sources)
         .output(output_path)
         .target(cc.target.to_konanc_arg())
         .release(cc.options.is_release())
         .produce(produce)
-        .libraries(cc.library_paths)
+        .libraries(&lib_paths)
         .plugins(cc.plugin_jars);
 
     if let Some(jh) = cc.jre_home {
@@ -621,7 +693,11 @@ pub(crate) fn lockfile_toml_content(lockfile: &Lockfile) -> Result<String, Engin
 ///
 /// Iterates over all Maven dependency entries in the lockfile (both direct
 /// and transitive), downloads the per-target `.klib` artifact, verifies the
-/// SHA-256 hash, and returns the list of klib paths to pass to `konanc -library`.
+/// SHA-256 hash, and returns the list of klib inputs to pass to the build.
+///
+/// Each returned [`LibraryInput`] carries the file path plus the SHA-256 of
+/// its contents (produced by `ensure_artifact`), so the cache-key code does
+/// not rehash the file.
 ///
 /// Only the klib for the current build target is downloaded (lazy download).
 ///
@@ -631,7 +707,7 @@ pub(crate) fn lockfile_toml_content(lockfile: &Lockfile) -> Result<String, Engin
 pub(crate) fn resolve_maven_deps(
     lockfile: &Lockfile,
     target: &Target,
-) -> Result<Vec<PathBuf>, EngineError> {
+) -> Result<Vec<LibraryInput>, EngineError> {
     // Collect all Maven dependency entries from the lockfile (direct + transitive).
     let maven_locks: Vec<&DependencyLock> = lockfile
         .dependencies
@@ -647,7 +723,7 @@ pub(crate) fn resolve_maven_deps(
     let target_str = target.to_konanc_arg();
     let maven_suffix = target.to_maven_suffix();
 
-    let klib_paths: Vec<Result<PathBuf, EngineError>> = maven_locks
+    let klib_inputs: Vec<Result<LibraryInput, EngineError>> = maven_locks
         .par_iter()
         .map(|lock_entry| {
             let dep_name = lock_entry.name.clone();
@@ -717,11 +793,13 @@ pub(crate) fn resolve_maven_deps(
                 });
             }
 
-            Ok(result.path)
+            // Carry the freshly-verified hash through so `build_single` can
+            // reuse it for the cache key without re-reading the file.
+            Ok(LibraryInput::with_hash(result.path, result.sha256))
         })
         .collect();
 
-    klib_paths.into_iter().collect()
+    klib_inputs.into_iter().collect()
 }
 
 /// Returns `true` if the manifest declares Maven deps that have no matching
@@ -1404,7 +1482,7 @@ mod tests {
             jre_home: None,
             target: &target,
             options: &options,
-            library_paths: &[],
+            library_inputs: &[],
             plugin_jars: &[],
         };
         let (output_path, outcome) =
@@ -1491,7 +1569,7 @@ mod tests {
             jre_home: None,
             target: &target,
             options: &options,
-            library_paths: &[],
+            library_inputs: &[],
             plugin_jars: &[],
         };
         let (output_path, outcome) =
@@ -1603,7 +1681,7 @@ mod tests {
             jre_home: None,
             target: &target,
             options: &options,
-            library_paths: &[],
+            library_inputs: &[],
             plugin_jars: &[],
         };
         let (output_path, outcome) =
@@ -2192,7 +2270,7 @@ mod tests {
             jre_home: None,
             target: &target,
             options: &options_no_force,
-            library_paths: &[],
+            library_inputs: &[],
             plugin_jars: &[],
         };
         let (_, outcome) = build_single(
@@ -2220,7 +2298,7 @@ mod tests {
             jre_home: None,
             target: &target,
             options: &options_force,
-            library_paths: &[],
+            library_inputs: &[],
             plugin_jars: &[],
         };
         let result = build_single(&project, &manifest, &cc_force, profile, &lockfile_content);
@@ -4587,5 +4665,60 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             false,
         );
         assert!(result.is_ok(), "force should bypass hash mismatch");
+    }
+
+    // -------------------------------------------------------------------
+    // LibraryInput constructors + helpers
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn library_input_unhashed_carries_path_and_no_hash() {
+        // `unhashed` is used for path-deps and pre-built klibs where the
+        // cache-key code will hash on demand.
+        let p = PathBuf::from("/tmp/some.klib");
+        let lib = LibraryInput::unhashed(p.clone());
+        assert_eq!(lib.path, p);
+        assert!(
+            lib.precomputed_sha256.is_none(),
+            "unhashed must produce None for the hash"
+        );
+    }
+
+    #[test]
+    fn library_input_with_hash_carries_both_path_and_hash() {
+        // `with_hash` is used by Maven downloads where `ensure_artifact`
+        // already hashed the file — the cache-key code reuses that value.
+        let p = PathBuf::from("/tmp/dep.klib");
+        let h = "deadbeef".to_owned();
+        let lib = LibraryInput::with_hash(p.clone(), h.clone());
+        assert_eq!(lib.path, p);
+        assert_eq!(lib.precomputed_sha256.as_deref(), Some("deadbeef"));
+    }
+
+    #[test]
+    fn library_paths_of_extracts_paths_in_order() {
+        // `library_paths_of` strips the hashes; konanc only needs paths.
+        // Order must be preserved so `-library` args feed in deterministically.
+        let libs = vec![
+            LibraryInput::unhashed(PathBuf::from("/a.klib")),
+            LibraryInput::with_hash(PathBuf::from("/b.klib"), "h".to_owned()),
+            LibraryInput::unhashed(PathBuf::from("/c.klib")),
+        ];
+        let paths = library_paths_of(&libs);
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/a.klib"),
+                PathBuf::from("/b.klib"),
+                PathBuf::from("/c.klib"),
+            ]
+        );
+    }
+
+    #[test]
+    fn library_paths_of_empty_input_returns_empty() {
+        // Empty input must not allocate a spurious element.
+        let paths = library_paths_of(&[]);
+        assert!(paths.is_empty());
     }
 }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -115,9 +115,18 @@ pub fn ensure_detekt(
     let url = detekt_download_url(version);
 
     let progress = konvoy_util::progress::new_download_bar(format!("detekt {version}"));
-    let result =
-        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", &progress)
-            .map_err(|e| map_download_err(version, e))?;
+    let ensure_result = konvoy_util::artifact::ensure_artifact(
+        &url,
+        &jar,
+        expected_sha256,
+        "detekt",
+        &progress.bar,
+    );
+    match &ensure_result {
+        Ok(_) => progress.mark_success(),
+        Err(_) => progress.mark_failure(),
+    }
+    let result = ensure_result.map_err(|e| map_download_err(version, e))?;
 
     Ok((result.path, result.sha256))
 }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -115,18 +115,15 @@ pub fn ensure_detekt(
     let url = detekt_download_url(version);
 
     let progress = konvoy_util::progress::new_download_bar(format!("detekt {version}"));
-    let ensure_result = konvoy_util::artifact::ensure_artifact(
-        &url,
-        &jar,
-        expected_sha256,
-        "detekt",
-        &progress.bar,
-    );
-    match &ensure_result {
-        Ok(_) => progress.mark_success(),
-        Err(_) => progress.mark_failure(),
-    }
-    let result = ensure_result.map_err(|e| map_download_err(version, e))?;
+    let result = progress
+        .finish(konvoy_util::artifact::ensure_artifact(
+            &url,
+            &jar,
+            expected_sha256,
+            "detekt",
+            progress.inner(),
+        ))
+        .map_err(|e| map_download_err(version, e))?;
 
     Ok((result.path, result.sha256))
 }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -119,10 +119,9 @@ pub fn ensure_detekt(
     // is more noise than information.
     let progress = (!jar.exists())
         .then(|| konvoy_util::progress::new_download_bar(format!("detekt {version}")));
-    let result = konvoy_util::progress::run_with_optional_bar(progress.as_ref(), |pb| {
-        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", pb)
-    })
-    .map_err(|e| map_download_err(version, e))?;
+    let result =
+        konvoy_util::progress::fetch(&url, &jar, expected_sha256, "detekt", progress.as_ref())
+            .map_err(|e| map_download_err(version, e))?;
     if progress.is_some() {
         eprintln!();
     }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -114,17 +114,27 @@ pub fn ensure_detekt(
     let jar = detekt_jar_path(version)?;
     let url = detekt_download_url(version);
 
-    let progress = konvoy_util::progress::new_download_bar(format!("detekt {version}"));
-    let result = progress
-        .finish(konvoy_util::artifact::ensure_artifact(
+    // Only show a download bar when the JAR isn't already cached — a
+    // cached re-verify completes in milliseconds and the flash of ⚙️ → ✅
+    // is more noise than information.
+    let progress = (!jar.exists())
+        .then(|| konvoy_util::progress::new_download_bar(format!("detekt {version}")));
+    let raw = if let Some(bar) = &progress {
+        bar.finish(konvoy_util::artifact::ensure_artifact(
             &url,
             &jar,
             expected_sha256,
             "detekt",
-            progress.inner(),
+            bar.inner(),
         ))
-        .map_err(|e| map_download_err(version, e))?;
-    eprintln!();
+    } else {
+        let hidden = konvoy_util::progress::hidden_bar();
+        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", &hidden)
+    };
+    let result = raw.map_err(|e| map_download_err(version, e))?;
+    if progress.is_some() {
+        eprintln!();
+    }
 
     Ok((result.path, result.sha256))
 }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -114,8 +114,9 @@ pub fn ensure_detekt(
     let jar = detekt_jar_path(version)?;
     let url = detekt_download_url(version);
 
+    let progress = konvoy_util::progress::new_download_bar(format!("detekt {version}"));
     let result =
-        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", version)
+        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", &progress)
             .map_err(|e| map_download_err(version, e))?;
 
     Ok((result.path, result.sha256))

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -119,19 +119,10 @@ pub fn ensure_detekt(
     // is more noise than information.
     let progress = (!jar.exists())
         .then(|| konvoy_util::progress::new_download_bar(format!("detekt {version}")));
-    let raw = if let Some(bar) = &progress {
-        bar.finish(konvoy_util::artifact::ensure_artifact(
-            &url,
-            &jar,
-            expected_sha256,
-            "detekt",
-            bar.inner(),
-        ))
-    } else {
-        let hidden = konvoy_util::progress::hidden_bar();
-        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", &hidden)
-    };
-    let result = raw.map_err(|e| map_download_err(version, e))?;
+    let result = konvoy_util::progress::run_with_optional_bar(progress.as_ref(), |pb| {
+        konvoy_util::artifact::ensure_artifact(&url, &jar, expected_sha256, "detekt", pb)
+    })
+    .map_err(|e| map_download_err(version, e))?;
     if progress.is_some() {
         eprintln!();
     }

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -124,6 +124,7 @@ pub fn ensure_detekt(
             progress.inner(),
         ))
         .map_err(|e| map_download_err(version, e))?;
+    eprintln!();
 
     Ok((result.path, result.sha256))
 }

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -185,6 +185,11 @@ pub enum EngineError {
     /// A cycle was detected during Maven transitive dependency resolution.
     #[error("maven dependency cycle detected: {cycle} — remove one of these dependencies from konvoy.toml or file an issue upstream")]
     MavenDependencyCycle { cycle: String },
+
+    /// An internal invariant was violated. This indicates a bug in konvoy
+    /// itself; user code/config should never trigger it.
+    #[error("internal invariant violated: {context} — please file a bug report")]
+    InternalInvariantViolated { context: String },
 }
 
 /// Map a `UtilError` from artifact download/verify to an `EngineError`.

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -155,7 +155,8 @@ pub fn ensure_plugin_artifacts(
     lockfile: &Lockfile,
     locked: bool,
 ) -> Result<Vec<PluginArtifactResult>, EngineError> {
-    use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+    use indicatif::MultiProgress;
+    use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
     // Fail fast in --locked mode before spawning any downloads.
     if locked {
@@ -166,15 +167,29 @@ pub fn ensure_plugin_artifacts(
         }
     }
 
-    artifacts
-        .par_iter()
-        .map(|artifact| {
-            let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
+    if artifacts.is_empty() {
+        return Ok(Vec::new());
+    }
 
-            let progress = konvoy_util::progress::new_download_bar(format!(
-                "{} {}",
-                artifact.plugin_name, artifact.maven_coord.version
-            ));
+    // Pre-allocate one bar per artifact in stable order with a uniform
+    // prefix width so the parallel downloads render as a clean vertical
+    // stack instead of overwriting each other.
+    let multi = MultiProgress::new();
+    let labels: Vec<String> = artifacts
+        .iter()
+        .map(|a| format!("{} {}", a.plugin_name, a.maven_coord.version))
+        .collect();
+    let prefix_width = labels.iter().map(String::len).max().unwrap_or(0);
+    let bars: Vec<konvoy_util::progress::DownloadBar> = labels
+        .into_iter()
+        .map(|label| konvoy_util::progress::add_download_bar(&multi, label, prefix_width))
+        .collect();
+
+    let results: Vec<Result<PluginArtifactResult, EngineError>> = artifacts
+        .par_iter()
+        .zip(bars.par_iter())
+        .map(|(artifact, progress)| {
+            let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
             let util_result = progress
                 .finish(konvoy_util::artifact::ensure_artifact(
                     &artifact.url,
@@ -195,7 +210,13 @@ pub fn ensure_plugin_artifacts(
                 version: artifact.maven_coord.version.clone(),
             })
         })
-        .collect()
+        .collect();
+
+    // Trailing newline so the next eprintln status line isn't concatenated
+    // onto the last bar's row (indicatif leaves the cursor at end-of-line).
+    eprintln!();
+
+    results.into_iter().collect()
 }
 
 /// Build `PluginLock` entries from download results.

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -175,19 +175,15 @@ pub fn ensure_plugin_artifacts(
                 "{} {}",
                 artifact.plugin_name, artifact.maven_coord.version
             ));
-            let ensure_result = konvoy_util::artifact::ensure_artifact(
-                &artifact.url,
-                &artifact.cache_path,
-                expected_hash,
-                &artifact.plugin_name,
-                &progress.bar,
-            );
-            match &ensure_result {
-                Ok(_) => progress.mark_success(),
-                Err(_) => progress.mark_failure(),
-            }
-            let util_result =
-                ensure_result.map_err(|e| map_download_err(&artifact.plugin_name, e))?;
+            let util_result = progress
+                .finish(konvoy_util::artifact::ensure_artifact(
+                    &artifact.url,
+                    &artifact.cache_path,
+                    expected_hash,
+                    &artifact.plugin_name,
+                    progress.inner(),
+                ))
+                .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 
             Ok(PluginArtifactResult {
                 plugin_name: artifact.plugin_name.clone(),

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -175,14 +175,19 @@ pub fn ensure_plugin_artifacts(
                 "{} {}",
                 artifact.plugin_name, artifact.maven_coord.version
             ));
-            let util_result = konvoy_util::artifact::ensure_artifact(
+            let ensure_result = konvoy_util::artifact::ensure_artifact(
                 &artifact.url,
                 &artifact.cache_path,
                 expected_hash,
                 &artifact.plugin_name,
-                &progress,
-            )
-            .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
+                &progress.bar,
+            );
+            match &ensure_result {
+                Ok(_) => progress.mark_success(),
+                Err(_) => progress.mark_failure(),
+            }
+            let util_result =
+                ensure_result.map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 
             Ok(PluginArtifactResult {
                 plugin_name: artifact.plugin_name.clone(),

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -202,25 +202,16 @@ pub fn ensure_plugin_artifacts(
         .zip(aligned_bars.par_iter())
         .map(|(artifact, maybe_bar)| {
             let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
-            let raw = if let Some(bar) = maybe_bar {
-                bar.finish(konvoy_util::artifact::ensure_artifact(
-                    &artifact.url,
-                    &artifact.cache_path,
-                    expected_hash,
-                    &artifact.plugin_name,
-                    bar.inner(),
-                ))
-            } else {
-                let hidden = konvoy_util::progress::hidden_bar();
+            let util_result = konvoy_util::progress::run_with_optional_bar(*maybe_bar, |pb| {
                 konvoy_util::artifact::ensure_artifact(
                     &artifact.url,
                     &artifact.cache_path,
                     expected_hash,
                     &artifact.plugin_name,
-                    &hidden,
+                    pb,
                 )
-            };
-            let util_result = raw.map_err(|e| map_download_err(&artifact.plugin_name, e))?;
+            })
+            .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 
             Ok(PluginArtifactResult {
                 plugin_name: artifact.plugin_name.clone(),

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -170,29 +170,57 @@ pub fn ensure_plugin_artifacts(
         return Ok(Vec::new());
     }
 
-    // Pre-allocate one bar per artifact in stable order with a uniform
-    // prefix width so the parallel downloads render as a clean vertical
-    // stack instead of overwriting each other.
-    let labels: Vec<String> = artifacts
+    // Only allocate bars for artifacts that actually need a network fetch.
+    // Cached items (cache_path already exists) re-verify their hash via a
+    // hidden bar so the user sees no UI flash when nothing's being
+    // downloaded.
+    let download_labels: Vec<String> = artifacts
         .iter()
+        .filter(|a| !a.cache_path.exists())
         .map(|a| format!("{} {}", a.plugin_name, a.maven_coord.version))
         .collect();
-    let (_multi, bars) = konvoy_util::progress::pre_allocate_bars(labels);
+    let any_downloads = !download_labels.is_empty();
+    let bars: Vec<konvoy_util::progress::DownloadBar> = if any_downloads {
+        konvoy_util::progress::pre_allocate_bars(download_labels).1
+    } else {
+        Vec::new()
+    };
+    let mut bar_iter = bars.iter();
+    let aligned_bars: Vec<Option<&konvoy_util::progress::DownloadBar>> = artifacts
+        .iter()
+        .map(|a| {
+            if a.cache_path.exists() {
+                None
+            } else {
+                bar_iter.next()
+            }
+        })
+        .collect();
 
     let results: Vec<Result<PluginArtifactResult, EngineError>> = artifacts
         .par_iter()
-        .zip(bars.par_iter())
-        .map(|(artifact, progress)| {
+        .zip(aligned_bars.par_iter())
+        .map(|(artifact, maybe_bar)| {
             let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
-            let util_result = progress
-                .finish(konvoy_util::artifact::ensure_artifact(
+            let raw = if let Some(bar) = maybe_bar {
+                bar.finish(konvoy_util::artifact::ensure_artifact(
                     &artifact.url,
                     &artifact.cache_path,
                     expected_hash,
                     &artifact.plugin_name,
-                    progress.inner(),
+                    bar.inner(),
                 ))
-                .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
+            } else {
+                let hidden = konvoy_util::progress::hidden_bar();
+                konvoy_util::artifact::ensure_artifact(
+                    &artifact.url,
+                    &artifact.cache_path,
+                    expected_hash,
+                    &artifact.plugin_name,
+                    &hidden,
+                )
+            };
+            let util_result = raw.map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 
             Ok(PluginArtifactResult {
                 plugin_name: artifact.plugin_name.clone(),
@@ -206,9 +234,9 @@ pub fn ensure_plugin_artifacts(
         })
         .collect();
 
-    // Trailing newline so the next eprintln status line isn't concatenated
-    // onto the last bar's row (indicatif leaves the cursor at end-of-line).
-    eprintln!();
+    if any_downloads {
+        eprintln!();
+    }
 
     results.into_iter().collect()
 }

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -171,12 +171,16 @@ pub fn ensure_plugin_artifacts(
         .map(|artifact| {
             let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
 
+            let progress = konvoy_util::progress::new_download_bar(format!(
+                "{} {}",
+                artifact.plugin_name, artifact.maven_coord.version
+            ));
             let util_result = konvoy_util::artifact::ensure_artifact(
                 &artifact.url,
                 &artifact.cache_path,
                 expected_hash,
                 &artifact.plugin_name,
-                &artifact.maven_coord.version,
+                &progress,
             )
             .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -202,15 +202,13 @@ pub fn ensure_plugin_artifacts(
         .zip(aligned_bars.par_iter())
         .map(|(artifact, maybe_bar)| {
             let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
-            let util_result = konvoy_util::progress::run_with_optional_bar(*maybe_bar, |pb| {
-                konvoy_util::artifact::ensure_artifact(
-                    &artifact.url,
-                    &artifact.cache_path,
-                    expected_hash,
-                    &artifact.plugin_name,
-                    pb,
-                )
-            })
+            let util_result = konvoy_util::progress::fetch(
+                &artifact.url,
+                &artifact.cache_path,
+                expected_hash,
+                &artifact.plugin_name,
+                *maybe_bar,
+            )
             .map_err(|e| map_download_err(&artifact.plugin_name, e))?;
 
             Ok(PluginArtifactResult {

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -155,7 +155,6 @@ pub fn ensure_plugin_artifacts(
     lockfile: &Lockfile,
     locked: bool,
 ) -> Result<Vec<PluginArtifactResult>, EngineError> {
-    use indicatif::MultiProgress;
     use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
     // Fail fast in --locked mode before spawning any downloads.
@@ -174,16 +173,11 @@ pub fn ensure_plugin_artifacts(
     // Pre-allocate one bar per artifact in stable order with a uniform
     // prefix width so the parallel downloads render as a clean vertical
     // stack instead of overwriting each other.
-    let multi = MultiProgress::new();
     let labels: Vec<String> = artifacts
         .iter()
         .map(|a| format!("{} {}", a.plugin_name, a.maven_coord.version))
         .collect();
-    let prefix_width = labels.iter().map(String::len).max().unwrap_or(0);
-    let bars: Vec<konvoy_util::progress::DownloadBar> = labels
-        .into_iter()
-        .map(|label| konvoy_util::progress::add_download_bar(&multi, label, prefix_width))
-        .collect();
+    let (_multi, bars) = konvoy_util::progress::pre_allocate_bars(labels);
 
     let results: Vec<Result<PluginArtifactResult, EngineError>> = artifacts
         .par_iter()

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -83,9 +83,12 @@ pub fn build_tests(
         os: std::env::consts::OS.to_owned(),
         arch: std::env::consts::ARCH.to_owned(),
         dependency_hashes: ctx
-            .library_paths
+            .library_inputs
             .iter()
-            .map(|p| konvoy_util::hash::sha256_file(p).map_err(EngineError::from))
+            .map(|lib| match &lib.precomputed_sha256 {
+                Some(h) => Ok(h.clone()),
+                None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
+            })
             .collect::<Result<Vec<_>, _>>()?,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
@@ -121,6 +124,8 @@ pub fn build_tests(
         konvoy_util::fs::ensure_dir(parent)?;
     }
 
+    let library_paths = crate::build::library_paths_of(&ctx.library_inputs);
+
     let mut cmd = KonancCommand::new()
         .sources(&sources)
         .output(&output_path)
@@ -128,7 +133,7 @@ pub fn build_tests(
         .release(options.is_release())
         .produce(ProduceKind::Program)
         .generate_test_runner(true)
-        .libraries(&ctx.library_paths)
+        .libraries(&library_paths)
         .plugins(&ctx.plugin_jars);
 
     if let Some(jh) = ctx.jre_home.as_deref() {

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -401,21 +401,11 @@ impl ResolvedMavenDep {
 // Transitive resolution (BFS on artifact metadata)
 // ---------------------------------------------------------------------------
 
-/// Resolve the full transitive closure of Maven dependencies via BFS on
-/// artifact metadata (`.module` JSON first, POM XML as fallback).
+/// A BFS queue entry: `(group_id, artifact_id, version, requirer_name, ancestor_path)`.
 ///
-/// Uses the first known target to discover transitive deps (the dependency
-/// graph is the same across targets — only the klib differs).
-///
-/// After resolving the dependency graph, inspects each dep's metadata for
-/// additional klib files (e.g. cinterop klibs) and adds them as separate
-/// entries with a `classifier` set.
-///
-/// # Errors
-///
-/// Returns an error if metadata cannot be fetched or parsed, a version conflict
-/// is detected, or a dependency cycle is found.
-/// A BFS queue entry: (group_id, artifact_id, version, requirer_name, ancestor_path).
+/// `requirer_name` is `None` for direct deps and `Some(parent_name)` for
+/// transitive ones; `ancestor_path` carries the `group:artifact` chain
+/// from a direct dep down to here for cycle detection.
 type BfsEntry = (String, String, String, Option<String>, Vec<String>);
 
 /// State accumulated during the BFS traversal of Maven transitive dependencies.
@@ -534,6 +524,31 @@ fn finalize_required_by(
     }
 }
 
+/// Resolve the full transitive closure of Maven dependencies via a
+/// level-parallel BFS on artifact metadata (`.module` JSON first, POM XML
+/// as fallback).
+///
+/// Each BFS level is processed in three phases:
+/// 1. Drain the queue and fold per-entry `required_by` bookkeeping (no I/O).
+/// 2. Dedupe + parallel-fetch metadata for unique `(group, artifact, version)`
+///    tuples not already in the in-memory cache (rayon `par_iter`).
+/// 3. Sequentially process each entry against the now-populated cache,
+///    pushing children onto the queue for the next level. Cycle detection
+///    uses the per-entry ancestor path.
+///
+/// Uses the first known target ([`konvoy_targets::Target::LinuxX64`]) to
+/// discover transitive deps — the dependency graph is identical across
+/// targets, only the klib differs.
+///
+/// After the graph is resolved, [`discover_cinterop_deps`] scans the
+/// metadata cache for cinterop `.klib` files and adds them as separate
+/// entries with `classifier` set.
+///
+/// # Errors
+///
+/// Returns an error if metadata cannot be fetched or parsed, a version
+/// conflict is detected (see [`check_version_conflict`]), or a dependency
+/// cycle is found.
 fn resolve_transitive(
     direct_deps: &[ResolvedMavenDep],
 ) -> Result<Vec<ResolvedMavenDep>, EngineError> {

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -139,9 +139,8 @@ fn download_target_klib(
     let dest = coord.cache_path(cache_root);
     let label = format!("{}:{}", dep.name, target);
 
-    let result = progress
-        .run(|pb| konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, pb))
-        .map_err(|e| match e {
+    let result = konvoy_util::progress::fetch(&url, &dest, None, &label, Some(progress)).map_err(
+        |e| match e {
             konvoy_util::error::UtilError::Download { message } => {
                 EngineError::LibraryDownloadFailed {
                     name: dep.name.clone(),
@@ -150,7 +149,8 @@ fn download_target_klib(
                 }
             }
             other => EngineError::Util(other),
-        })?;
+        },
+    )?;
 
     Ok((target, result.sha256))
 }

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -140,13 +140,7 @@ fn download_target_klib(
     let label = format!("{}:{}", dep.name, target);
 
     let result = progress
-        .finish(konvoy_util::artifact::ensure_artifact(
-            &url,
-            &dest,
-            None,
-            &label,
-            progress.inner(),
-        ))
+        .run(|pb| konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, pb))
         .map_err(|e| match e {
             konvoy_util::error::UtilError::Download { message } => {
                 EngineError::LibraryDownloadFailed {

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 
-use indicatif::{MultiProgress, ProgressBar};
+use indicatif::MultiProgress;
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile};
@@ -75,7 +75,7 @@ fn placeholder_lock(dep: &ResolvedMavenDep, maven_coord: &str) -> DependencyLock
 fn download_dep(
     dep: &ResolvedMavenDep,
     cache_root: &Path,
-    bars: &[ProgressBar],
+    bars: &[konvoy_util::progress::DownloadBar],
 ) -> Result<DependencyLock, EngineError> {
     let known_targets = konvoy_targets::KNOWN_TARGETS;
     let maven_coord = dep.key();
@@ -121,7 +121,7 @@ fn download_target_klib(
     dep: &ResolvedMavenDep,
     target: konvoy_targets::Target,
     cache_root: &Path,
-    progress: &ProgressBar,
+    progress: &konvoy_util::progress::DownloadBar,
 ) -> Result<(konvoy_targets::Target, String), EngineError> {
     let maven_suffix = target.to_maven_suffix();
     let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
@@ -139,17 +139,20 @@ fn download_target_klib(
     let dest = coord.cache_path(cache_root);
     let label = format!("{}:{}", dep.name, target);
 
-    let result = konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, progress)
-        .map_err(|e| match e {
-            konvoy_util::error::UtilError::Download { message } => {
-                EngineError::LibraryDownloadFailed {
-                    name: dep.name.clone(),
-                    url: url.clone(),
-                    message,
-                }
-            }
-            other => EngineError::Util(other),
-        })?;
+    let ensure_result =
+        konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, &progress.bar);
+    match &ensure_result {
+        Ok(_) => progress.mark_success(),
+        Err(_) => progress.mark_failure(),
+    }
+    let result = ensure_result.map_err(|e| match e {
+        konvoy_util::error::UtilError::Download { message } => EngineError::LibraryDownloadFailed {
+            name: dep.name.clone(),
+            url: url.clone(),
+            message,
+        },
+        other => EngineError::Util(other),
+    })?;
 
     Ok((target, result.sha256))
 }
@@ -283,7 +286,7 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         .max()
         .unwrap_or(0);
 
-    let dep_bars: Vec<Vec<ProgressBar>> = labels
+    let dep_bars: Vec<Vec<konvoy_util::progress::DownloadBar>> = labels
         .into_iter()
         .map(|row| {
             row.into_iter()
@@ -304,10 +307,16 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         })
         .collect();
 
-    // Bars remain on screen at their final state after `finish()` (called
-    // inside `download_with_progress`); the `MultiProgress` is dropped at end
-    // of scope which releases the draw region without clearing the rendered
-    // content.
+    // Bars remain on screen at their final state after each is abandoned
+    // (inside `DownloadBar::mark_success` / `mark_failure`); the
+    // `MultiProgress` is dropped at end of scope which releases the draw
+    // region without clearing the rendered content. Indicatif leaves the
+    // cursor at the end of the last bar's row, so emit one trailing newline
+    // before any subsequent `eprintln!` so the caller's status line doesn't
+    // get concatenated onto the bar row.
+    if !needs_download.is_empty() {
+        eprintln!();
+    }
 
     // Apply results in original order so the lockfile output is deterministic
     // (parallel downloads finish in arbitrary order, but the on-disk layout

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -139,20 +139,24 @@ fn download_target_klib(
     let dest = coord.cache_path(cache_root);
     let label = format!("{}:{}", dep.name, target);
 
-    let ensure_result =
-        konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, &progress.bar);
-    match &ensure_result {
-        Ok(_) => progress.mark_success(),
-        Err(_) => progress.mark_failure(),
-    }
-    let result = ensure_result.map_err(|e| match e {
-        konvoy_util::error::UtilError::Download { message } => EngineError::LibraryDownloadFailed {
-            name: dep.name.clone(),
-            url: url.clone(),
-            message,
-        },
-        other => EngineError::Util(other),
-    })?;
+    let result = progress
+        .finish(konvoy_util::artifact::ensure_artifact(
+            &url,
+            &dest,
+            None,
+            &label,
+            progress.inner(),
+        ))
+        .map_err(|e| match e {
+            konvoy_util::error::UtilError::Download { message } => {
+                EngineError::LibraryDownloadFailed {
+                    name: dep.name.clone(),
+                    url: url.clone(),
+                    message,
+                }
+            }
+            other => EngineError::Util(other),
+        })?;
 
     Ok((target, result.sha256))
 }

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -39,6 +39,120 @@ const FILTERED_GROUP_ARTIFACTS: &[(&str, &str)] = &[
 ];
 
 // ---------------------------------------------------------------------------
+// Per-dep download helpers
+// ---------------------------------------------------------------------------
+
+/// Build a placeholder lock entry used while the real one is being downloaded.
+///
+/// The placeholder is overwritten before the lockfile is written, so its
+/// `targets`/`source_hash` are never observed.
+fn placeholder_lock(dep: &ResolvedMavenDep, maven_coord: &str) -> DependencyLock {
+    DependencyLock {
+        name: dep.name.clone(),
+        source: DepSource::Maven {
+            version: dep.version.clone(),
+            maven: maven_coord.to_owned(),
+            targets: BTreeMap::new(),
+            required_by: dep.required_by.clone(),
+            classifier: dep.classifier.clone(),
+        },
+        source_hash: String::new(),
+    }
+}
+
+/// Download a Maven dep's klib for every known target and produce its lock entry.
+///
+/// Per-target downloads run in parallel via rayon; the final summary
+/// `eprintln!` is emitted once per dep so concurrent dep downloads don't
+/// interleave on stderr in confusing ways.
+fn download_dep(dep: &ResolvedMavenDep, tmp_base: &Path) -> Result<DependencyLock, EngineError> {
+    let known_targets = konvoy_targets::KNOWN_TARGETS;
+    let maven_coord = dep.key();
+
+    let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> = known_targets
+        .par_iter()
+        .map(|&target| download_target_klib(dep, target, tmp_base))
+        .collect();
+
+    // Build a deterministic target hash map and a multi-line summary string.
+    let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
+    let mut summary_lines: Vec<String> = Vec::with_capacity(known_targets.len() + 1);
+    summary_lines.push(format!("  Resolving {} {}...", dep.name, dep.version));
+    for result in target_results {
+        let (target, sha256) = result?;
+        let display_hash = crate::common::truncate_hash(&sha256, 16);
+        summary_lines.push(format!("    {target}: {display_hash}..."));
+        targets_map.insert(target.to_string(), sha256);
+    }
+    // Single eprintln for the whole dep so parallel deps don't interleave.
+    eprintln!("{}", summary_lines.join("\n"));
+
+    let hash_input: String = targets_map
+        .iter()
+        .map(|(k, v)| format!("{k}:{v}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source_hash = konvoy_util::hash::sha256_bytes(hash_input.as_bytes());
+
+    Ok(DependencyLock {
+        name: dep.name.clone(),
+        source: DepSource::Maven {
+            version: dep.version.clone(),
+            maven: maven_coord,
+            targets: targets_map,
+            required_by: dep.required_by.clone(),
+            classifier: dep.classifier.clone(),
+        },
+        source_hash,
+    })
+}
+
+/// Download a single dep's klib for one target and return `(target, sha256)`.
+fn download_target_klib(
+    dep: &ResolvedMavenDep,
+    target: konvoy_targets::Target,
+    tmp_base: &Path,
+) -> Result<(konvoy_targets::Target, String), EngineError> {
+    let maven_suffix = target.to_maven_suffix();
+    let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
+
+    let mut coord = konvoy_util::maven::MavenCoordinate::new(
+        &dep.group_id,
+        &per_target_artifact_id,
+        &dep.version,
+    )
+    .with_packaging("klib");
+    if let Some(cls) = &dep.classifier {
+        coord = coord.with_classifier(cls);
+    }
+    let url = coord.to_url(MAVEN_CENTRAL);
+
+    // Use a target- and dep-unique tmp filename so parallel downloads from
+    // different deps cannot collide on the same file.
+    let tmp_file = tmp_base.join(format!("{}-{}", dep.name, coord.filename()));
+
+    let result = konvoy_util::artifact::ensure_artifact(
+        &url,
+        &tmp_file,
+        None,
+        &format!("{}:{}", dep.name, target),
+        &dep.version,
+    )
+    .map_err(|e| match e {
+        konvoy_util::error::UtilError::Download { message } => EngineError::LibraryDownloadFailed {
+            name: dep.name.clone(),
+            url: url.clone(),
+            message,
+        },
+        other => EngineError::Util(other),
+    })?;
+
+    let _ = std::fs::remove_file(&tmp_file);
+
+    Ok((target, result.sha256))
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -113,14 +227,17 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         all_deps.len().saturating_sub(direct_deps.len())
     );
 
-    // 5. Check if all resolved deps already match the lockfile — skip download if so.
-    let mut new_dep_locks = Vec::new();
+    // 5. Partition deps into "already locked" vs "needs download" before any
+    //    parallel work, so we don't read the lockfile under contention.
+    //
+    //    Then download the "needs download" set in parallel (across deps),
+    //    while each dep also parallelizes its per-target downloads (nested
+    //    rayon is fine).
+    let mut new_dep_locks: Vec<DependencyLock> = Vec::with_capacity(all_deps.len());
+    let mut needs_download: Vec<(usize, &ResolvedMavenDep)> = Vec::new();
 
-    for dep in &all_deps {
+    for (idx, dep) in all_deps.iter().enumerate() {
         let maven_coord = dep.key();
-        eprintln!("  Resolving {} {}...", dep.name, dep.version);
-
-        // Check if lockfile already has this dep at this version and classifier.
         let dep_classifier = &dep.classifier;
         let already_locked = lockfile.dependencies.iter().find(|d| {
             d.name == dep.name
@@ -129,90 +246,53 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         });
 
         if let Some(existing) = already_locked {
-            eprintln!("    (already up to date)");
+            // Reserve a slot — we'll fill the same index for needs_download
+            // entries after the parallel work completes.
             new_dep_locks.push(existing.clone());
-            continue;
+            eprintln!("  Resolving {} {}...", dep.name, dep.version);
+            eprintln!("    (already up to date)");
+        } else {
+            // Placeholder; replaced below.
+            new_dep_locks.push(placeholder_lock(dep, &maven_coord));
+            needs_download.push((idx, dep));
         }
+    }
 
-        // For each known target, download and hash (in parallel).
-        let known_targets = konvoy_targets::KNOWN_TARGETS;
+    // One shared tmp dir for the whole update; cleaned up at the end.
+    let pid = std::process::id();
+    let tmp_base = std::env::temp_dir().join(format!("konvoy-update-{pid}"));
+    konvoy_util::fs::ensure_dir(&tmp_base)?;
 
-        let pid = std::process::id();
-        let tmp_base = std::env::temp_dir().join(format!("konvoy-update-{pid}"));
-        konvoy_util::fs::ensure_dir(&tmp_base)?;
+    // Download deps in parallel; per-target downloads are parallel within each.
+    let download_results: Vec<Result<(usize, DependencyLock), EngineError>> = needs_download
+        .par_iter()
+        .map(|(idx, dep)| {
+            let lock = download_dep(dep, &tmp_base)?;
+            Ok((*idx, lock))
+        })
+        .collect();
 
-        let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> =
-            known_targets
-                .par_iter()
-                .map(|&target| {
-                    let maven_suffix = target.to_maven_suffix();
-                    let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
+    konvoy_util::fs::remove_dir_all_if_exists(&tmp_base)?;
 
-                    let mut coord = konvoy_util::maven::MavenCoordinate::new(
-                        &dep.group_id,
-                        &per_target_artifact_id,
-                        &dep.version,
-                    )
-                    .with_packaging("klib");
-                    if let Some(cls) = &dep.classifier {
-                        coord = coord.with_classifier(cls);
-                    }
-                    let url = coord.to_url(MAVEN_CENTRAL);
-
-                    let tmp_file = tmp_base.join(coord.filename());
-
-                    let result = konvoy_util::artifact::ensure_artifact(
-                        &url,
-                        &tmp_file,
-                        None,
-                        &format!("{}:{}", dep.name, target),
-                        &dep.version,
-                    )
-                    .map_err(|e| match e {
-                        konvoy_util::error::UtilError::Download { message } => {
-                            EngineError::LibraryDownloadFailed {
-                                name: dep.name.clone(),
-                                url: url.clone(),
-                                message,
-                            }
-                        }
-                        other => EngineError::Util(other),
-                    })?;
-
-                    let _ = std::fs::remove_file(&tmp_file);
-
-                    Ok((target, result.sha256))
-                })
-                .collect();
-
-        let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
-        for result in target_results {
-            let (target, sha256) = result?;
-            let display_hash = crate::common::truncate_hash(&sha256, 16);
-            eprintln!("    {target}: {display_hash}...");
-            targets_map.insert(target.to_string(), sha256);
+    // Apply results in original order so the lockfile output is deterministic.
+    for result in download_results {
+        let (idx, lock) = result?;
+        if let Some(slot) = new_dep_locks.get_mut(idx) {
+            *slot = lock;
         }
+    }
 
-        konvoy_util::fs::remove_dir_all_if_exists(&tmp_base)?;
-
-        let hash_input: String = targets_map
-            .iter()
-            .map(|(k, v)| format!("{k}:{v}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let source_hash = konvoy_util::hash::sha256_bytes(hash_input.as_bytes());
-
-        new_dep_locks.push(DependencyLock {
-            name: dep.name.clone(),
-            source: DepSource::Maven {
-                version: dep.version.clone(),
-                maven: maven_coord,
-                targets: targets_map,
-                required_by: dep.required_by.clone(),
-                classifier: dep.classifier.clone(),
-            },
-            source_hash,
-        });
+    // After applying parallel results, every placeholder should have been
+    // replaced with a real lock entry carrying a non-empty source_hash. Use
+    // a debug_assert so a future bug (e.g. an index miscount or a skipped
+    // download) surfaces immediately in test/debug builds without changing
+    // release-time behavior.
+    for lock in &new_dep_locks {
+        debug_assert!(
+            !lock.source_hash.is_empty(),
+            "placeholder lock for {} not replaced",
+            lock.name
+        );
     }
 
     // 6. Merge: preserve existing path deps, replace all Maven deps.
@@ -437,106 +517,168 @@ fn resolve_transitive(
         ));
     }
 
-    // BFS loop.
-    while let Some((group_id, artifact_id, version, requirer, path)) = state.queue.pop_front() {
-        let key = format!("{group_id}:{artifact_id}");
+    // Level-based BFS: drain the queue into a Vec, fetch all metadata for
+    // that level in parallel, then process children sequentially so the
+    // graph mutations remain race-free.
+    while !state.queue.is_empty() {
+        // Drain the current level into a Vec.
+        let level: Vec<BfsEntry> = state.queue.drain(..).collect();
 
-        if let Some(req) = &requirer {
-            state
-                .required_by_map
-                .entry(key.clone())
-                .or_default()
-                .insert(req.clone());
+        // Fold pre-fetch bookkeeping (required_by entries from `requirer`)
+        // into the map before doing any I/O — these only depend on `requirer`
+        // and `(group_id, artifact_id)`, not on the fetched metadata.
+        for (group_id, artifact_id, _version, requirer, _path) in &level {
+            let key = format!("{group_id}:{artifact_id}");
+            if let Some(req) = requirer {
+                state
+                    .required_by_map
+                    .entry(key)
+                    .or_default()
+                    .insert(req.clone());
+            }
         }
 
-        let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
-        let metadata = fetch_metadata_cached(
-            &group_id,
-            &per_target_artifact_id,
-            &version,
-            maven_suffix,
-            &mut state.metadata_cache,
-        )?;
-
-        for meta_dep in &metadata.dependencies {
-            if is_filtered_dependency(&meta_dep.group_id, &meta_dep.artifact_id) {
+        // Collect unique (group, artifact, version) tuples that need fetching
+        // and are not already in the metadata cache. Multiple entries in the
+        // queue may point at the same artifact via different paths.
+        let mut to_fetch: Vec<(String, String, String, String)> = Vec::new();
+        let mut seen_keys: BTreeSet<String> = BTreeSet::new();
+        for (group_id, artifact_id, version, _requirer, _path) in &level {
+            let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
+            let cache_key = format!("{group_id}:{per_target_artifact_id}:{version}");
+            if state.metadata_cache.contains_key(&cache_key) || !seen_keys.insert(cache_key.clone())
+            {
                 continue;
             }
-            if meta_dep.version.is_empty() {
-                continue;
-            }
+            to_fetch.push((
+                group_id.clone(),
+                per_target_artifact_id,
+                version.clone(),
+                cache_key,
+            ));
+        }
 
-            let base_artifact_id = strip_target_suffix(&meta_dep.artifact_id, maven_suffix);
-            let dep_key = format!("{}:{}", meta_dep.group_id, base_artifact_id);
+        // Parallel fetch — no shared mutable state.
+        let fetched: Vec<Result<(String, ArtifactMetadata), EngineError>> = to_fetch
+            .par_iter()
+            .map(|(group_id, per_target_artifact_id, version, cache_key)| {
+                let metadata = konvoy_util::metadata::fetch_artifact_metadata(
+                    group_id,
+                    per_target_artifact_id,
+                    version,
+                    maven_suffix,
+                )
+                .map_err(EngineError::Util)?;
+                Ok((cache_key.clone(), metadata))
+            })
+            .collect();
 
-            let resolved_version = state
-                .user_versions
-                .get(&dep_key)
-                .cloned()
-                .unwrap_or_else(|| meta_dep.version.clone());
+        // Merge fetched metadata into the cache (sequential, no contention).
+        for result in fetched {
+            let (cache_key, metadata) = result?;
+            state.metadata_cache.insert(cache_key, metadata);
+        }
 
-            // Already resolved — check for version conflict, then skip.
-            if let Some(existing) = state.resolved.get(&dep_key) {
-                check_version_conflict(
-                    existing,
-                    &resolved_version,
-                    &dep_key,
-                    &base_artifact_id,
-                    requirer.as_deref(),
-                )?;
-                if let Some(req) = &requirer {
-                    state
-                        .required_by_map
-                        .entry(dep_key)
-                        .or_default()
-                        .insert(req.clone());
+        // Process this level's entries sequentially using the now-populated cache.
+        for (group_id, artifact_id, version, requirer, path) in level {
+            let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
+            let cache_key = format!("{group_id}:{per_target_artifact_id}:{version}");
+            let metadata = match state.metadata_cache.get(&cache_key) {
+                Some(m) => m.clone(),
+                // Unreachable per the prefetch logic above: every entry in
+                // `level` either had its metadata already cached or was just
+                // fetched into the cache. Surface as a typed internal error
+                // so tests catch any future refactor that breaks the
+                // invariant instead of silently skipping the entry.
+                None => {
+                    return Err(EngineError::InternalInvariantViolated {
+                        context: format!(
+                            "BFS prefetch missed metadata for {group_id}:{artifact_id}-{maven_suffix}:{version}"
+                        ),
+                    });
                 }
-                continue;
-            }
-
-            let dep_name = base_artifact_id.clone();
-            let parent_name = requirer
-                .clone()
-                .or_else(|| {
-                    state
-                        .resolved
-                        .get(&format!("{group_id}:{artifact_id}"))
-                        .map(|d| d.name.clone())
-                })
-                .unwrap_or_else(|| "unknown".to_owned());
-
-            state
-                .required_by_map
-                .entry(dep_key.clone())
-                .or_default()
-                .insert(parent_name.clone());
-
-            // Check for cycles.
-            if path.contains(&dep_key) {
-                let cycle = format!("{} -> {dep_key}", path.join(" -> "));
-                return Err(EngineError::MavenDependencyCycle { cycle });
-            }
-
-            let new_dep = ResolvedMavenDep {
-                name: dep_name.clone(),
-                group_id: meta_dep.group_id.clone(),
-                artifact_id: base_artifact_id.clone(),
-                version: resolved_version.clone(),
-                required_by: vec![parent_name],
-                classifier: None,
             };
 
-            let mut child_path = path.clone();
-            child_path.push(dep_key.clone());
+            for meta_dep in &metadata.dependencies {
+                if is_filtered_dependency(&meta_dep.group_id, &meta_dep.artifact_id) {
+                    continue;
+                }
+                if meta_dep.version.is_empty() {
+                    continue;
+                }
 
-            state.resolved.insert(dep_key, new_dep);
-            state.queue.push_back((
-                meta_dep.group_id.clone(),
-                base_artifact_id,
-                resolved_version,
-                Some(dep_name),
-                child_path,
-            ));
+                let base_artifact_id = strip_target_suffix(&meta_dep.artifact_id, maven_suffix);
+                let dep_key = format!("{}:{}", meta_dep.group_id, base_artifact_id);
+
+                let resolved_version = state
+                    .user_versions
+                    .get(&dep_key)
+                    .cloned()
+                    .unwrap_or_else(|| meta_dep.version.clone());
+
+                // Already resolved — check for version conflict, then skip.
+                if let Some(existing) = state.resolved.get(&dep_key) {
+                    check_version_conflict(
+                        existing,
+                        &resolved_version,
+                        &dep_key,
+                        &base_artifact_id,
+                        requirer.as_deref(),
+                    )?;
+                    if let Some(req) = &requirer {
+                        state
+                            .required_by_map
+                            .entry(dep_key)
+                            .or_default()
+                            .insert(req.clone());
+                    }
+                    continue;
+                }
+
+                let dep_name = base_artifact_id.clone();
+                let parent_name = requirer
+                    .clone()
+                    .or_else(|| {
+                        state
+                            .resolved
+                            .get(&format!("{group_id}:{artifact_id}"))
+                            .map(|d| d.name.clone())
+                    })
+                    .unwrap_or_else(|| "unknown".to_owned());
+
+                state
+                    .required_by_map
+                    .entry(dep_key.clone())
+                    .or_default()
+                    .insert(parent_name.clone());
+
+                // Check for cycles.
+                if path.contains(&dep_key) {
+                    let cycle = format!("{} -> {dep_key}", path.join(" -> "));
+                    return Err(EngineError::MavenDependencyCycle { cycle });
+                }
+
+                let new_dep = ResolvedMavenDep {
+                    name: dep_name.clone(),
+                    group_id: meta_dep.group_id.clone(),
+                    artifact_id: base_artifact_id.clone(),
+                    version: resolved_version.clone(),
+                    required_by: vec![parent_name],
+                    classifier: None,
+                };
+
+                let mut child_path = path.clone();
+                child_path.push(dep_key.clone());
+
+                state.resolved.insert(dep_key, new_dep);
+                state.queue.push_back((
+                    meta_dep.group_id.clone(),
+                    base_artifact_id,
+                    resolved_version,
+                    Some(dep_name),
+                    child_path,
+                ));
+            }
         }
     }
 
@@ -560,42 +702,6 @@ fn resolve_transitive(
     });
 
     Ok(result)
-}
-
-// ---------------------------------------------------------------------------
-// Metadata caching
-// ---------------------------------------------------------------------------
-
-/// Fetch artifact metadata via the provider chain, with an in-memory cache.
-///
-/// Uses `fetch_artifact_metadata()` (`.module` first, POM fallback) and stores
-/// the result in `cache` keyed by `groupId:artifactId:version`.
-///
-/// # Errors
-///
-/// Returns an error if both `.module` and POM fetching/parsing fail.
-fn fetch_metadata_cached(
-    group_id: &str,
-    artifact_id: &str,
-    version: &str,
-    maven_suffix: &str,
-    cache: &mut HashMap<String, ArtifactMetadata>,
-) -> Result<ArtifactMetadata, EngineError> {
-    let key = format!("{group_id}:{artifact_id}:{version}");
-    if let Some(cached) = cache.get(&key) {
-        return Ok(cached.clone());
-    }
-
-    let metadata = konvoy_util::metadata::fetch_artifact_metadata(
-        group_id,
-        artifact_id,
-        version,
-        maven_suffix,
-    )
-    .map_err(EngineError::Util)?;
-
-    cache.insert(key, metadata.clone());
-    Ok(metadata)
 }
 
 // ---------------------------------------------------------------------------
@@ -1336,5 +1442,71 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
         let url = "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/atomicfu-linuxx64/0.23.1/atomicfu-linuxx64-0.23.1-cinterop-interop.klib";
         let cls = extract_classifier_from_url(url, "0.23.1");
         assert_eq!(cls.as_deref(), Some("cinterop-interop"));
+    }
+
+    // -------------------------------------------------------------------
+    // placeholder_lock
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn placeholder_lock_produces_maven_source_with_empty_targets_and_hash() {
+        // The placeholder is overwritten after download_dep completes, but its
+        // shape still matters: if the post-download replacement is ever skipped
+        // (e.g. an index miscount) the placeholder propagates into the
+        // lockfile. The empty `source_hash` is what the debug_assert in
+        // `update()` keys on to catch that bug.
+        let dep = ResolvedMavenDep {
+            name: "kotlinx-coroutines".to_owned(),
+            group_id: "org.jetbrains.kotlinx".to_owned(),
+            artifact_id: "kotlinx-coroutines-core".to_owned(),
+            version: "1.8.0".to_owned(),
+            required_by: vec!["root".to_owned()],
+            classifier: Some("cinterop-interop".to_owned()),
+        };
+        let coord = "org.jetbrains.kotlinx:kotlinx-coroutines-core";
+        let lock = placeholder_lock(&dep, coord);
+
+        assert_eq!(lock.name, "kotlinx-coroutines");
+        assert!(
+            lock.source_hash.is_empty(),
+            "placeholder source_hash must be empty so the debug_assert in update() fires if it leaks"
+        );
+        match &lock.source {
+            DepSource::Maven {
+                version,
+                maven,
+                targets,
+                required_by,
+                classifier,
+            } => {
+                assert_eq!(version, "1.8.0");
+                assert_eq!(maven, coord);
+                assert!(
+                    targets.is_empty(),
+                    "placeholder targets must be empty — they are filled by download_dep"
+                );
+                assert_eq!(required_by, &vec!["root".to_owned()]);
+                assert_eq!(classifier.as_deref(), Some("cinterop-interop"));
+            }
+            other => panic!("expected Maven source, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn placeholder_lock_no_classifier_for_main_klib() {
+        // The classifier flows through unchanged; for a regular dep it stays None.
+        let dep = ResolvedMavenDep {
+            name: "atomicfu".to_owned(),
+            group_id: "org.jetbrains.kotlinx".to_owned(),
+            artifact_id: "atomicfu".to_owned(),
+            version: "0.23.1".to_owned(),
+            required_by: Vec::new(),
+            classifier: None,
+        };
+        let lock = placeholder_lock(&dep, "org.jetbrains.kotlinx:atomicfu");
+        match &lock.source {
+            DepSource::Maven { classifier, .. } => assert!(classifier.is_none()),
+            other => panic!("expected Maven source, got: {other:?}"),
+        }
     }
 }

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -17,8 +17,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 
-use indicatif::MultiProgress;
-use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use indicatif::{MultiProgress, ProgressBar};
+use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile};
 use konvoy_config::manifest::Manifest;
@@ -66,19 +66,24 @@ fn placeholder_lock(dep: &ResolvedMavenDep, maven_coord: &str) -> DependencyLock
 /// Klibs are written directly into the shared Maven cache at
 /// `~/.konvoy/cache/maven/.../<artifact>-<version>.klib` so subsequent
 /// `konvoy build` runs reuse the verified file. Per-target downloads run in
-/// parallel via rayon and each renders its own progress bar under `multi` so
-/// the user sees a live vertical stack of bars updating concurrently.
+/// parallel via rayon and each renders into a pre-allocated progress bar (one
+/// per target, in `KNOWN_TARGETS` order) so the on-screen layout stays in
+/// the same stable rows regardless of completion order.
+///
+/// `bars` must have one entry per `KNOWN_TARGETS` element; caller-enforced
+/// via the zip in `update()`.
 fn download_dep(
     dep: &ResolvedMavenDep,
     cache_root: &Path,
-    multi: &MultiProgress,
+    bars: &[ProgressBar],
 ) -> Result<DependencyLock, EngineError> {
     let known_targets = konvoy_targets::KNOWN_TARGETS;
     let maven_coord = dep.key();
 
     let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> = known_targets
         .par_iter()
-        .map(|&target| download_target_klib(dep, target, cache_root, multi))
+        .zip(bars.par_iter())
+        .map(|(&target, bar)| download_target_klib(dep, target, cache_root, bar))
         .collect();
 
     let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
@@ -110,12 +115,13 @@ fn download_dep(
 /// Download a single dep's klib for one target and return `(target, sha256)`.
 ///
 /// Writes the klib to the shared Maven cache so `konvoy build` can reuse it
-/// without re-downloading. Renders its own bar in `multi`.
+/// without re-downloading. The bar is provided by the caller so the on-screen
+/// row is fixed and stable.
 fn download_target_klib(
     dep: &ResolvedMavenDep,
     target: konvoy_targets::Target,
     cache_root: &Path,
-    multi: &MultiProgress,
+    progress: &ProgressBar,
 ) -> Result<(konvoy_targets::Target, String), EngineError> {
     let maven_suffix = target.to_maven_suffix();
     let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
@@ -131,14 +137,9 @@ fn download_target_klib(
     }
     let url = coord.to_url(MAVEN_CENTRAL);
     let dest = coord.cache_path(cache_root);
-
-    let progress = konvoy_util::progress::add_download_bar(
-        multi,
-        format!("{} {} [{}]", dep.name, dep.version, target),
-    );
     let label = format!("{}:{}", dep.name, target);
 
-    let result = konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, &progress)
+    let result = konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, progress)
         .map_err(|e| match e {
             konvoy_util::error::UtilError::Download { message } => {
                 EngineError::LibraryDownloadFailed {
@@ -263,21 +264,50 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     // verified klibs without re-downloading.
     let cache_root: PathBuf = crate::plugin::maven_cache_root()?;
 
-    // Hosts all per-(dep, target) progress bars in a vertical stack on stderr.
-    // Indicatif handles interleaving from rayon workers safely.
+    // Hosts all per-(dep, target) bars. Bars are added in stable order
+    // (`needs_download` order × `KNOWN_TARGETS` order) BEFORE any parallel
+    // work starts so the on-screen rows stay fixed regardless of which
+    // download finishes first.
     let multi = MultiProgress::new();
+    let known_targets = konvoy_targets::KNOWN_TARGETS;
+
+    // Build labels once, then reuse them to compute the max width AND to
+    // construct the bars — avoids formatting each prefix twice.
+    let labels: Vec<Vec<String>> = needs_download
+        .iter()
+        .map(|(_, dep)| known_targets.iter().map(|&t| dep.bar_label(t)).collect())
+        .collect();
+    let prefix_width = labels
+        .iter()
+        .flat_map(|row| row.iter().map(String::len))
+        .max()
+        .unwrap_or(0);
+
+    let dep_bars: Vec<Vec<ProgressBar>> = labels
+        .into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|label| konvoy_util::progress::add_download_bar(&multi, label, prefix_width))
+                .collect()
+        })
+        .collect();
 
     // Download deps in parallel; per-target downloads are also parallel within
-    // each. Each (dep, target) renders its own live progress bar under `multi`.
+    // each. `zip` pairs each dep with its pre-allocated bar row, removing any
+    // index-based fallback.
     let download_results: Vec<Result<(usize, DependencyLock), EngineError>> = needs_download
         .par_iter()
-        .map(|(idx, dep)| {
-            let lock = download_dep(dep, &cache_root, &multi)?;
+        .zip(dep_bars.par_iter())
+        .map(|((idx, dep), bars)| {
+            let lock = download_dep(dep, &cache_root, bars)?;
             Ok((*idx, lock))
         })
         .collect();
 
-    multi.clear().ok();
+    // Bars remain on screen at their final state after `finish()` (called
+    // inside `download_with_progress`); the `MultiProgress` is dropped at end
+    // of scope which releases the draw region without clearing the rendered
+    // content.
 
     // Apply results in original order so the lockfile output is deterministic
     // (parallel downloads finish in arbitrary order, but the on-disk layout
@@ -352,6 +382,11 @@ impl ResolvedMavenDep {
     /// Render the `"groupId:artifactId"` key used in lockfile entries and BFS maps.
     fn key(&self) -> String {
         format!("{}:{}", self.group_id, self.artifact_id)
+    }
+
+    /// Render the human-readable label shown on a download progress bar.
+    fn bar_label(&self, target: konvoy_targets::Target) -> String {
+        format!("{} {} [{}]", self.name, self.version, target)
     }
 }
 

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -17,6 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 
+use indicatif::MultiProgress;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
 use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile};
@@ -60,37 +61,29 @@ fn placeholder_lock(dep: &ResolvedMavenDep, maven_coord: &str) -> DependencyLock
     }
 }
 
-/// Result of downloading one dep across all known targets.
-struct DownloadedDep {
-    lock: DependencyLock,
-    /// Pre-formatted multi-line summary; printed sequentially in dep order
-    /// after parallel work completes so the user sees deterministic output.
-    summary: String,
-}
-
 /// Download a Maven dep's klib for every known target and produce its lock entry.
 ///
 /// Klibs are written directly into the shared Maven cache at
 /// `~/.konvoy/cache/maven/.../<artifact>-<version>.klib` so subsequent
 /// `konvoy build` runs reuse the verified file. Per-target downloads run in
-/// parallel via rayon; logging is deferred — the caller prints `summary` in
-/// dep order so concurrent downloads do not reshuffle stderr between runs.
-fn download_dep(dep: &ResolvedMavenDep, cache_root: &Path) -> Result<DownloadedDep, EngineError> {
+/// parallel via rayon and each renders its own progress bar under `multi` so
+/// the user sees a live vertical stack of bars updating concurrently.
+fn download_dep(
+    dep: &ResolvedMavenDep,
+    cache_root: &Path,
+    multi: &MultiProgress,
+) -> Result<DependencyLock, EngineError> {
     let known_targets = konvoy_targets::KNOWN_TARGETS;
     let maven_coord = dep.key();
 
     let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> = known_targets
         .par_iter()
-        .map(|&target| download_target_klib(dep, target, cache_root))
+        .map(|&target| download_target_klib(dep, target, cache_root, multi))
         .collect();
 
     let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
-    let mut summary_lines: Vec<String> = Vec::with_capacity(known_targets.len() + 1);
-    summary_lines.push(format!("  Resolving {} {}...", dep.name, dep.version));
     for result in target_results {
         let (target, sha256) = result?;
-        let display_hash = crate::common::truncate_hash(&sha256, 16);
-        summary_lines.push(format!("    {target}: {display_hash}..."));
         targets_map.insert(target.to_string(), sha256);
     }
 
@@ -101,30 +94,28 @@ fn download_dep(dep: &ResolvedMavenDep, cache_root: &Path) -> Result<DownloadedD
         .join("\n");
     let source_hash = konvoy_util::hash::sha256_bytes(hash_input.as_bytes());
 
-    Ok(DownloadedDep {
-        lock: DependencyLock {
-            name: dep.name.clone(),
-            source: DepSource::Maven {
-                version: dep.version.clone(),
-                maven: maven_coord,
-                targets: targets_map,
-                required_by: dep.required_by.clone(),
-                classifier: dep.classifier.clone(),
-            },
-            source_hash,
+    Ok(DependencyLock {
+        name: dep.name.clone(),
+        source: DepSource::Maven {
+            version: dep.version.clone(),
+            maven: maven_coord,
+            targets: targets_map,
+            required_by: dep.required_by.clone(),
+            classifier: dep.classifier.clone(),
         },
-        summary: summary_lines.join("\n"),
+        source_hash,
     })
 }
 
 /// Download a single dep's klib for one target and return `(target, sha256)`.
 ///
 /// Writes the klib to the shared Maven cache so `konvoy build` can reuse it
-/// without re-downloading.
+/// without re-downloading. Renders its own bar in `multi`.
 fn download_target_klib(
     dep: &ResolvedMavenDep,
     target: konvoy_targets::Target,
     cache_root: &Path,
+    multi: &MultiProgress,
 ) -> Result<(konvoy_targets::Target, String), EngineError> {
     let maven_suffix = target.to_maven_suffix();
     let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
@@ -141,21 +132,23 @@ fn download_target_klib(
     let url = coord.to_url(MAVEN_CENTRAL);
     let dest = coord.cache_path(cache_root);
 
-    let result = konvoy_util::artifact::ensure_artifact(
-        &url,
-        &dest,
-        None,
-        &format!("{}:{}", dep.name, target),
-        &dep.version,
-    )
-    .map_err(|e| match e {
-        konvoy_util::error::UtilError::Download { message } => EngineError::LibraryDownloadFailed {
-            name: dep.name.clone(),
-            url: url.clone(),
-            message,
-        },
-        other => EngineError::Util(other),
-    })?;
+    let progress = konvoy_util::progress::add_download_bar(
+        multi,
+        format!("{} {} [{}]", dep.name, dep.version, target),
+    );
+    let label = format!("{}:{}", dep.name, target);
+
+    let result = konvoy_util::artifact::ensure_artifact(&url, &dest, None, &label, &progress)
+        .map_err(|e| match e {
+            konvoy_util::error::UtilError::Download { message } => {
+                EngineError::LibraryDownloadFailed {
+                    name: dep.name.clone(),
+                    url: url.clone(),
+                    message,
+                }
+            }
+            other => EngineError::Util(other),
+        })?;
 
     Ok((target, result.sha256))
 }
@@ -270,23 +263,29 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     // verified klibs without re-downloading.
     let cache_root: PathBuf = crate::plugin::maven_cache_root()?;
 
-    // Download deps in parallel; per-target downloads are parallel within each.
-    let download_results: Vec<Result<(usize, DownloadedDep), EngineError>> = needs_download
+    // Hosts all per-(dep, target) progress bars in a vertical stack on stderr.
+    // Indicatif handles interleaving from rayon workers safely.
+    let multi = MultiProgress::new();
+
+    // Download deps in parallel; per-target downloads are also parallel within
+    // each. Each (dep, target) renders its own live progress bar under `multi`.
+    let download_results: Vec<Result<(usize, DependencyLock), EngineError>> = needs_download
         .par_iter()
         .map(|(idx, dep)| {
-            let downloaded = download_dep(dep, &cache_root)?;
-            Ok((*idx, downloaded))
+            let lock = download_dep(dep, &cache_root, &multi)?;
+            Ok((*idx, lock))
         })
         .collect();
 
-    // Apply results in original order so both the lockfile and stderr output
-    // are deterministic across runs (parallel downloads finish in arbitrary
-    // order, but the user sees a stable summary).
+    multi.clear().ok();
+
+    // Apply results in original order so the lockfile output is deterministic
+    // (parallel downloads finish in arbitrary order, but the on-disk layout
+    // remains stable).
     for result in download_results {
-        let (idx, downloaded) = result?;
-        eprintln!("{}", downloaded.summary);
+        let (idx, lock) = result?;
         if let Some(slot) = new_dep_locks.get_mut(idx) {
-            *slot = downloaded.lock;
+            *slot = lock;
         }
     }
 

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -15,7 +15,7 @@
 //!    populated for transitive deps and `classifier` for non-primary artifacts.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
@@ -60,21 +60,30 @@ fn placeholder_lock(dep: &ResolvedMavenDep, maven_coord: &str) -> DependencyLock
     }
 }
 
+/// Result of downloading one dep across all known targets.
+struct DownloadedDep {
+    lock: DependencyLock,
+    /// Pre-formatted multi-line summary; printed sequentially in dep order
+    /// after parallel work completes so the user sees deterministic output.
+    summary: String,
+}
+
 /// Download a Maven dep's klib for every known target and produce its lock entry.
 ///
-/// Per-target downloads run in parallel via rayon; the final summary
-/// `eprintln!` is emitted once per dep so concurrent dep downloads don't
-/// interleave on stderr in confusing ways.
-fn download_dep(dep: &ResolvedMavenDep, tmp_base: &Path) -> Result<DependencyLock, EngineError> {
+/// Klibs are written directly into the shared Maven cache at
+/// `~/.konvoy/cache/maven/.../<artifact>-<version>.klib` so subsequent
+/// `konvoy build` runs reuse the verified file. Per-target downloads run in
+/// parallel via rayon; logging is deferred — the caller prints `summary` in
+/// dep order so concurrent downloads do not reshuffle stderr between runs.
+fn download_dep(dep: &ResolvedMavenDep, cache_root: &Path) -> Result<DownloadedDep, EngineError> {
     let known_targets = konvoy_targets::KNOWN_TARGETS;
     let maven_coord = dep.key();
 
     let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> = known_targets
         .par_iter()
-        .map(|&target| download_target_klib(dep, target, tmp_base))
+        .map(|&target| download_target_klib(dep, target, cache_root))
         .collect();
 
-    // Build a deterministic target hash map and a multi-line summary string.
     let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
     let mut summary_lines: Vec<String> = Vec::with_capacity(known_targets.len() + 1);
     summary_lines.push(format!("  Resolving {} {}...", dep.name, dep.version));
@@ -84,8 +93,6 @@ fn download_dep(dep: &ResolvedMavenDep, tmp_base: &Path) -> Result<DependencyLoc
         summary_lines.push(format!("    {target}: {display_hash}..."));
         targets_map.insert(target.to_string(), sha256);
     }
-    // Single eprintln for the whole dep so parallel deps don't interleave.
-    eprintln!("{}", summary_lines.join("\n"));
 
     let hash_input: String = targets_map
         .iter()
@@ -94,24 +101,30 @@ fn download_dep(dep: &ResolvedMavenDep, tmp_base: &Path) -> Result<DependencyLoc
         .join("\n");
     let source_hash = konvoy_util::hash::sha256_bytes(hash_input.as_bytes());
 
-    Ok(DependencyLock {
-        name: dep.name.clone(),
-        source: DepSource::Maven {
-            version: dep.version.clone(),
-            maven: maven_coord,
-            targets: targets_map,
-            required_by: dep.required_by.clone(),
-            classifier: dep.classifier.clone(),
+    Ok(DownloadedDep {
+        lock: DependencyLock {
+            name: dep.name.clone(),
+            source: DepSource::Maven {
+                version: dep.version.clone(),
+                maven: maven_coord,
+                targets: targets_map,
+                required_by: dep.required_by.clone(),
+                classifier: dep.classifier.clone(),
+            },
+            source_hash,
         },
-        source_hash,
+        summary: summary_lines.join("\n"),
     })
 }
 
 /// Download a single dep's klib for one target and return `(target, sha256)`.
+///
+/// Writes the klib to the shared Maven cache so `konvoy build` can reuse it
+/// without re-downloading.
 fn download_target_klib(
     dep: &ResolvedMavenDep,
     target: konvoy_targets::Target,
-    tmp_base: &Path,
+    cache_root: &Path,
 ) -> Result<(konvoy_targets::Target, String), EngineError> {
     let maven_suffix = target.to_maven_suffix();
     let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
@@ -126,14 +139,11 @@ fn download_target_klib(
         coord = coord.with_classifier(cls);
     }
     let url = coord.to_url(MAVEN_CENTRAL);
-
-    // Use a target- and dep-unique tmp filename so parallel downloads from
-    // different deps cannot collide on the same file.
-    let tmp_file = tmp_base.join(format!("{}-{}", dep.name, coord.filename()));
+    let dest = coord.cache_path(cache_root);
 
     let result = konvoy_util::artifact::ensure_artifact(
         &url,
-        &tmp_file,
+        &dest,
         None,
         &format!("{}:{}", dep.name, target),
         &dep.version,
@@ -146,8 +156,6 @@ fn download_target_klib(
         },
         other => EngineError::Util(other),
     })?;
-
-    let _ = std::fs::remove_file(&tmp_file);
 
     Ok((target, result.sha256))
 }
@@ -258,27 +266,27 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         }
     }
 
-    // One shared tmp dir for the whole update; cleaned up at the end.
-    let pid = std::process::id();
-    let tmp_base = std::env::temp_dir().join(format!("konvoy-update-{pid}"));
-    konvoy_util::fs::ensure_dir(&tmp_base)?;
+    // Download into the shared Maven cache so `konvoy build` can reuse the
+    // verified klibs without re-downloading.
+    let cache_root: PathBuf = crate::plugin::maven_cache_root()?;
 
     // Download deps in parallel; per-target downloads are parallel within each.
-    let download_results: Vec<Result<(usize, DependencyLock), EngineError>> = needs_download
+    let download_results: Vec<Result<(usize, DownloadedDep), EngineError>> = needs_download
         .par_iter()
         .map(|(idx, dep)| {
-            let lock = download_dep(dep, &tmp_base)?;
-            Ok((*idx, lock))
+            let downloaded = download_dep(dep, &cache_root)?;
+            Ok((*idx, downloaded))
         })
         .collect();
 
-    konvoy_util::fs::remove_dir_all_if_exists(&tmp_base)?;
-
-    // Apply results in original order so the lockfile output is deterministic.
+    // Apply results in original order so both the lockfile and stderr output
+    // are deterministic across runs (parallel downloads finish in arbitrary
+    // order, but the user sees a stable summary).
     for result in download_results {
-        let (idx, lock) = result?;
+        let (idx, downloaded) = result?;
+        eprintln!("{}", downloaded.summary);
         if let Some(slot) = new_dep_locks.get_mut(idx) {
-            *slot = lock;
+            *slot = downloaded.lock;
         }
     }
 
@@ -521,13 +529,22 @@ fn resolve_transitive(
     // that level in parallel, then process children sequentially so the
     // graph mutations remain race-free.
     while !state.queue.is_empty() {
-        // Drain the current level into a Vec.
-        let level: Vec<BfsEntry> = state.queue.drain(..).collect();
+        // Drain the current level into a Vec paired with its per-entry cache
+        // keys. The key derivation is identical for prefetch and post-fetch
+        // passes; compute it once.
+        let level: Vec<(BfsEntry, String)> = state
+            .queue
+            .drain(..)
+            .map(|entry| {
+                let cache_key = format!("{}:{}-{}:{}", entry.0, entry.1, maven_suffix, entry.2);
+                (entry, cache_key)
+            })
+            .collect();
 
         // Fold pre-fetch bookkeeping (required_by entries from `requirer`)
         // into the map before doing any I/O — these only depend on `requirer`
         // and `(group_id, artifact_id)`, not on the fetched metadata.
-        for (group_id, artifact_id, _version, requirer, _path) in &level {
+        for ((group_id, artifact_id, _version, requirer, _path), _cache_key) in &level {
             let key = format!("{group_id}:{artifact_id}");
             if let Some(req) = requirer {
                 state
@@ -538,23 +555,21 @@ fn resolve_transitive(
             }
         }
 
-        // Collect unique (group, artifact, version) tuples that need fetching
-        // and are not already in the metadata cache. Multiple entries in the
-        // queue may point at the same artifact via different paths.
-        let mut to_fetch: Vec<(String, String, String, String)> = Vec::new();
+        // Collect unique tuples that need fetching and are not already in the
+        // metadata cache. Multiple entries in the queue may point at the same
+        // artifact via different paths.
+        let mut to_fetch: Vec<(String, String, String, String)> = Vec::with_capacity(level.len());
         let mut seen_keys: BTreeSet<String> = BTreeSet::new();
-        for (group_id, artifact_id, version, _requirer, _path) in &level {
-            let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
-            let cache_key = format!("{group_id}:{per_target_artifact_id}:{version}");
-            if state.metadata_cache.contains_key(&cache_key) || !seen_keys.insert(cache_key.clone())
+        for ((group_id, artifact_id, version, _requirer, _path), cache_key) in &level {
+            if state.metadata_cache.contains_key(cache_key) || !seen_keys.insert(cache_key.clone())
             {
                 continue;
             }
             to_fetch.push((
                 group_id.clone(),
-                per_target_artifact_id,
+                format!("{artifact_id}-{maven_suffix}"),
                 version.clone(),
-                cache_key,
+                cache_key.clone(),
             ));
         }
 
@@ -580,21 +595,15 @@ fn resolve_transitive(
         }
 
         // Process this level's entries sequentially using the now-populated cache.
-        for (group_id, artifact_id, version, requirer, path) in level {
-            let per_target_artifact_id = format!("{artifact_id}-{maven_suffix}");
-            let cache_key = format!("{group_id}:{per_target_artifact_id}:{version}");
+        for ((group_id, artifact_id, _version, requirer, path), cache_key) in level {
+            // Every entry was either cached or just fetched above; a miss
+            // here means a logic bug. Surface as a typed error so tests catch
+            // future refactors that break this invariant.
             let metadata = match state.metadata_cache.get(&cache_key) {
                 Some(m) => m.clone(),
-                // Unreachable per the prefetch logic above: every entry in
-                // `level` either had its metadata already cached or was just
-                // fetched into the cache. Surface as a typed internal error
-                // so tests catch any future refactor that breaks the
-                // invariant instead of silently skipping the entry.
                 None => {
                     return Err(EngineError::InternalInvariantViolated {
-                        context: format!(
-                            "BFS prefetch missed metadata for {group_id}:{artifact_id}-{maven_suffix}:{version}"
-                        ),
+                        context: format!("BFS prefetch missed metadata for {cache_key}"),
                     });
                 }
             };

--- a/crates/konvoy-konanc/Cargo.toml
+++ b/crates/konvoy-konanc/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 flate2.workspace = true
+indicatif.workspace = true
 konvoy-util.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -196,6 +196,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
                 progress.inner(),
             ))
             .map_err(|e| map_download_err(version, e))?;
+        eprintln!();
 
         let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
         extract_tarball(&tmp_tarball, &tmp_extract, "Kotlin/Native", version)?;
@@ -254,6 +255,7 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
             progress.inner(),
         ))
         .map_err(|e| map_download_err(version, e))?;
+    eprintln!();
 
     let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
     extract_tarball(&tmp_tarball, &tmp_extract, "JRE", version)?;

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -190,11 +190,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
         let sha256 = progress
-            .finish(konvoy_util::download::download_with_progress(
-                &url,
-                &tmp_tarball,
-                progress.inner(),
-            ))
+            .run(|pb| konvoy_util::download::download_with_progress(&url, &tmp_tarball, pb))
             .map_err(|e| map_download_err(version, e))?;
         eprintln!();
 
@@ -249,11 +245,7 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
     let sha256 = progress
-        .finish(konvoy_util::download::download_with_progress(
-            &url,
-            &tmp_tarball,
-            progress.inner(),
-        ))
+        .run(|pb| konvoy_util::download::download_with_progress(&url, &tmp_tarball, pb))
         .map_err(|e| map_download_err(version, e))?;
     eprintln!();
 

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -189,13 +189,13 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
-        let download_result =
-            konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress.bar);
-        match &download_result {
-            Ok(_) => progress.mark_success(),
-            Err(_) => progress.mark_failure(),
-        }
-        let sha256 = download_result.map_err(|e| map_download_err(version, e))?;
+        let sha256 = progress
+            .finish(konvoy_util::download::download_with_progress(
+                &url,
+                &tmp_tarball,
+                progress.inner(),
+            ))
+            .map_err(|e| map_download_err(version, e))?;
 
         let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
         extract_tarball(&tmp_tarball, &tmp_extract, "Kotlin/Native", version)?;
@@ -247,13 +247,13 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
-    let download_result =
-        konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress.bar);
-    match &download_result {
-        Ok(_) => progress.mark_success(),
-        Err(_) => progress.mark_failure(),
-    }
-    let sha256 = download_result.map_err(|e| map_download_err(version, e))?;
+    let sha256 = progress
+        .finish(konvoy_util::download::download_with_progress(
+            &url,
+            &tmp_tarball,
+            progress.inner(),
+        ))
+        .map_err(|e| map_download_err(version, e))?;
 
     let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
     extract_tarball(&tmp_tarball, &tmp_extract, "JRE", version)?;

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -188,13 +188,9 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let prefix = format!(".tmp-{version}-");
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
-        let sha256 = konvoy_util::download::download_with_progress(
-            &url,
-            &tmp_tarball,
-            "Kotlin/Native",
-            version,
-        )
-        .map_err(|e| map_download_err(version, e))?;
+        let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
+        let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress)
+            .map_err(|e| map_download_err(version, e))?;
 
         let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
         extract_tarball(&tmp_tarball, &tmp_extract, "Kotlin/Native", version)?;
@@ -245,7 +241,8 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let prefix = format!(".tmp-{version}-jre-");
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
-    let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, "JRE", version)
+    let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
+    let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress)
         .map_err(|e| map_download_err(version, e))?;
 
     let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -189,8 +189,13 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
-        let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress)
-            .map_err(|e| map_download_err(version, e))?;
+        let download_result =
+            konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress.bar);
+        match &download_result {
+            Ok(_) => progress.mark_success(),
+            Err(_) => progress.mark_failure(),
+        }
+        let sha256 = download_result.map_err(|e| map_download_err(version, e))?;
 
         let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
         extract_tarball(&tmp_tarball, &tmp_extract, "Kotlin/Native", version)?;
@@ -242,8 +247,13 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
-    let sha256 = konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress)
-        .map_err(|e| map_download_err(version, e))?;
+    let download_result =
+        konvoy_util::download::download_with_progress(&url, &tmp_tarball, &progress.bar);
+    match &download_result {
+        Ok(_) => progress.mark_success(),
+        Err(_) => progress.mark_failure(),
+    }
+    let sha256 = download_result.map_err(|e| map_download_err(version, e))?;
 
     let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
     extract_tarball(&tmp_tarball, &tmp_extract, "JRE", version)?;

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -189,7 +189,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
-        let sha256 = konvoy_util::progress::stream_download(&url, &tmp_tarball, Some(&progress))
+        let sha256 = konvoy_util::progress::stream_with_bar(&url, &tmp_tarball, Some(&progress))
             .map_err(|e| map_download_err(version, e))?;
         eprintln!();
 
@@ -243,7 +243,7 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
-    let sha256 = konvoy_util::progress::stream_download(&url, &tmp_tarball, Some(&progress))
+    let sha256 = konvoy_util::progress::stream_with_bar(&url, &tmp_tarball, Some(&progress))
         .map_err(|e| map_download_err(version, e))?;
     eprintln!();
 

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -189,8 +189,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
-        let sha256 = progress
-            .run(|pb| konvoy_util::download::download_with_progress(&url, &tmp_tarball, pb))
+        let sha256 = konvoy_util::progress::stream_download(&url, &tmp_tarball, Some(&progress))
             .map_err(|e| map_download_err(version, e))?;
         eprintln!();
 
@@ -244,8 +243,7 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
-    let sha256 = progress
-        .run(|pb| konvoy_util::download::download_with_progress(&url, &tmp_tarball, pb))
+    let sha256 = konvoy_util::progress::stream_download(&url, &tmp_tarball, Some(&progress))
         .map_err(|e| map_download_err(version, e))?;
     eprintln!();
 

--- a/crates/konvoy-util/Cargo.toml
+++ b/crates/konvoy-util/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 glob.workspace = true
+indicatif.workspace = true
 rayon.workspace = true
 roxmltree.workspace = true
 serde.workspace = true

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::error::UtilError;
 
-/// Result of ensuring an artifact is available locally.
+/// Result of resolving an artifact locally — either a cache-hit reported by
+/// [`check_cached`] or a fresh fetch from [`download_artifact`].
 #[derive(Debug, Clone)]
 pub struct ArtifactResult {
     /// Path to the artifact on disk.

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -35,6 +35,32 @@ pub fn validate_version(version: &str) -> Result<(), UtilError> {
     Ok(())
 }
 
+/// Validate that a Maven group or artifact identifier is safe for filesystem paths.
+///
+/// Allows only `[a-zA-Z0-9._-]`. Must be non-empty and must not contain `..`
+/// path-traversal sequences. This protects functions that build cache paths
+/// from identifier components (e.g. `~/.konvoy/cache/pom/<group>/<artifact>-<version>.pom`).
+///
+/// # Errors
+/// Returns `UtilError::InvalidVersion` (re-used: the underlying constraint is
+/// identical) if the string is empty, contains disallowed characters, or
+/// contains a `..` sequence.
+pub fn validate_identifier(identifier: &str) -> Result<(), UtilError> {
+    // `..` would let a malicious coordinate escape the cache dir even though
+    // every individual character is in the allowed set (`.` and `.` are both ok).
+    if identifier.is_empty()
+        || identifier.contains("..")
+        || !identifier
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+    {
+        return Err(UtilError::InvalidVersion {
+            version: identifier.to_owned(),
+        });
+    }
+    Ok(())
+}
+
 /// Ensure a single-file artifact exists at `dest`, downloading from `url` if needed.
 ///
 /// Follows the same atomic-download pattern as the detekt JAR management:
@@ -172,6 +198,31 @@ mod tests {
     fn validate_version_rejects_special_chars() {
         assert!(validate_version("1.0; rm -rf /").is_err());
         assert!(validate_version("ver\0sion").is_err());
+    }
+
+    #[test]
+    fn validate_identifier_accepts_typical_maven_ids() {
+        assert!(validate_identifier("org.jetbrains.kotlinx").is_ok());
+        assert!(validate_identifier("kotlinx-coroutines-core").is_ok());
+        assert!(validate_identifier("kotlin_stdlib").is_ok());
+        assert!(validate_identifier("a").is_ok());
+    }
+
+    #[test]
+    fn validate_identifier_rejects_path_traversal() {
+        assert!(validate_identifier("..").is_err());
+        assert!(validate_identifier("..foo").is_err());
+        assert!(validate_identifier("foo..bar").is_err());
+        assert!(validate_identifier("../etc").is_err());
+    }
+
+    #[test]
+    fn validate_identifier_rejects_empty_and_special_chars() {
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("foo/bar").is_err());
+        assert!(validate_identifier("foo bar").is_err());
+        assert!(validate_identifier("foo\0bar").is_err());
+        assert!(validate_identifier("foo:bar").is_err());
     }
 
     #[test]

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -2,8 +2,6 @@
 
 use std::path::{Path, PathBuf};
 
-use indicatif::ProgressBar;
-
 use crate::error::UtilError;
 
 /// Result of ensuring an artifact is available locally.
@@ -117,20 +115,22 @@ pub fn check_cached(
 /// 5. Clean up the temp file on all error paths.
 ///
 /// Callers should normally check [`check_cached`] first and only invoke
-/// this on a cache miss. The bar is provided because this function is the
-/// origin of progress events — pair it with [`crate::progress::DownloadBar::run`]
-/// or [`crate::progress::run_with_optional_bar`].
+/// this on a cache miss. `on_progress(downloaded, total)` is invoked once
+/// per chunk; the UI layer (`konvoy_util::progress`) wires this to a bar.
 ///
 /// # Errors
 /// Returns an error if the download fails, the hash does not match, or an
 /// I/O operation fails.
-pub fn download_artifact(
+pub fn download_artifact<F>(
     url: &str,
     dest: &Path,
     expected_sha256: Option<&str>,
     label: &str,
-    progress: &ProgressBar,
-) -> Result<ArtifactResult, UtilError> {
+    on_progress: F,
+) -> Result<ArtifactResult, UtilError>
+where
+    F: FnMut(u64, Option<u64>),
+{
     // Create parent directories.
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|source| UtilError::Io {
@@ -149,7 +149,7 @@ pub fn download_artifact(
         .unwrap_or_else(|| PathBuf::from(&tmp_name));
 
     // Download to temp file.
-    let download_hash = crate::download::download_with_progress(url, &tmp_path, progress)?;
+    let download_hash = crate::download::stream_download(url, &tmp_path, on_progress)?;
 
     // Verify hash of downloaded file before placing it.
     if let Some(expected) = expected_sha256 {
@@ -330,7 +330,7 @@ mod tests {
             &dest,
             None,
             "test",
-            &crate::progress::hidden_bar(),
+            |_, _| {},
         );
 
         assert!(result.is_err());

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -63,49 +63,75 @@ pub fn validate_identifier(identifier: &str) -> Result<(), UtilError> {
     Ok(())
 }
 
-/// Ensure a single-file artifact exists at `dest`, downloading from `url` if needed.
+/// Check whether `dest` is already on disk with the expected SHA-256.
 ///
-/// Follows the same atomic-download pattern as the detekt JAR management:
+/// Returns:
+/// - `Ok(Some(ArtifactResult))` if the file exists and (when `expected_sha256`
+///   is `Some`) its hash matches.
+/// - `Ok(None)` if the file does not exist — caller should download.
+/// - `Err(UtilError::ArtifactHashMismatch)` if the file exists but its hash
+///   does not match `expected_sha256` (this is a hard error, not a "go
+///   re-download" signal: a hash mismatch on a cached artifact usually
+///   means the lockfile is stale or the cache was tampered with).
+/// - Other `UtilError` variants for I/O failures reading the file.
 ///
-/// 1. If `dest` already exists, hash it and verify against `expected_sha256`
-///    (if provided). Return immediately with `freshly_downloaded = false`.
-/// 2. If missing, create parent directories, download to a temp file, verify
-///    the hash, then atomically rename into place.
-/// 3. Handle the race condition where another process downloads the artifact
-///    concurrently: if the rename fails but `dest` now exists, verify the
-///    placed file's hash.
-/// 4. Clean up the temp file on all error paths.
+/// This function does no UI work. Pair it with [`download_artifact`] when
+/// the result is `None`.
+///
+/// # Errors
+/// See above.
+pub fn check_cached(
+    dest: &Path,
+    expected_sha256: Option<&str>,
+) -> Result<Option<ArtifactResult>, UtilError> {
+    if !dest.exists() {
+        return Ok(None);
+    }
+    let actual_hash = crate::hash::sha256_file(dest)?;
+    if let Some(expected) = expected_sha256 {
+        if actual_hash != expected {
+            return Err(UtilError::ArtifactHashMismatch {
+                path: dest.display().to_string(),
+                expected: expected.to_owned(),
+                actual: actual_hash,
+            });
+        }
+    }
+    Ok(Some(ArtifactResult {
+        path: dest.to_path_buf(),
+        sha256: actual_hash,
+        freshly_downloaded: false,
+    }))
+}
+
+/// Download `url` to `dest`, atomically placing the file once the hash is
+/// verified.
+///
+/// Steps:
+/// 1. Create parent directories.
+/// 2. Download to a `.tmp-{label}-{pid}` sibling.
+/// 3. Verify the hash of the downloaded bytes.
+/// 4. Atomically rename into place. If another process already placed a
+///    file at `dest` concurrently (TOCTOU with `check_cached`), verify the
+///    placed file's hash and report it as the result.
+/// 5. Clean up the temp file on all error paths.
+///
+/// Callers should normally check [`check_cached`] first and only invoke
+/// this on a cache miss. The bar is provided because this function is the
+/// origin of progress events — pair it with [`crate::progress::DownloadBar::run`]
+/// or [`crate::progress::run_with_optional_bar`].
 ///
 /// # Errors
 /// Returns an error if the download fails, the hash does not match, or an
 /// I/O operation fails.
-pub fn ensure_artifact(
+pub fn download_artifact(
     url: &str,
     dest: &Path,
     expected_sha256: Option<&str>,
     label: &str,
     progress: &ProgressBar,
 ) -> Result<ArtifactResult, UtilError> {
-    // 1. If the file already exists, verify its hash and return early.
-    if dest.exists() {
-        let actual_hash = crate::hash::sha256_file(dest)?;
-        if let Some(expected) = expected_sha256 {
-            if actual_hash != expected {
-                return Err(UtilError::ArtifactHashMismatch {
-                    path: dest.display().to_string(),
-                    expected: expected.to_owned(),
-                    actual: actual_hash,
-                });
-            }
-        }
-        return Ok(ArtifactResult {
-            path: dest.to_path_buf(),
-            sha256: actual_hash,
-            freshly_downloaded: false,
-        });
-    }
-
-    // 2. Create parent directories.
+    // Create parent directories.
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|source| UtilError::Io {
             path: parent.display().to_string(),
@@ -137,7 +163,7 @@ pub fn ensure_artifact(
         }
     }
 
-    // 3. Atomic rename into final location.
+    // Atomic rename into final location.
     match std::fs::rename(&tmp_path, dest) {
         Ok(()) => {}
         Err(_) if dest.exists() => {
@@ -228,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_artifact_returns_existing_with_correct_hash() {
+    fn check_cached_returns_some_with_correct_hash() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("artifact.jar");
         let content = b"test artifact content";
@@ -236,14 +262,7 @@ mod tests {
 
         let expected_hash = crate::hash::sha256_bytes(content);
 
-        let result = ensure_artifact(
-            "http://unused.example.com/artifact.jar",
-            &dest,
-            Some(&expected_hash),
-            "test",
-            &crate::progress::hidden_bar(),
-        )
-        .unwrap();
+        let result = check_cached(&dest, Some(&expected_hash)).unwrap().unwrap();
 
         assert!(!result.freshly_downloaded);
         assert_eq!(result.sha256, expected_hash);
@@ -251,19 +270,21 @@ mod tests {
     }
 
     #[test]
-    fn ensure_artifact_errors_on_hash_mismatch() {
+    fn check_cached_returns_none_for_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("missing.jar");
+        let result = check_cached(&dest, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn check_cached_errors_on_hash_mismatch() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("artifact.jar");
         std::fs::write(&dest, b"some content").unwrap();
 
         let bogus_hash = "0000000000000000000000000000000000000000000000000000000000000000";
-        let result = ensure_artifact(
-            "http://unused.example.com/artifact.jar",
-            &dest,
-            Some(bogus_hash),
-            "test",
-            &crate::progress::hidden_bar(),
-        );
+        let result = check_cached(&dest, Some(bogus_hash));
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -285,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_artifact_returns_existing_without_expected_hash() {
+    fn check_cached_returns_some_without_expected_hash() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("artifact.jar");
         let content = b"no hash check content";
@@ -293,25 +314,18 @@ mod tests {
 
         let expected_hash = crate::hash::sha256_bytes(content);
 
-        let result = ensure_artifact(
-            "http://unused.example.com/artifact.jar",
-            &dest,
-            None,
-            "test",
-            &crate::progress::hidden_bar(),
-        )
-        .unwrap();
+        let result = check_cached(&dest, None).unwrap().unwrap();
 
         assert!(!result.freshly_downloaded);
         assert_eq!(result.sha256, expected_hash);
     }
 
     #[test]
-    fn ensure_artifact_errors_on_invalid_url() {
+    fn download_artifact_errors_on_invalid_url() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("missing.jar");
 
-        let result = ensure_artifact(
+        let result = download_artifact(
             "http://127.0.0.1:1/nonexistent",
             &dest,
             None,

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use indicatif::ProgressBar;
+
 use crate::error::UtilError;
 
 /// Result of ensuring an artifact is available locally.
@@ -82,7 +84,7 @@ pub fn ensure_artifact(
     dest: &Path,
     expected_sha256: Option<&str>,
     label: &str,
-    version: &str,
+    progress: &ProgressBar,
 ) -> Result<ArtifactResult, UtilError> {
     // 1. If the file already exists, verify its hash and return early.
     if dest.exists() {
@@ -121,7 +123,7 @@ pub fn ensure_artifact(
         .unwrap_or_else(|| PathBuf::from(&tmp_name));
 
     // Download to temp file.
-    let download_hash = crate::download::download_with_progress(url, &tmp_path, label, version)?;
+    let download_hash = crate::download::download_with_progress(url, &tmp_path, progress)?;
 
     // Verify hash of downloaded file before placing it.
     if let Some(expected) = expected_sha256 {
@@ -239,7 +241,7 @@ mod tests {
             &dest,
             Some(&expected_hash),
             "test",
-            "1.0.0",
+            &crate::progress::hidden_bar(),
         )
         .unwrap();
 
@@ -260,7 +262,7 @@ mod tests {
             &dest,
             Some(bogus_hash),
             "test",
-            "1.0.0",
+            &crate::progress::hidden_bar(),
         );
 
         assert!(result.is_err());
@@ -296,7 +298,7 @@ mod tests {
             &dest,
             None,
             "test",
-            "1.0.0",
+            &crate::progress::hidden_bar(),
         )
         .unwrap();
 
@@ -314,7 +316,7 @@ mod tests {
             &dest,
             None,
             "test",
-            "1.0.0",
+            &crate::progress::hidden_bar(),
         );
 
         assert!(result.is_err());

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -42,15 +42,9 @@ pub fn download_with_progress(
     dest: &Path,
     progress: &ProgressBar,
 ) -> Result<String, UtilError> {
-    download_inner(url, dest, progress)
     // Caller (engine layer holding a `DownloadBar`) finalises the bar via
-    // `DownloadBar::mark_success` / `mark_failure`, which flips state THEN
-    // calls `abandon()` — order matters so the final frame reflects state.
-}
-
-/// Inner download routine. Drives the byte stream and bar position; wrapper
-/// above flips the state indicator (✅/❌) once the result is known.
-fn download_inner(url: &str, dest: &Path, progress: &ProgressBar) -> Result<String, UtilError> {
+    // `DownloadBar::finish` after this returns — state must flip BEFORE
+    // `abandon()` halts redraws so the final frame reflects success/failure.
     let agent = http_agent(600);
 
     let response = agent.get(url).call().map_err(|e| UtilError::Download {
@@ -65,12 +59,13 @@ fn download_inner(url: &str, dest: &Path, progress: &ProgressBar) -> Result<Stri
 
     // The bar's `position` tracks the actual downloaded byte count so the
     // template's `{bytes}` and `{bytes_per_sec}` fields read correctly. The
-    // right-to-left fill effect is handled by the custom `{kbar}` renderer
-    // in `progress.rs`, which computes its edge index from `(len - pos)`.
+    // right-to-left fill is handled inside the custom `{kbar}` renderer
+    // (`progress.rs::render_truck_bar`), which computes its edge from
+    // `(len - pos)`. If `Content-Length` is missing, `set_length` is never
+    // called and the renderer's `len == 0` branch shows an all-road bar
+    // with the truck (or crash glyph on failure) at the right edge.
     if let Some(total) = content_length.filter(|t| *t > 0) {
         progress.set_length(total);
-    } else {
-        crate::progress::switch_to_spinner(progress);
     }
 
     let mut body = response.into_body();

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -26,23 +26,29 @@ pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
 
 /// Stream a URL to a file, calling `on_progress` as bytes arrive and computing SHA-256.
 ///
+/// Pure network primitive: no UI dependencies. Callers in
+/// [`crate::artifact`] and [`crate::progress`] adapt it to higher-level
+/// flows; engine code should not call this directly — use
+/// [`crate::progress::stream_with_bar`] for tarballs or
+/// [`crate::progress::fetch`] for hash-verified artifacts.
+///
 /// `on_progress(downloaded, total)` is invoked after each chunk:
 /// - `downloaded`: cumulative bytes written so far
 /// - `total`: `Content-Length` from the response (or `None` if absent)
 ///
-/// `total` is `None` until the response headers are parsed and the server
-/// advertises a content length; from the first chunk onward it's either
-/// always `Some(n)` for the same `n` or always `None`.
-///
-/// This function knows nothing about progress bars — callers in
-/// `konvoy_util::progress` adapt it.
+/// `total` is consistent across chunks — either always `Some(n)` for the
+/// same `n` or always `None`.
 ///
 /// Returns the hex-encoded SHA-256 hash of the downloaded content.
 ///
 /// # Errors
 /// Returns an error if the HTTP request fails, the file cannot be written,
 /// or a read error occurs during streaming.
-pub fn stream_download<F>(url: &str, dest: &Path, mut on_progress: F) -> Result<String, UtilError>
+pub(crate) fn stream_download<F>(
+    url: &str,
+    dest: &Path,
+    mut on_progress: F,
+) -> Result<String, UtilError>
 where
     F: FnMut(u64, Option<u64>),
 {

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -2,7 +2,6 @@
 
 use std::path::Path;
 
-use indicatif::ProgressBar;
 use sha2::{Digest, Sha256};
 
 use crate::error::UtilError;
@@ -25,26 +24,28 @@ pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
     )
 }
 
-/// Download a URL to a file, updating `progress` as bytes arrive and computing SHA-256.
+/// Stream a URL to a file, calling `on_progress` as bytes arrive and computing SHA-256.
 ///
-/// The caller owns the `ProgressBar` — set its prefix/style before calling so
-/// it can host a single download or attach to a [`indicatif::MultiProgress`].
-/// If the response has a `Content-Length`, the bar's length is set; otherwise
-/// the bar is switched to spinner mode.
+/// `on_progress(downloaded, total)` is invoked after each chunk:
+/// - `downloaded`: cumulative bytes written so far
+/// - `total`: `Content-Length` from the response (or `None` if absent)
+///
+/// `total` is `None` until the response headers are parsed and the server
+/// advertises a content length; from the first chunk onward it's either
+/// always `Some(n)` for the same `n` or always `None`.
+///
+/// This function knows nothing about progress bars — callers in
+/// `konvoy_util::progress` adapt it.
 ///
 /// Returns the hex-encoded SHA-256 hash of the downloaded content.
 ///
 /// # Errors
 /// Returns an error if the HTTP request fails, the file cannot be written,
 /// or a read error occurs during streaming.
-pub fn download_with_progress(
-    url: &str,
-    dest: &Path,
-    progress: &ProgressBar,
-) -> Result<String, UtilError> {
-    // Caller (engine layer holding a `DownloadBar`) finalises the bar via
-    // `DownloadBar::finish` after this returns — state must flip BEFORE
-    // `abandon()` halts redraws so the final frame reflects success/failure.
+pub fn stream_download<F>(url: &str, dest: &Path, mut on_progress: F) -> Result<String, UtilError>
+where
+    F: FnMut(u64, Option<u64>),
+{
     let agent = http_agent(600);
 
     let response = agent.get(url).call().map_err(|e| UtilError::Download {
@@ -55,18 +56,8 @@ pub fn download_with_progress(
         .headers()
         .get("content-length")
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse().ok());
-
-    // The bar's `position` tracks the actual downloaded byte count so the
-    // template's `{bytes}` and `{bytes_per_sec}` fields read correctly. The
-    // right-to-left fill is handled inside the custom `{kbar}` renderer
-    // (`progress.rs::render_truck_bar`), which computes its edge from
-    // `(len - pos)`. If `Content-Length` is missing, `set_length` is never
-    // called and the renderer's `len == 0` branch shows an all-road bar
-    // with the truck (or crash glyph on failure) at the right edge.
-    if let Some(total) = content_length.filter(|t| *t > 0) {
-        progress.set_length(total);
-    }
+        .and_then(|s| s.parse().ok())
+        .filter(|t: &u64| *t > 0);
 
     let mut body = response.into_body();
     let mut file = std::fs::File::create(dest).map_err(|source| UtilError::Io {
@@ -98,7 +89,7 @@ pub fn download_with_progress(
         hasher.update(chunk);
 
         downloaded = downloaded.saturating_add(u64_from_usize(n));
-        progress.set_position(downloaded);
+        on_progress(downloaded, content_length);
     }
 
     Ok(finalize_hex(hasher))
@@ -107,8 +98,10 @@ pub fn download_with_progress(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::u64_from_usize;
-    use crate::progress::hidden_bar;
+    use super::{stream_download, u64_from_usize};
+
+    /// No-op progress callback used by tests that don't care about events.
+    fn ignore_progress(_: u64, _: Option<u64>) {}
 
     #[test]
     fn u64_from_usize_roundtrips() {
@@ -127,8 +120,7 @@ mod tests {
     fn download_invalid_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result =
-            super::download_with_progress("http://127.0.0.1:1/nonexistent", &dest, &hidden_bar());
+        let result = stream_download("http://127.0.0.1:1/nonexistent", &dest, ignore_progress);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("download failed"), "error was: {err}");
@@ -138,16 +130,16 @@ mod tests {
     fn download_malformed_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result = super::download_with_progress("not-a-valid-url", &dest, &hidden_bar());
+        let result = stream_download("not-a-valid-url", &dest, ignore_progress);
         assert!(result.is_err());
     }
 
     #[test]
     fn download_unwritable_dest_returns_error() {
-        let result = super::download_with_progress(
+        let result = stream_download(
             "http://127.0.0.1:1/file.bin",
             std::path::Path::new("/nonexistent_root/subdir/out.bin"),
-            &hidden_bar(),
+            ignore_progress,
         );
         assert!(result.is_err());
     }

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -55,7 +55,14 @@ pub fn download_with_progress(
         .and_then(|s| s.parse().ok());
 
     match content_length {
-        Some(total) if total > 0 => progress.set_length(total),
+        Some(total) if total > 0 => {
+            progress.set_length(total);
+            // Force the bar to redraw with the new length before the download
+            // races to completion. `set_length` alone does not trigger a redraw
+            // on `MultiProgress` children at indicatif's 20Hz throttle, so a
+            // sub-50ms download can finish before the length ever renders.
+            progress.set_position(0);
+        }
         _ => crate::progress::switch_to_spinner(progress),
     }
 

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use indicatif::ProgressBar;
 use sha2::{Digest, Sha256};
 
 use crate::error::UtilError;
@@ -10,16 +11,6 @@ use crate::hash::finalize_hex;
 /// Convert `usize` to `u64`. Infallible on 32-bit and 64-bit platforms.
 fn u64_from_usize(n: usize) -> u64 {
     u64::try_from(n).unwrap_or(u64::MAX)
-}
-
-/// Compute download percentage as a `u8` (0..=100).
-///
-/// Returns 0 when `total` is 0 to avoid division by zero.
-fn pct_u8(downloaded: u64, total: u64) -> u8 {
-    if total == 0 {
-        return 0;
-    }
-    u8::try_from((downloaded * 100) / total).unwrap_or(100)
 }
 
 /// Create an HTTP agent with the given global timeout.
@@ -34,7 +25,12 @@ pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
     )
 }
 
-/// Download a URL to a file, showing progress on stderr and computing SHA-256.
+/// Download a URL to a file, updating `progress` as bytes arrive and computing SHA-256.
+///
+/// The caller owns the `ProgressBar` — set its prefix/style before calling so
+/// it can host a single download or attach to a [`indicatif::MultiProgress`].
+/// If the response has a `Content-Length`, the bar's length is set; otherwise
+/// the bar is switched to spinner mode.
 ///
 /// Returns the hex-encoded SHA-256 hash of the downloaded content.
 ///
@@ -44,8 +40,7 @@ pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
 pub fn download_with_progress(
     url: &str,
     dest: &Path,
-    label: &str,
-    version: &str,
+    progress: &ProgressBar,
 ) -> Result<String, UtilError> {
     let agent = http_agent(600);
 
@@ -59,6 +54,11 @@ pub fn download_with_progress(
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse().ok());
 
+    match content_length {
+        Some(total) if total > 0 => progress.set_length(total),
+        _ => crate::progress::switch_to_spinner(progress),
+    }
+
     let mut body = response.into_body();
     let mut file = std::fs::File::create(dest).map_err(|source| UtilError::Io {
         path: dest.display().to_string(),
@@ -67,7 +67,6 @@ pub fn download_with_progress(
 
     let mut hasher = Sha256::new();
     let mut downloaded: u64 = 0;
-    let mut last_pct: u8 = 0;
     let mut buf = vec![0u8; 64 * 1024];
 
     loop {
@@ -90,58 +89,18 @@ pub fn download_with_progress(
         hasher.update(chunk);
 
         downloaded = downloaded.saturating_add(u64_from_usize(n));
-
-        if let Some(total) = content_length {
-            if total > 0 {
-                let pct = pct_u8(downloaded, total);
-                if pct != last_pct && pct.is_multiple_of(10) {
-                    eprint!("\r    Downloading {label} {version}... {pct}%");
-                    last_pct = pct;
-                }
-            }
-        }
+        progress.set_position(downloaded);
     }
 
-    if content_length.is_some() {
-        eprintln!("\r    Downloading {label} {version}... done   ");
-    } else {
-        let kb = downloaded / 1024;
-        if kb >= 1024 {
-            let mb = (kb + 512) / 1024;
-            eprintln!("    Downloaded {label} {version} ({mb} MB)");
-        } else {
-            eprintln!("    Downloaded {label} {version} ({kb} KB)");
-        }
-    }
-
+    progress.finish();
     Ok(finalize_hex(hasher))
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::{pct_u8, u64_from_usize};
-
-    #[test]
-    fn pct_u8_zero_total_returns_zero() {
-        assert_eq!(pct_u8(0, 0), 0);
-        assert_eq!(pct_u8(100, 0), 0);
-    }
-
-    #[test]
-    fn pct_u8_basic_percentages() {
-        assert_eq!(pct_u8(0, 100), 0);
-        assert_eq!(pct_u8(50, 100), 50);
-        assert_eq!(pct_u8(100, 100), 100);
-    }
-
-    #[test]
-    fn pct_u8_over_100_saturates() {
-        // When downloaded > total, the ratio exceeds 100.
-        // Values above 255 clamp to 100 via unwrap_or.
-        assert_eq!(pct_u8(200, 100), 200); // 200% fits in u8
-        assert_eq!(pct_u8(1000, 100), 100); // 1000% overflows u8 → clamps
-    }
+    use super::u64_from_usize;
+    use crate::progress::hidden_bar;
 
     #[test]
     fn u64_from_usize_roundtrips() {
@@ -150,40 +109,9 @@ mod tests {
     }
 
     #[test]
-    fn pct_u8_rounding_down() {
-        // Integer division truncates: 1/3 * 100 = 33, not 34.
-        assert_eq!(pct_u8(1, 3), 33);
-        assert_eq!(pct_u8(2, 3), 66);
-    }
-
-    #[test]
-    fn pct_u8_exact_multiples_of_ten() {
-        assert_eq!(pct_u8(10, 100), 10);
-        assert_eq!(pct_u8(20, 100), 20);
-        assert_eq!(pct_u8(90, 100), 90);
-    }
-
-    #[test]
-    fn pct_u8_large_values() {
-        // Test with large but non-overflowing u64 values.
-        let total: u64 = 1_000_000_000;
-        assert_eq!(pct_u8(500_000_000, total), 50);
-        assert_eq!(pct_u8(total, total), 100);
-    }
-
-    #[test]
-    fn pct_u8_one_byte_downloaded() {
-        // 1 byte out of 1000 is 0%.
-        assert_eq!(pct_u8(1, 1000), 0);
-        // 1 byte out of 1 is 100%.
-        assert_eq!(pct_u8(1, 1), 100);
-    }
-
-    #[test]
     fn u64_from_usize_max_value() {
         // usize::MAX should convert to u64 on 64-bit, or saturate to u64::MAX on 128-bit+.
         let result = u64_from_usize(usize::MAX);
-        // On 64-bit platforms, usize::MAX == u64::MAX; on 32-bit, it fits.
         assert!(result > 0);
     }
 
@@ -192,7 +120,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
         let result =
-            super::download_with_progress("http://127.0.0.1:1/nonexistent", &dest, "test", "0.0");
+            super::download_with_progress("http://127.0.0.1:1/nonexistent", &dest, &hidden_bar());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("download failed"), "error was: {err}");
@@ -202,22 +130,16 @@ mod tests {
     fn download_malformed_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result = super::download_with_progress("not-a-valid-url", &dest, "test", "0.0");
+        let result = super::download_with_progress("not-a-valid-url", &dest, &hidden_bar());
         assert!(result.is_err());
     }
 
     #[test]
     fn download_unwritable_dest_returns_error() {
-        // Destination directory that doesn't exist and can't be created is
-        // caught by File::create failing. However download_with_progress
-        // doesn't call ensure_dir — it trusts the caller. If the server
-        // rejects before writing, the download error comes first. Trying
-        // with a valid-looking URL to an unroutable host + bad dest path.
         let result = super::download_with_progress(
             "http://127.0.0.1:1/file.bin",
             std::path::Path::new("/nonexistent_root/subdir/out.bin"),
-            "test",
-            "0.0",
+            &hidden_bar(),
         );
         assert!(result.is_err());
     }

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -42,6 +42,15 @@ pub fn download_with_progress(
     dest: &Path,
     progress: &ProgressBar,
 ) -> Result<String, UtilError> {
+    download_inner(url, dest, progress)
+    // Caller (engine layer holding a `DownloadBar`) finalises the bar via
+    // `DownloadBar::mark_success` / `mark_failure`, which flips state THEN
+    // calls `abandon()` — order matters so the final frame reflects state.
+}
+
+/// Inner download routine. Drives the byte stream and bar position; wrapper
+/// above flips the state indicator (✅/❌) once the result is known.
+fn download_inner(url: &str, dest: &Path, progress: &ProgressBar) -> Result<String, UtilError> {
     let agent = http_agent(600);
 
     let response = agent.get(url).call().map_err(|e| UtilError::Download {
@@ -54,16 +63,14 @@ pub fn download_with_progress(
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse().ok());
 
-    match content_length {
-        Some(total) if total > 0 => {
-            progress.set_length(total);
-            // Force the bar to redraw with the new length before the download
-            // races to completion. `set_length` alone does not trigger a redraw
-            // on `MultiProgress` children at indicatif's 20Hz throttle, so a
-            // sub-50ms download can finish before the length ever renders.
-            progress.set_position(0);
-        }
-        _ => crate::progress::switch_to_spinner(progress),
+    // The bar's `position` tracks the actual downloaded byte count so the
+    // template's `{bytes}` and `{bytes_per_sec}` fields read correctly. The
+    // right-to-left fill effect is handled by the custom `{kbar}` renderer
+    // in `progress.rs`, which computes its edge index from `(len - pos)`.
+    if let Some(total) = content_length.filter(|t| *t > 0) {
+        progress.set_length(total);
+    } else {
+        crate::progress::switch_to_spinner(progress);
     }
 
     let mut body = response.into_body();
@@ -99,7 +106,6 @@ pub fn download_with_progress(
         progress.set_position(downloaded);
     }
 
-    progress.finish();
     Ok(finalize_hex(hasher))
 }
 

--- a/crates/konvoy-util/src/fs.rs
+++ b/crates/konvoy-util/src/fs.rs
@@ -325,9 +325,10 @@ mod tests {
         assert!(files.iter().any(|f| f.ends_with("beta.kt")));
     }
 
-    /// Guards tests that read or mutate HOME / USERPROFILE env vars so they
-    /// don't race with each other (env vars are process-wide shared state).
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Shared with `pom::tests` and `module_metadata::tests` via
+    // `crate::test_util::ENV_LOCK` so HOME-override tests in different
+    // modules don't race when `cargo test` runs them on multiple threads.
+    use crate::test_util::ENV_LOCK;
 
     #[test]
     fn konvoy_home_returns_dotkonvoy_subdir() {

--- a/crates/konvoy-util/src/lib.rs
+++ b/crates/konvoy-util/src/lib.rs
@@ -10,3 +10,6 @@ pub mod maven;
 pub mod metadata;
 pub mod module_metadata;
 pub mod pom;
+
+#[cfg(test)]
+pub(crate) mod test_util;

--- a/crates/konvoy-util/src/lib.rs
+++ b/crates/konvoy-util/src/lib.rs
@@ -10,6 +10,7 @@ pub mod maven;
 pub mod metadata;
 pub mod module_metadata;
 pub mod pom;
+pub mod progress;
 
 #[cfg(test)]
 pub(crate) mod test_util;

--- a/crates/konvoy-util/src/module_metadata.rs
+++ b/crates/konvoy-util/src/module_metadata.rs
@@ -126,23 +126,84 @@ pub fn module_metadata_url(group_id: &str, artifact_id: &str, version: &str) -> 
     crate::maven::maven_artifact_url(group_id, artifact_id, version, "module")
 }
 
+/// Build the on-disk cache path for a Gradle Module Metadata file.
+///
+/// Layout matches the POM cache scheme:
+/// `~/.konvoy/cache/pom/<group_path>/<artifact_id>-<version>.module`.
+/// (Same root directory; a different extension keeps POM and module entries
+/// from colliding.) Delegates to [`crate::pom::metadata_cache_path`] so both
+/// formats share validation and layout-versioning logic.
+fn module_cache_path(
+    group_id: &str,
+    artifact_id: &str,
+    version: &str,
+) -> Result<std::path::PathBuf, UtilError> {
+    crate::pom::metadata_cache_path(group_id, artifact_id, version, "module")
+}
+
+/// Build the 404-sentinel path that records "this artifact has no .module file".
+///
+/// Appends `.404` to the body filename. Fails loudly if the body path has no
+/// filename component — the caller (this module) always constructs the body
+/// via [`module_cache_path`], which guarantees a filename, so this is an
+/// invariant check rather than a user-facing error.
+fn module_404_sentinel_path(body: &std::path::Path) -> Result<std::path::PathBuf, UtilError> {
+    let file_name = body
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| UtilError::Io {
+            path: body.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cache path has no filename",
+            ),
+        })?;
+    let mut name = file_name.to_owned();
+    name.push_str(".404");
+    Ok(body.with_file_name(name))
+}
+
 /// Fetch a Gradle Module Metadata file from Maven Central.
 ///
 /// Returns `Ok(Some(json))` if the file exists, `Ok(None)` if the server
 /// returns a 404 (meaning the artifact does not publish `.module` files),
 /// or an error for other HTTP failures.
 ///
+/// Uses a disk cache at `~/.konvoy/cache/pom/<group_path>/<artifact_id>-<version>.module`.
+/// 404 responses are recorded by writing an empty sentinel file at
+/// `<path>.404`, so re-runs do not hit the network for known-missing
+/// artifacts. Cache writes are best-effort: failures are logged but the
+/// fetched content is still returned.
+///
 /// # Errors
 ///
-/// Returns `UtilError::Download` if the HTTP request fails with a non-404 error
-/// or the response body cannot be read.
+/// Returns `UtilError::Download` if the HTTP request fails with a non-404
+/// error or the response body cannot be read. Returns `UtilError::InvalidVersion`
+/// if any of `group_id`/`artifact_id`/`version` fail validation.
 pub fn fetch_module_metadata(
     group_id: &str,
     artifact_id: &str,
     version: &str,
 ) -> Result<Option<String>, UtilError> {
-    let url = module_metadata_url(group_id, artifact_id, version);
+    // 1. Try the disk cache. Check the body file first, then the 404 sentinel.
+    // Body file wins over the 404 sentinel if both exist. This recovers
+    // gracefully from the case where Maven Central publishes a previously
+    // missing artifact between two `konvoy update` runs.
+    let cache_path = module_cache_path(group_id, artifact_id, version)?;
+    if cache_path.exists() {
+        if let Ok(body) = std::fs::read_to_string(&cache_path) {
+            return Ok(Some(body));
+        }
+        // Cache read failed (truncated, permissions, etc.); fall through to
+        // fetch from network rather than block builds.
+    }
+    let sentinel_path = module_404_sentinel_path(&cache_path)?;
+    if sentinel_path.exists() {
+        return Ok(None);
+    }
 
+    // 2. Cache miss — fetch from Maven Central.
+    let url = module_metadata_url(group_id, artifact_id, version);
     let agent = crate::download::http_agent(60);
 
     match agent.get(&url).call() {
@@ -155,9 +216,26 @@ pub fn fetch_module_metadata(
                         "failed to read module metadata response body from {url}: {e}"
                     ),
                 })?;
+
+            if let Err(e) = crate::pom::write_cache_atomic(&cache_path, body.as_bytes()) {
+                eprintln!(
+                    "warning: failed to cache module metadata at {}: {e}",
+                    cache_path.display()
+                );
+            }
+
             Ok(Some(body))
         }
-        Err(ureq::Error::StatusCode(404)) => Ok(None),
+        Err(ureq::Error::StatusCode(404)) => {
+            // Persist the 404 so we don't re-hit the network on every run.
+            if let Err(e) = crate::pom::write_cache_atomic(&sentinel_path, &[]) {
+                eprintln!(
+                    "warning: failed to cache module 404 sentinel at {}: {e}",
+                    sentinel_path.display()
+                );
+            }
+            Ok(None)
+        }
         Err(e) => Err(UtilError::Download {
             message: format!("failed to fetch module metadata from {url}: {e}"),
         }),
@@ -504,6 +582,60 @@ mod tests {
     }
 
     #[test]
+    fn module_cache_path_uses_module_extension() {
+        let path = module_cache_path("com.example", "lib", "1.0.0").unwrap();
+        let suffix: std::path::PathBuf = ["cache", "pom", "com", "example", "lib-1.0.0.module"]
+            .iter()
+            .collect();
+        assert!(
+            path.ends_with(&suffix),
+            "expected {} to end with {}",
+            path.display(),
+            suffix.display()
+        );
+    }
+
+    #[test]
+    fn module_cache_path_rejects_path_traversal() {
+        assert!(module_cache_path("..", "lib", "1.0.0").is_err());
+        assert!(module_cache_path("com.ex", "..", "1.0.0").is_err());
+        assert!(module_cache_path("com.ex", "lib", "..").is_err());
+    }
+
+    #[test]
+    fn module_404_sentinel_path_appends_suffix() {
+        let body = std::path::PathBuf::from("/tmp/cache/pom/com/example/lib-1.0.0.module");
+        let sentinel = module_404_sentinel_path(&body).unwrap();
+        assert_eq!(
+            sentinel,
+            std::path::PathBuf::from("/tmp/cache/pom/com/example/lib-1.0.0.module.404")
+        );
+    }
+
+    #[test]
+    fn module_404_sentinel_path_rejects_path_without_filename() {
+        // An empty path has no file_name — the invariant check should fire.
+        let body = std::path::PathBuf::from("");
+        let result = module_404_sentinel_path(&body);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_module_metadata_rejects_path_traversal_in_group_id() {
+        let result = fetch_module_metadata("../etc/passwd", "lib", "1.0.0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_module_metadata_rejects_invalid_version() {
+        let err = fetch_module_metadata("com.example", "lib", "1.0/0").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion, got: {err:?}"
+        );
+    }
+
+    #[test]
     fn fetch_module_metadata_nonexistent_returns_none() {
         // Use a non-existent artifact to test 404 handling.
         let result = fetch_module_metadata("com.nonexistent.fake", "no-such-artifact", "0.0.0");
@@ -624,5 +756,109 @@ mod tests {
         assert_eq!(metadata.files.len(), 1);
         // sha256 is None because it was not present (sha512/md5 are different fields).
         assert!(metadata.files.first().unwrap().sha256.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // fetch_module_metadata — disk-cache behavior (HOME-override pattern)
+    // -----------------------------------------------------------------
+
+    /// Run `f` with HOME pointing at a tempdir, serialized against other
+    /// HOME-mutating tests. Restores HOME before assertions can panic.
+    fn with_fake_home<F, R>(f: F) -> R
+    where
+        F: FnOnce(&std::path::Path) -> R,
+    {
+        let _guard = crate::test_util::ENV_LOCK.lock().unwrap();
+
+        let saved_home = std::env::var("HOME").ok();
+        let saved_profile = std::env::var("USERPROFILE").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var("USERPROFILE");
+
+        // Catch any panic so we always restore the env.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(tmp.path())));
+
+        if let Some(v) = saved_home {
+            std::env::set_var("HOME", v);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(v) = saved_profile {
+            std::env::set_var("USERPROFILE", v);
+        }
+
+        match result {
+            Ok(r) => r,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+
+    #[test]
+    fn fetch_module_metadata_cache_hit_body_returns_some_without_network() {
+        // Pre-populate the body file; the function must return `Some(body)`
+        // without any HTTP I/O.
+        with_fake_home(|_home| {
+            let group = "com.example";
+            let artifact = "cached-mod";
+            let version = "1.0.0";
+            let body_path = module_cache_path(group, artifact, version).unwrap();
+            std::fs::create_dir_all(body_path.parent().unwrap()).unwrap();
+            let expected = r#"{"variants":[{"name":"x"}]}"#;
+            std::fs::write(&body_path, expected).unwrap();
+
+            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            assert_eq!(
+                result.as_deref(),
+                Some(expected),
+                "cache hit must return Some(body)"
+            );
+        });
+    }
+
+    #[test]
+    fn fetch_module_metadata_cache_hit_404_sentinel_returns_none() {
+        // Pre-populate ONLY the 404 sentinel; the function must return None
+        // without any HTTP I/O.
+        with_fake_home(|_home| {
+            let group = "com.example";
+            let artifact = "no-module";
+            let version = "1.0.0";
+            let body_path = module_cache_path(group, artifact, version).unwrap();
+            let sentinel = module_404_sentinel_path(&body_path).unwrap();
+            std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();
+            std::fs::write(&sentinel, b"").unwrap();
+
+            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            assert!(
+                result.is_none(),
+                "sentinel hit must return None (no .module published)"
+            );
+        });
+    }
+
+    #[test]
+    fn fetch_module_metadata_body_wins_over_404_sentinel() {
+        // If both the body and the sentinel exist (Maven Central started
+        // publishing a previously-missing artifact), the body must win.
+        // This is the recovery contract documented at the call site.
+        with_fake_home(|_home| {
+            let group = "com.example";
+            let artifact = "now-published";
+            let version = "1.0.0";
+            let body_path = module_cache_path(group, artifact, version).unwrap();
+            let sentinel = module_404_sentinel_path(&body_path).unwrap();
+            std::fs::create_dir_all(body_path.parent().unwrap()).unwrap();
+            let expected = r#"{"variants":[{"name":"y"}]}"#;
+            std::fs::write(&body_path, expected).unwrap();
+            std::fs::write(&sentinel, b"").unwrap();
+
+            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            assert_eq!(
+                result.as_deref(),
+                Some(expected),
+                "body file must take precedence over stale 404 sentinel"
+            );
+        });
     }
 }

--- a/crates/konvoy-util/src/pom.rs
+++ b/crates/konvoy-util/src/pom.rs
@@ -301,15 +301,149 @@ pub fn pom_url(group_id: &str, artifact_id: &str, version: &str) -> String {
     crate::maven::maven_artifact_url(group_id, artifact_id, version, "pom")
 }
 
+// Cache layout v1: <konvoy_home>/cache/pom/<group_path>/<artifact>-<version>.{pom,module,module.404}.
+// If the on-disk format ever changes, bump to v2 by introducing a subdirectory.
+
+/// Build the on-disk cache path for a Maven artifact metadata file.
+///
+/// Layout matches the contract in CLAUDE.md:
+/// `~/.konvoy/cache/pom/<group_path>/<artifact_id>-<version>.<extension>`.
+///
+/// `group_id` is split on `.` so that `org.jetbrains.kotlinx` becomes
+/// nested directories (matching Maven Central's own layout). The
+/// `extension` is `"pom"` for POM files or `"module"` for Gradle Module
+/// Metadata files; both share the same cache root so a single layout-version
+/// bump suffices for either format.
+///
+/// # Errors
+/// Returns an error if the home directory cannot be located, or any
+/// identifier/version component fails validation (path-traversal guard).
+pub(crate) fn metadata_cache_path(
+    group_id: &str,
+    artifact_id: &str,
+    version: &str,
+    extension: &str,
+) -> Result<std::path::PathBuf, UtilError> {
+    crate::artifact::validate_identifier(group_id)?;
+    crate::artifact::validate_identifier(artifact_id)?;
+    // `validate_identifier` is strictly stronger than `validate_version`
+    // (same charset plus `..` rejection), so a single call suffices.
+    crate::artifact::validate_identifier(version)?;
+
+    let mut path = crate::fs::konvoy_home()?.join("cache").join("pom");
+    for segment in group_id.split('.') {
+        // `validate_identifier` already rejects `..`, but be defensive against
+        // empty segments produced by leading/trailing dots.
+        if segment.is_empty() {
+            return Err(UtilError::InvalidVersion {
+                version: group_id.to_owned(),
+            });
+        }
+        path.push(segment);
+    }
+    path.push(format!("{artifact_id}-{version}.{extension}"));
+    Ok(path)
+}
+
+/// Build the on-disk cache path for a POM file.
+///
+/// Thin wrapper over [`metadata_cache_path`] with `extension = "pom"`.
+fn pom_cache_path(
+    group_id: &str,
+    artifact_id: &str,
+    version: &str,
+) -> Result<std::path::PathBuf, UtilError> {
+    metadata_cache_path(group_id, artifact_id, version, "pom")
+}
+
+/// Atomically write `contents` to `dest` via a temp file in the same directory.
+///
+/// Mirrors the pattern in `ensure_artifact`: write to a `.tmp-<pid>` sibling
+/// and rename into place. If another writer wins the race, the rename may fail
+/// but the destination exists with valid contents, which is what we want.
+///
+/// Returns `Ok(())` on success. On failure to create the parent directory or
+/// to write the temp file, returns the underlying I/O error. A failed rename
+/// when `dest` already exists is treated as success (another writer placed it).
+///
+/// # Errors
+/// Returns the underlying I/O error if the parent directory cannot be created
+/// or the temp file cannot be written. A rename failure where `dest` already
+/// exists is not treated as an error.
+pub(crate) fn write_cache_atomic(dest: &std::path::Path, contents: &[u8]) -> Result<(), UtilError> {
+    let parent = dest.parent().ok_or_else(|| UtilError::Io {
+        path: dest.display().to_string(),
+        source: std::io::Error::new(std::io::ErrorKind::InvalidInput, "cache path has no parent"),
+    })?;
+
+    std::fs::create_dir_all(parent).map_err(|source| UtilError::Io {
+        path: parent.display().to_string(),
+        source,
+    })?;
+
+    let pid = std::process::id();
+    let file_name = dest
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| UtilError::Io {
+            path: dest.display().to_string(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cache path has no filename",
+            ),
+        })?;
+    let tmp_path = parent.join(format!(".tmp-{pid}-{file_name}"));
+
+    std::fs::write(&tmp_path, contents).map_err(|source| UtilError::Io {
+        path: tmp_path.display().to_string(),
+        source,
+    })?;
+
+    match std::fs::rename(&tmp_path, dest) {
+        Ok(()) => Ok(()),
+        Err(_) if dest.exists() => {
+            // Another writer beat us — clean up our temp file and proceed.
+            // POSIX rename(2) is atomic, so if dest now exists another writer completed an atomic place — safe to read.
+            // NTFS MoveFileEx is similarly atomic for same-volume renames.
+            let _ = std::fs::remove_file(&tmp_path);
+            Ok(())
+        }
+        Err(source) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(UtilError::Io {
+                path: dest.display().to_string(),
+                source,
+            })
+        }
+    }
+}
+
 /// Fetch a POM file from Maven Central and return its contents as a string.
 ///
-/// Uses `ureq` with a 30-second connect timeout and 60-second global timeout.
+/// Uses a disk cache at `~/.konvoy/cache/pom/<group_path>/<artifact_id>-<version>.pom`.
+/// Cache hits avoid the HTTP round trip entirely. Cache misses fetch from
+/// Maven Central, then write the contents atomically into the cache (write
+/// failures are non-fatal — the function still returns the fetched content).
+///
+/// Uses `ureq` with a 60-second global timeout.
 ///
 /// # Errors
 ///
 /// Returns `UtilError::Download` if the HTTP request fails or the response
-/// body cannot be read.
+/// body cannot be read. Returns `UtilError::InvalidVersion` if any of
+/// `group_id`/`artifact_id`/`version` fail validation.
 pub fn fetch_pom(group_id: &str, artifact_id: &str, version: &str) -> Result<String, UtilError> {
+    // 1. Try the on-disk cache.
+    let cache_path = pom_cache_path(group_id, artifact_id, version)?;
+    if cache_path.exists() {
+        if let Ok(body) = std::fs::read_to_string(&cache_path) {
+            return Ok(body);
+        }
+        // Cache read failed (truncated, permissions, etc.); fall through to
+        // fetch from network so a degraded cache never blocks builds.
+    }
+
+    // 2. Cache miss — fetch from Maven Central.
     let url = pom_url(group_id, artifact_id, version);
 
     let agent = crate::download::http_agent(60);
@@ -324,6 +458,14 @@ pub fn fetch_pom(group_id: &str, artifact_id: &str, version: &str) -> Result<Str
         .map_err(|e| UtilError::Download {
             message: format!("failed to read POM response body from {url}: {e}"),
         })?;
+
+    // 3. Best-effort cache write. A failure here must not block the caller.
+    if let Err(e) = write_cache_atomic(&cache_path, body.as_bytes()) {
+        eprintln!(
+            "warning: failed to cache POM at {}: {e}",
+            cache_path.display()
+        );
+    }
 
     Ok(body)
 }
@@ -825,6 +967,78 @@ mod tests {
     }
 
     #[test]
+    fn fetch_pom_rejects_path_traversal_in_group_id() {
+        // Path-traversal in the group must be caught before any HTTP work or
+        // cache-path construction.
+        let result = fetch_pom("../etc/passwd", "lib", "1.0.0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_pom_rejects_invalid_version() {
+        let err = fetch_pom("com.example", "lib", "1.0/0").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn pom_cache_path_layout_matches_claude_md_contract() {
+        // Verify the layout suffix without depending on HOME (env mutation in
+        // tests races with other tests in the crate). The suffix is the
+        // load-bearing part — the prefix is `konvoy_home()` which is tested
+        // independently in fs.rs.
+        let path =
+            pom_cache_path("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.9.0").unwrap();
+        let suffix: std::path::PathBuf = [
+            "cache",
+            "pom",
+            "org",
+            "jetbrains",
+            "kotlinx",
+            "kotlinx-coroutines-core-1.9.0.pom",
+        ]
+        .iter()
+        .collect();
+        assert!(
+            path.ends_with(&suffix),
+            "expected path to end with {} — got {}",
+            suffix.display(),
+            path.display()
+        );
+    }
+
+    #[test]
+    fn pom_cache_path_rejects_invalid_identifiers() {
+        assert!(pom_cache_path("..", "lib", "1.0.0").is_err());
+        assert!(pom_cache_path("com.ex", "..", "1.0.0").is_err());
+        assert!(pom_cache_path("com.ex", "lib", "..").is_err());
+    }
+
+    #[test]
+    fn write_cache_atomic_creates_parent_and_writes_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("nested").join("dir").join("file.pom");
+
+        write_cache_atomic(&dest, b"contents").unwrap();
+
+        let written = std::fs::read(&dest).unwrap();
+        assert_eq!(written, b"contents");
+    }
+
+    #[test]
+    fn write_cache_atomic_overwrites_existing_file() {
+        // Overwriting is fine — Unix rename replaces the target atomically.
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("file.pom");
+        std::fs::write(&dest, b"old").unwrap();
+
+        write_cache_atomic(&dest, b"new").unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"new");
+    }
+
+    #[test]
     fn parse_pom_dependency_missing_version_inherits_empty() {
         // When a dependency has no <version>, it gets an empty string.
         // In practice the caller would resolve it via dependencyManagement
@@ -1047,5 +1261,172 @@ mod tests {
         assert_eq!(dep.group_id, "org.jetbrains.kotlin");
         assert_eq!(dep.artifact_id, "kotlin-native-prebuilt");
         assert_eq!(dep.version, "1.9.21");
+    }
+
+    // -----------------------------------------------------------------
+    // metadata_cache_path validation branches (one test per validation site)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn metadata_cache_path_rejects_invalid_group_id() {
+        // First validation site: group_id.
+        let err = metadata_cache_path("../etc", "lib", "1.0.0", "pom").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion for bad group_id, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_cache_path_rejects_invalid_artifact_id() {
+        // Second validation site: artifact_id.
+        let err = metadata_cache_path("com.example", "..", "1.0.0", "pom").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion for bad artifact_id, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_cache_path_rejects_invalid_version() {
+        // Third validation site: version.
+        let err = metadata_cache_path("com.example", "lib", "..", "pom").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion for bad version, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_cache_path_rejects_empty_dot_segment() {
+        // A leading dot makes `split('.')` produce an empty segment even
+        // though `validate_identifier` (which only rejects ".." and bad
+        // chars) accepts the input. That's specifically what the in-loop
+        // `if segment.is_empty()` guard exists for.
+        let err = metadata_cache_path(".com", "lib", "1.0.0", "pom").unwrap_err();
+        assert!(
+            matches!(err, UtilError::InvalidVersion { .. }),
+            "expected InvalidVersion for empty segment, got: {err:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // write_cache_atomic — error branches
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn write_cache_atomic_errors_when_path_has_no_filename() {
+        // `Path::file_name()` returns None when the path ends in `..`. The
+        // parent and the create_dir_all succeed (parent() returns the
+        // containing dir, which exists), so the no-filename branch is the
+        // first failure point.
+        let tmp = tempfile::tempdir().unwrap();
+        let bad_path = tmp.path().join("..");
+        let result = write_cache_atomic(&bad_path, b"contents");
+        assert!(result.is_err(), "path ending in `..` has no filename");
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, UtilError::Io { .. }),
+            "expected Io error, got: {msg}"
+        );
+        assert!(
+            msg.contains("no filename") || msg.contains("InvalidInput"),
+            "error should mention the no-filename invariant, got: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_cache_atomic_errors_when_path_has_no_parent() {
+        // The root directory `/` has no parent — `Path::parent()` returns None.
+        // This exercises the early `ok_or_else` branch.
+        let result = write_cache_atomic(std::path::Path::new("/"), b"contents");
+        assert!(result.is_err(), "writing to / must fail with a typed error");
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, UtilError::Io { .. }),
+            "expected Io error, got: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_cache_atomic_errors_on_unwritable_parent() {
+        // Reproduces the "rename failed, dest does not exist" branch:
+        // make the parent read-only so the temp-file write fails. (Running
+        // as root would bypass this; CI normally doesn't.)
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("ro");
+        std::fs::create_dir(&parent).unwrap();
+        let mut perms = std::fs::metadata(&parent).unwrap().permissions();
+        use std::os::unix::fs::PermissionsExt;
+        let original = perms.mode();
+        perms.set_mode(0o500); // r-x -- no writes
+        std::fs::set_permissions(&parent, perms).unwrap();
+
+        let dest = parent.join("file.pom");
+        let result = write_cache_atomic(&dest, b"contents");
+
+        // Restore permissions so the tempdir cleans up.
+        let mut restored = std::fs::metadata(&parent).unwrap().permissions();
+        restored.set_mode(original);
+        let _ = std::fs::set_permissions(&parent, restored);
+
+        // On most filesystems the temp-file write fails with EACCES; on
+        // an unusual setup it could succeed, so we only assert when the
+        // error path engages.
+        if let Err(err) = result {
+            assert!(
+                matches!(err, UtilError::Io { .. }),
+                "expected Io error, got: {err}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // fetch_pom — cache hit and cache-write failure paths
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn fetch_pom_cache_hit_returns_disk_contents_without_network() {
+        // Verify the cache-hit early-return path: by pre-populating the
+        // on-disk cache, `fetch_pom` must read it back without trying any
+        // HTTP I/O. Uses a HOME override so we point at a temp dir.
+        let _guard = crate::test_util::ENV_LOCK.lock().unwrap();
+
+        let saved_home = std::env::var("HOME").ok();
+        let saved_profile = std::env::var("USERPROFILE").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        // Clear USERPROFILE so the unix path is used everywhere.
+        std::env::remove_var("USERPROFILE");
+
+        // Construct the cache path that `fetch_pom` will look at, and
+        // pre-populate it.
+        let group = "com.example";
+        let artifact = "cached-lib";
+        let version = "1.2.3";
+        let cache_path = pom_cache_path(group, artifact, version).unwrap();
+        std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        let expected_body = "<project><artifactId>cached-lib</artifactId></project>";
+        std::fs::write(&cache_path, expected_body).unwrap();
+
+        let result = fetch_pom(group, artifact, version);
+
+        // Restore HOME/USERPROFILE before asserting so a panic leaves the
+        // environment clean for other tests.
+        if let Some(v) = saved_home {
+            std::env::set_var("HOME", v);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(v) = saved_profile {
+            std::env::set_var("USERPROFILE", v);
+        }
+
+        let body = result.unwrap();
+        assert_eq!(body, expected_body, "cache hit must return the disk bytes");
     }
 }

--- a/crates/konvoy-util/src/pom.rs
+++ b/crates/konvoy-util/src/pom.rs
@@ -301,9 +301,6 @@ pub fn pom_url(group_id: &str, artifact_id: &str, version: &str) -> String {
     crate::maven::maven_artifact_url(group_id, artifact_id, version, "pom")
 }
 
-// Cache layout v1: <konvoy_home>/cache/pom/<group_path>/<artifact>-<version>.{pom,module,module.404}.
-// If the on-disk format ever changes, bump to v2 by introducing a subdirectory.
-
 /// Build the on-disk cache path for a Maven artifact metadata file.
 ///
 /// Layout matches the contract in CLAUDE.md:

--- a/crates/konvoy-util/src/pom.rs
+++ b/crates/konvoy-util/src/pom.rs
@@ -355,7 +355,7 @@ fn pom_cache_path(
 
 /// Atomically write `contents` to `dest` via a temp file in the same directory.
 ///
-/// Mirrors the pattern in `ensure_artifact`: write to a `.tmp-<pid>` sibling
+/// Mirrors the pattern in `download_artifact`: write to a `.tmp-<pid>` sibling
 /// and rename into place. If another writer wins the race, the rename may fail
 /// but the destination exists with valid contents, which is what we want.
 ///

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -68,7 +68,7 @@ impl DownloadBar {
     /// directly — prefer the higher-level helpers [`fetch`] and
     /// [`stream_with_bar`] in this module, which adapt the lower-level
     /// callback-based primitives ([`crate::artifact::download_artifact`]
-    /// and [`crate::download::stream_download`]) to a bar internally.
+    /// and `crate::download::stream_download`) to a bar internally.
     /// When the closure returns, this bar's state flips to ✅ on `Ok` or
     /// ❌ on `Err`, and the bar is abandoned so its final frame stays on
     /// screen.
@@ -173,14 +173,14 @@ pub fn fetch(
 
 /// Stream a URL to `dest` with an optional bar; returns the SHA-256.
 ///
-/// Thin UI-aware wrapper over [`crate::download::stream_download`] for
+/// Thin UI-aware wrapper over `crate::download::stream_download` for
 /// callers (toolchain tarballs, JRE tarballs) that just need to drop
 /// bytes onto disk and get a hash back — no `expected_sha256`, no
 /// atomic-rename dance, no `freshly_downloaded` flag. The bar is wired
 /// up internally; pass `None` to suppress UI.
 ///
 /// # Errors
-/// Returns whatever [`crate::download::stream_download`] returns.
+/// Returns whatever `crate::download::stream_download` returns.
 pub fn stream_with_bar(
     url: &str,
     dest: &std::path::Path,

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -133,12 +133,29 @@ where
     }
 }
 
+/// Build a progress callback that drives a [`ProgressBar`] from the
+/// `(downloaded, total)` events emitted by network primitives.
+///
+/// The callback sets the bar's length from the first `Some(total)` it
+/// receives and updates its position on every chunk.
+fn bar_progress(pb: &ProgressBar) -> impl FnMut(u64, Option<u64>) + '_ {
+    move |downloaded, total| {
+        if let Some(t) = total {
+            pb.set_length(t);
+        }
+        pb.set_position(downloaded);
+    }
+}
+
+/// No-op progress callback for the cache-hit / hidden-bar path.
+const fn ignore_progress(_: u64, _: Option<u64>) {}
+
 /// Fetch a Maven-style artifact: check the cache first, download (with the
 /// supplied bar) only on miss.
 ///
 /// Composes [`crate::artifact::check_cached`] (no UI) and
-/// [`crate::artifact::download_artifact`] (with bar) so engine code can
-/// call one function instead of writing the match-on-cache pattern at
+/// [`crate::artifact::download_artifact`] (callback-driven) so engine code
+/// can call one function instead of writing the match-on-cache pattern at
 /// every site. The `bar` parameter is `Option` so callers can suppress UI
 /// entirely (e.g. for already-known-cached items in a parallel batch).
 ///
@@ -156,9 +173,37 @@ pub fn fetch(
     if let Some(cached) = crate::artifact::check_cached(dest, expected_sha256)? {
         return Ok(cached);
     }
-    run_with_optional_bar(bar, |pb| {
-        crate::artifact::download_artifact(url, dest, expected_sha256, label, pb)
-    })
+    let download = |on_progress: &mut dyn FnMut(u64, Option<u64>)| {
+        crate::artifact::download_artifact(url, dest, expected_sha256, label, on_progress)
+    };
+    if let Some(b) = bar {
+        b.run(|pb| download(&mut bar_progress(pb)))
+    } else {
+        download(&mut ignore_progress)
+    }
+}
+
+/// Stream a URL to `dest` with an optional bar; returns the SHA-256.
+///
+/// Thin UI-aware wrapper over [`crate::download::stream_download`] for
+/// callers (toolchain tarballs, JRE tarballs) that don't need
+/// hash-verified atomic placement.
+///
+/// # Errors
+/// Returns whatever [`crate::download::stream_download`] returns.
+pub fn stream_download(
+    url: &str,
+    dest: &std::path::Path,
+    bar: Option<&DownloadBar>,
+) -> Result<String, crate::error::UtilError> {
+    let download = |on_progress: &mut dyn FnMut(u64, Option<u64>)| {
+        crate::download::stream_download(url, dest, on_progress)
+    };
+    if let Some(b) = bar {
+        b.run(|pb| download(&mut bar_progress(pb)))
+    } else {
+        download(&mut ignore_progress)
+    }
 }
 
 /// Build a styled [`DownloadBar`] for a single-shot download.

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -50,9 +50,21 @@ const BLINK_TICK: Duration = Duration::from_millis(250);
 /// finalises each bar via [`DownloadBar::finish`] (or the lower-level
 /// [`DownloadBar::mark_success`] / [`DownloadBar::mark_failure`]) once the
 /// download result is known.
+///
+/// Both constructors render through a [`MultiProgress`] — single-bar paths
+/// ([`new_download_bar`]) own theirs internally for lifetime management;
+/// multi-bar paths ([`add_download_bar`]) attach to a caller-owned one.
+/// Callers are responsible for emitting a single trailing `eprintln!()`
+/// after the bar block so the next stderr line doesn't get concatenated
+/// onto the last bar's row.
 pub struct DownloadBar {
     bar: ProgressBar,
     state: Arc<AtomicU8>,
+    /// Owned `MultiProgress` for single-bar paths. Kept alive for the
+    /// bar's lifetime so the remote draw target doesn't dangle. Field-drop
+    /// order is bar → state → `_owned_multi`, so the multi state outlives
+    /// the bar that renders into it.
+    _owned_multi: Option<MultiProgress>,
 }
 
 impl DownloadBar {
@@ -94,25 +106,30 @@ impl DownloadBar {
     }
 }
 
-/// Build a styled standalone [`DownloadBar`] for an HTTP download.
+/// Build a styled [`DownloadBar`] for a single-shot download.
 ///
-/// Used by single-shot download paths (toolchain install, detekt JAR, plugin
-/// JAR) that render one bar at a time.
+/// Creates an owned [`MultiProgress`] internally so the rendering pipeline
+/// matches the multi-bar path used by `konvoy update`'s parallel klib
+/// downloads. Caller must still emit a trailing `eprintln!()` after the
+/// download finishes (same as for multi-bar paths) so the next stderr line
+/// doesn't get concatenated onto the bar's row.
 #[must_use]
 pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> DownloadBar {
+    let multi = MultiProgress::new();
     let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
-    let pb = ProgressBar::new(0);
-    pb.set_style(download_style(DEFAULT_PREFIX_WIDTH, Arc::clone(&state)));
-    pb.set_prefix(prefix);
-    pb.enable_steady_tick(BLINK_TICK);
-    DownloadBar { bar: pb, state }
+    let pb = build_bar(&multi, prefix, DEFAULT_PREFIX_WIDTH, Arc::clone(&state));
+    DownloadBar {
+        bar: pb,
+        state,
+        _owned_multi: Some(multi),
+    }
 }
 
-/// Attach a styled bar to a [`MultiProgress`] container with a caller-supplied
-/// prefix column width.
+/// Attach a styled bar to a caller-owned [`MultiProgress`] container.
 ///
 /// `prefix_width` should be the max prefix length across every bar in the
-/// container so all bar columns line up vertically.
+/// container so all bar columns line up vertically. The caller is
+/// responsible for emitting a trailing newline after the whole bar group.
 #[must_use]
 pub fn add_download_bar(
     mp: &MultiProgress,
@@ -120,11 +137,27 @@ pub fn add_download_bar(
     prefix_width: usize,
 ) -> DownloadBar {
     let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
+    let pb = build_bar(mp, prefix, prefix_width, Arc::clone(&state));
+    DownloadBar {
+        bar: pb,
+        state,
+        _owned_multi: None,
+    }
+}
+
+/// Shared bar construction: attach to `mp`, apply the styled template,
+/// set the prefix, and start the blink ticker.
+fn build_bar(
+    mp: &MultiProgress,
+    prefix: impl Into<Cow<'static, str>>,
+    prefix_width: usize,
+    state: Arc<AtomicU8>,
+) -> ProgressBar {
     let pb = mp.add(ProgressBar::new(0));
-    pb.set_style(download_style(prefix_width, Arc::clone(&state)));
+    pb.set_style(download_style(prefix_width, state));
     pb.set_prefix(prefix);
     pb.enable_steady_tick(BLINK_TICK);
-    DownloadBar { bar: pb, state }
+    pb
 }
 
 /// Hidden bar for use in tests or non-interactive contexts.

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -1,0 +1,101 @@
+//! Styled `indicatif` progress bars for downloads.
+//!
+//! Centralises the look-and-feel so every place that downloads an artifact
+//! (toolchain, detekt, plugins, Maven klibs) renders the same way and
+//! `konvoy update`'s `MultiProgress` can host any of them as a child bar.
+
+use std::borrow::Cow;
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+/// Template used for download bars: prefix, bar, bytes / total, speed.
+const DOWNLOAD_TEMPLATE: &str =
+    "  {prefix:<32} [{bar:30.cyan/blue}] {bytes:>10}/{total_bytes:<10} {bytes_per_sec:>12}";
+
+/// Template used when the server didn't send `Content-Length`.
+const SPINNER_TEMPLATE: &str = "  {prefix:<32} {spinner} {bytes:>10} {bytes_per_sec:>12}";
+
+/// Build a styled [`ProgressBar`] for an HTTP download.
+///
+/// The `prefix` is shown left of the bar (e.g. `"kotlinx-coroutines 1.9.0"`).
+/// The length is set later by the downloader once `Content-Length` is known;
+/// callers don't need to know it upfront.
+#[must_use]
+pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> ProgressBar {
+    let pb = ProgressBar::new(0);
+    pb.set_style(download_style());
+    pb.set_prefix(prefix);
+    pb
+}
+
+/// Build the same kind of bar but attach it to a [`MultiProgress`] container.
+///
+/// Used by `konvoy update` to render N parallel downloads in a vertical row.
+#[must_use]
+pub fn add_download_bar(mp: &MultiProgress, prefix: impl Into<Cow<'static, str>>) -> ProgressBar {
+    let pb = mp.add(ProgressBar::new(0));
+    pb.set_style(download_style());
+    pb.set_prefix(prefix);
+    pb
+}
+
+/// Hidden bar for use in tests or non-interactive contexts.
+#[must_use]
+pub fn hidden_bar() -> ProgressBar {
+    ProgressBar::hidden()
+}
+
+/// Switch a bar to spinner mode (no known total).
+///
+/// Call from the downloader when the response has no `Content-Length`.
+pub fn switch_to_spinner(pb: &ProgressBar) {
+    pb.set_style(spinner_style());
+}
+
+fn download_style() -> ProgressStyle {
+    // The template strings are static and well-formed; falling back to the
+    // default style is fine if a future indicatif version tightens parsing.
+    ProgressStyle::with_template(DOWNLOAD_TEMPLATE)
+        .unwrap_or_else(|_| ProgressStyle::default_bar())
+        .progress_chars("=> ")
+}
+
+fn spinner_style() -> ProgressStyle {
+    ProgressStyle::with_template(SPINNER_TEMPLATE)
+        .unwrap_or_else(|_| ProgressStyle::default_spinner())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_download_bar_sets_prefix() {
+        let pb = new_download_bar("test-prefix");
+        assert_eq!(pb.prefix(), "test-prefix");
+    }
+
+    #[test]
+    fn hidden_bar_does_not_render() {
+        let pb = hidden_bar();
+        pb.set_position(50);
+        pb.finish();
+        // No assertion possible on stderr; hidden() is a no-op renderer.
+    }
+
+    #[test]
+    fn add_download_bar_attaches_to_multiprogress() {
+        let mp = MultiProgress::new();
+        let pb = add_download_bar(&mp, "child");
+        assert_eq!(pb.prefix(), "child");
+    }
+
+    #[test]
+    fn switch_to_spinner_changes_style() {
+        let pb = new_download_bar("a");
+        switch_to_spinner(&pb);
+        // No public API to read the style; just verify it doesn't panic.
+        pb.set_position(100);
+    }
+}

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -61,17 +61,32 @@ pub struct DownloadBar {
 }
 
 impl DownloadBar {
-    /// Access the underlying `ProgressBar` for functions that take
-    /// `&ProgressBar` (e.g. [`crate::download::download_with_progress`] and
-    /// [`crate::artifact::ensure_artifact`]).
-    #[must_use]
-    pub fn inner(&self) -> &ProgressBar {
-        &self.bar
+    /// Run a download function with this bar attached and finalise based on
+    /// the result.
+    ///
+    /// The closure receives a `&ProgressBar` it can hand to lower-level
+    /// download primitives (e.g. [`crate::artifact::ensure_artifact`] or
+    /// [`crate::download::download_with_progress`]). When the closure
+    /// returns, this bar's state flips to ✅ on `Ok` or ❌ on `Err`, and
+    /// the bar is abandoned so its final frame stays on screen.
+    ///
+    /// This is the recommended way to use a `DownloadBar` — callers should
+    /// not need to touch the inner `ProgressBar` directly.
+    ///
+    /// # Errors
+    /// Returns whatever `Err` the closure produced, unchanged.
+    pub fn run<F, T, E>(&self, f: F) -> Result<T, E>
+    where
+        F: FnOnce(&ProgressBar) -> Result<T, E>,
+    {
+        self.finish(f(&self.bar))
     }
 
-    /// Finalise the bar based on a download result: success on `Ok`,
-    /// failure on `Err`. Returns the result unchanged so callers can chain
-    /// `?` on it.
+    /// Finalise the bar based on a pre-computed download result.
+    ///
+    /// Most callers should prefer [`Self::run`], which wires both halves
+    /// together via a closure. Use `finish` only when the result was
+    /// produced separately and you just need to flip state.
     ///
     /// # Errors
     /// Returns whatever `Err` was passed in, unchanged.
@@ -96,6 +111,25 @@ impl DownloadBar {
     pub fn mark_failure(&self) {
         self.state.store(STATE_FAILURE, Ordering::Relaxed);
         self.bar.abandon();
+    }
+}
+
+/// Run a download function with an optional bar attached.
+///
+/// Mirrors [`DownloadBar::run`] but lets the caller pass `None` for the
+/// cache-hit path where no UI should appear. When `bar` is `None`, the
+/// closure receives a hidden `ProgressBar` and no state flip happens.
+///
+/// # Errors
+/// Returns whatever `Err` the closure produced, unchanged.
+pub fn run_with_optional_bar<F, T, E>(bar: Option<&DownloadBar>, f: F) -> Result<T, E>
+where
+    F: FnOnce(&ProgressBar) -> Result<T, E>,
+{
+    if let Some(b) = bar {
+        b.run(f)
+    } else {
+        f(&hidden_bar())
     }
 }
 
@@ -321,7 +355,7 @@ mod tests {
     #[test]
     fn new_download_bar_sets_prefix() {
         let bar = new_download_bar("test-prefix");
-        assert_eq!(bar.inner().prefix(), "test-prefix");
+        assert_eq!(bar.bar.prefix(), "test-prefix");
     }
 
     #[test]
@@ -341,7 +375,7 @@ mod tests {
     fn add_download_bar_attaches_to_multiprogress() {
         let mp = MultiProgress::new();
         let bar = add_download_bar(&mp, "child", 32);
-        assert_eq!(bar.inner().prefix(), "child");
+        assert_eq!(bar.bar.prefix(), "child");
         assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
     }
 

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -471,4 +471,100 @@ mod tests {
         assert_eq!(result, Err("boom"));
         assert_eq!(bar.state.load(Ordering::Relaxed), STATE_FAILURE);
     }
+
+    /// `fetch` should short-circuit on a cache hit and never touch the
+    /// (bogus) URL. The dest file is pre-written so `check_cached` returns
+    /// `Some` before any network attempt.
+    #[test]
+    fn fetch_returns_cached_when_hash_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("artifact.jar");
+        let content = b"cached artifact content";
+        std::fs::write(&dest, content).unwrap();
+        let expected = crate::hash::sha256_bytes(content);
+
+        let result = fetch(
+            "http://127.0.0.1:1/should-not-be-hit",
+            &dest,
+            Some(&expected),
+            "test",
+            None,
+        )
+        .unwrap();
+
+        assert!(!result.freshly_downloaded);
+        assert_eq!(result.sha256, expected);
+        assert_eq!(result.path, dest);
+    }
+
+    /// With no `expected_sha256`, an existing file is still served from
+    /// cache — `check_cached` hashes it and returns `Some` with the
+    /// computed hash. The bogus URL must not be hit.
+    #[test]
+    fn fetch_returns_cached_without_expected_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("artifact.jar");
+        let content = b"unverified cached content";
+        std::fs::write(&dest, content).unwrap();
+        let computed = crate::hash::sha256_bytes(content);
+
+        let result = fetch(
+            "http://127.0.0.1:1/should-not-be-hit",
+            &dest,
+            None,
+            "test",
+            None,
+        )
+        .unwrap();
+
+        assert!(!result.freshly_downloaded);
+        assert_eq!(result.sha256, computed);
+    }
+
+    /// Cached file with the wrong hash returns `ArtifactHashMismatch`
+    /// without falling through to the download path.
+    #[test]
+    fn fetch_errors_on_cached_hash_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("artifact.jar");
+        std::fs::write(&dest, b"any content").unwrap();
+        let bogus = "0".repeat(64);
+
+        let result = fetch(
+            "http://127.0.0.1:1/should-not-be-hit",
+            &dest,
+            Some(&bogus),
+            "test",
+            None,
+        );
+        assert!(matches!(
+            result,
+            Err(crate::error::UtilError::ArtifactHashMismatch { .. })
+        ));
+    }
+
+    /// Cache-hit path doesn't touch the bar (no `run`, no state flip).
+    /// The supplied `DownloadBar`'s state must stay `STATE_IN_PROGRESS`
+    /// after a cache-hit fetch.
+    #[test]
+    fn fetch_cache_hit_leaves_bar_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("artifact.jar");
+        let content = b"cached";
+        std::fs::write(&dest, content).unwrap();
+        let expected = crate::hash::sha256_bytes(content);
+
+        let bar = new_download_bar("test");
+        let result = fetch(
+            "http://127.0.0.1:1/should-not-be-hit",
+            &dest,
+            Some(&expected),
+            "test",
+            Some(&bar),
+        )
+        .unwrap();
+
+        assert!(!result.freshly_downloaded);
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
+    }
 }

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -22,12 +22,12 @@ const DEFAULT_PREFIX_WIDTH: usize = 36;
 /// position is a 2-column emoji).
 const BAR_LOGICAL_WIDTH: usize = 20;
 
-/// State indicator emoji shown in the `{msg}` slot at the start of each row.
+/// State indicator emoji rendered by the `{indicator}` template key.
 const IN_PROGRESS_MARKER: &str = "\u{2699}\u{FE0F}"; // ⚙️ (gear)
 const SUCCESS_MARKER: &str = "\u{2705}"; // ✅
 const FAILURE_MARKER: &str = "\u{274C}"; // ❌
 
-/// State values driving the bar's trail-character rendering.
+/// State values driving the indicator + trail-glyph rendering.
 const STATE_IN_PROGRESS: u8 = 0;
 const STATE_SUCCESS: u8 = 1;
 const STATE_FAILURE: u8 = 2;
@@ -39,24 +39,47 @@ const CRASH: &str = "\u{1F4A5}"; // 💥 crash glyph drawn over the truck on fai
 const DUST_TRAIL: &str = "\u{1F4A8}"; // 💨 dust while the truck is moving
 const DELIVERED_CARGO: &str = "\u{1F7E9}"; // 🟩 green block left after delivery
 
-/// Handle bundling a bar with the atomic flag that drives its trail glyph.
+/// Tick interval driving the indicator's redraw cadence. 250ms is half the
+/// 500ms blink period (computed inside [`write_indicator`]) so each on/off
+/// boundary is hit at least once even with indicatif's 20Hz draw throttle.
+const BLINK_TICK: Duration = Duration::from_millis(250);
+
+/// Handle bundling a bar with the atomic flag that drives its glyph state.
 ///
 /// Returned by [`add_download_bar`] / [`new_download_bar`]. The engine layer
-/// keeps the handle alive for the bar's lifetime and flips state via
-/// [`DownloadBar::mark_success`] / [`DownloadBar::mark_failure`] once the
-/// download result is known. The custom bar renderer reads the flag on each
-/// redraw to decide whether to draw dust (in progress / failure) or cargo
-/// (success) behind the truck.
+/// finalises each bar via [`DownloadBar::finish`] (or the lower-level
+/// [`DownloadBar::mark_success`] / [`DownloadBar::mark_failure`]) once the
+/// download result is known.
 pub struct DownloadBar {
-    /// The underlying indicatif bar — pass `&bar.bar` to functions that
-    /// expect `&ProgressBar` (like [`crate::download::download_with_progress`]).
-    pub bar: ProgressBar,
+    bar: ProgressBar,
     state: Arc<AtomicU8>,
 }
 
 impl DownloadBar {
+    /// Access the underlying `ProgressBar` for functions that take
+    /// `&ProgressBar` (e.g. [`crate::download::download_with_progress`] and
+    /// [`crate::artifact::ensure_artifact`]).
+    #[must_use]
+    pub fn inner(&self) -> &ProgressBar {
+        &self.bar
+    }
+
+    /// Finalise the bar based on a download result: success on `Ok`,
+    /// failure on `Err`. Returns the result unchanged so callers can chain
+    /// `?` on it.
+    ///
+    /// # Errors
+    /// Returns whatever `Err` was passed in, unchanged.
+    pub fn finish<T, E>(&self, result: Result<T, E>) -> Result<T, E> {
+        match &result {
+            Ok(_) => self.mark_success(),
+            Err(_) => self.mark_failure(),
+        }
+        result
+    }
+
     /// Flip state to success (✅ + 🟩 cargo) AND stop the bar so its final
-    /// frame is preserved. Order matters: the state has to be set before
+    /// frame is preserved. Order matters: state must be set before
     /// `abandon` halts further redraws.
     pub fn mark_success(&self) {
         self.state.store(STATE_SUCCESS, Ordering::Relaxed);
@@ -70,9 +93,6 @@ impl DownloadBar {
         self.bar.abandon();
     }
 }
-
-/// Interval at which bars redraw to drive the blinking-gear indicator.
-const BLINK_TICK: Duration = Duration::from_millis(250);
 
 /// Build a styled standalone [`DownloadBar`] for an HTTP download.
 ///
@@ -111,13 +131,6 @@ pub fn add_download_bar(
 #[must_use]
 pub fn hidden_bar() -> ProgressBar {
     ProgressBar::hidden()
-}
-
-/// Switch a bar to spinner mode (no known total).
-///
-/// Call from the downloader when the response has no `Content-Length`.
-pub fn switch_to_spinner(pb: &ProgressBar) {
-    pb.set_style(spinner_style(DEFAULT_PREFIX_WIDTH));
 }
 
 /// Custom `{elapsed_ms}` formatter — millisecond-precision elapsed time.
@@ -258,15 +271,6 @@ fn write_indicator(state: &ProgressState, w: &mut dyn Write, current_state: u8) 
     let _ = write!(w, "{glyph}");
 }
 
-fn spinner_style(prefix_width: usize) -> ProgressStyle {
-    let template = format!(
-        "  {{msg}}  {{prefix:<{prefix_width}.bold}} {{bytes:>10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
-    );
-    ProgressStyle::with_template(&template)
-        .unwrap_or_else(|_| ProgressStyle::default_spinner())
-        .with_key("elapsed_ms", write_elapsed_ms)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -275,7 +279,7 @@ mod tests {
     #[test]
     fn new_download_bar_sets_prefix() {
         let bar = new_download_bar("test-prefix");
-        assert_eq!(bar.bar.prefix(), "test-prefix");
+        assert_eq!(bar.inner().prefix(), "test-prefix");
     }
 
     #[test]
@@ -295,7 +299,7 @@ mod tests {
     fn add_download_bar_attaches_to_multiprogress() {
         let mp = MultiProgress::new();
         let bar = add_download_bar(&mp, "child", 32);
-        assert_eq!(bar.bar.prefix(), "child");
+        assert_eq!(bar.inner().prefix(), "child");
         assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
     }
 
@@ -314,9 +318,18 @@ mod tests {
     }
 
     #[test]
-    fn switch_to_spinner_changes_style() {
-        let bar = new_download_bar("a");
-        switch_to_spinner(&bar.bar);
-        bar.bar.set_position(100);
+    fn finish_ok_flips_to_success_and_returns_result() {
+        let bar = new_download_bar("x");
+        let result: Result<u32, &str> = bar.finish(Ok(42));
+        assert_eq!(result, Ok(42));
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_SUCCESS);
+    }
+
+    #[test]
+    fn finish_err_flips_to_failure_and_returns_result() {
+        let bar = new_download_bar("x");
+        let result: Result<u32, &str> = bar.finish(Err("boom"));
+        assert_eq!(result, Err("boom"));
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_FAILURE);
     }
 }

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -5,36 +5,43 @@
 //! `konvoy update`'s `MultiProgress` can host any of them as a child bar.
 
 use std::borrow::Cow;
+use std::fmt::Write;
 
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 
-/// Template used for download bars: prefix, bar, bytes / total, speed.
-const DOWNLOAD_TEMPLATE: &str =
-    "  {prefix:<32} [{bar:30.cyan/blue}] {bytes:>10}/{total_bytes:<10} {bytes_per_sec:>12}";
+/// Default minimum prefix column width when the caller doesn't compute one
+/// from the full set of in-flight downloads. 36 is wide enough to fit a
+/// typical `"<dep> <version> [<target>]"` like
+/// `"kotlinx-coroutines-core 1.9.0 [macos_arm64]"` (42 chars overflows but
+/// that's only for single-download paths where alignment doesn't matter).
+const DEFAULT_PREFIX_WIDTH: usize = 36;
 
-/// Template used when the server didn't send `Content-Length`.
-const SPINNER_TEMPLATE: &str = "  {prefix:<32} {spinner} {bytes:>10} {bytes_per_sec:>12}";
-
-/// Build a styled [`ProgressBar`] for an HTTP download.
+/// Build a styled standalone [`ProgressBar`] for an HTTP download.
 ///
-/// The `prefix` is shown left of the bar (e.g. `"kotlinx-coroutines 1.9.0"`).
-/// The length is set later by the downloader once `Content-Length` is known;
-/// callers don't need to know it upfront.
+/// Used by single-shot download paths (toolchain install, detekt JAR, plugin
+/// JAR) that render one bar at a time.
 #[must_use]
 pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> ProgressBar {
     let pb = ProgressBar::new(0);
-    pb.set_style(download_style());
+    pb.set_style(download_style(DEFAULT_PREFIX_WIDTH));
     pb.set_prefix(prefix);
     pb
 }
 
-/// Build the same kind of bar but attach it to a [`MultiProgress`] container.
+/// Attach a styled bar to a [`MultiProgress`] container with a caller-supplied
+/// prefix column width.
 ///
-/// Used by `konvoy update` to render N parallel downloads in a vertical row.
+/// `prefix_width` should be the max prefix length across every bar in the
+/// container so all bar columns line up vertically. Bars added later than this
+/// call still render correctly — they just don't influence the width.
 #[must_use]
-pub fn add_download_bar(mp: &MultiProgress, prefix: impl Into<Cow<'static, str>>) -> ProgressBar {
+pub fn add_download_bar(
+    mp: &MultiProgress,
+    prefix: impl Into<Cow<'static, str>>,
+    prefix_width: usize,
+) -> ProgressBar {
     let pb = mp.add(ProgressBar::new(0));
-    pb.set_style(download_style());
+    pb.set_style(download_style(prefix_width));
     pb.set_prefix(prefix);
     pb
 }
@@ -49,20 +56,42 @@ pub fn hidden_bar() -> ProgressBar {
 ///
 /// Call from the downloader when the response has no `Content-Length`.
 pub fn switch_to_spinner(pb: &ProgressBar) {
-    pb.set_style(spinner_style());
+    pb.set_style(spinner_style(DEFAULT_PREFIX_WIDTH));
 }
 
-fn download_style() -> ProgressStyle {
-    // The template strings are static and well-formed; falling back to the
-    // default style is fine if a future indicatif version tightens parsing.
-    ProgressStyle::with_template(DOWNLOAD_TEMPLATE)
+/// Custom `{elapsed_ms}` formatter — millisecond-precision elapsed time.
+///
+/// Indicatif's built-in `{elapsed}` rounds to seconds ("0s" for fast
+/// downloads), which is too coarse for the typical sub-second klib fetches.
+fn write_elapsed_ms(state: &ProgressState, w: &mut dyn Write) {
+    let _ = write!(w, "{}ms", state.elapsed().as_millis());
+}
+
+fn download_style(prefix_width: usize) -> ProgressStyle {
+    // 2-space indent matches Konvoy's existing eprintln output (e.g.
+    // "  Resolved N dependencies..."). Bar width is capped so wide terminals
+    // don't stretch a 50 KiB download across 200 columns. The prefix column
+    // is left-padded to `prefix_width` so MultiProgress children line up.
+    // Brackets around the bar give each row a visible boundary so a stack of
+    // fully-filled bars doesn't merge into one solid block.
+    // `bytes_per_sec` minimum width 12 fits "999.99 MiB/s" (longest typical
+    // value) so the elapsed-time column stays right-aligned across rows.
+    let template = format!(
+        "  {{spinner:.green}} {{prefix:<{prefix_width}.bold}} [{{bar:40.green/dim}}] {{bytes:>10.cyan}} / {{total_bytes:<10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
+    );
+    ProgressStyle::with_template(&template)
         .unwrap_or_else(|_| ProgressStyle::default_bar())
+        .with_key("elapsed_ms", write_elapsed_ms)
         .progress_chars("=> ")
 }
 
-fn spinner_style() -> ProgressStyle {
-    ProgressStyle::with_template(SPINNER_TEMPLATE)
+fn spinner_style(prefix_width: usize) -> ProgressStyle {
+    let template = format!(
+        "  {{spinner:.green}} {{prefix:<{prefix_width}.bold}} {{bytes:>10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
+    );
+    ProgressStyle::with_template(&template)
         .unwrap_or_else(|_| ProgressStyle::default_spinner())
+        .with_key("elapsed_ms", write_elapsed_ms)
 }
 
 #[cfg(test)]
@@ -81,13 +110,12 @@ mod tests {
         let pb = hidden_bar();
         pb.set_position(50);
         pb.finish();
-        // No assertion possible on stderr; hidden() is a no-op renderer.
     }
 
     #[test]
     fn add_download_bar_attaches_to_multiprogress() {
         let mp = MultiProgress::new();
-        let pb = add_download_bar(&mp, "child");
+        let pb = add_download_bar(&mp, "child", 32);
         assert_eq!(pb.prefix(), "child");
     }
 
@@ -95,7 +123,6 @@ mod tests {
     fn switch_to_spinner_changes_style() {
         let pb = new_download_bar("a");
         switch_to_spinner(&pb);
-        // No public API to read the style; just verify it doesn't panic.
         pb.set_position(100);
     }
 }

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -51,20 +51,13 @@ const BLINK_TICK: Duration = Duration::from_millis(250);
 /// [`DownloadBar::mark_success`] / [`DownloadBar::mark_failure`]) once the
 /// download result is known.
 ///
-/// Both constructors render through a [`MultiProgress`] — single-bar paths
-/// ([`new_download_bar`]) own theirs internally for lifetime management;
-/// multi-bar paths ([`add_download_bar`]) attach to a caller-owned one.
-/// Callers are responsible for emitting a single trailing `eprintln!()`
-/// after the bar block so the next stderr line doesn't get concatenated
-/// onto the last bar's row.
+/// Both constructors render through a [`MultiProgress`]. Callers are
+/// responsible for emitting a single trailing `eprintln!()` after the bar
+/// block so the next stderr line doesn't get concatenated onto the last
+/// bar's row.
 pub struct DownloadBar {
     bar: ProgressBar,
     state: Arc<AtomicU8>,
-    /// Owned `MultiProgress` for single-bar paths. Kept alive for the
-    /// bar's lifetime so the remote draw target doesn't dangle. Field-drop
-    /// order is bar → state → `_owned_multi`, so the multi state outlives
-    /// the bar that renders into it.
-    _owned_multi: Option<MultiProgress>,
 }
 
 impl DownloadBar {
@@ -108,21 +101,19 @@ impl DownloadBar {
 
 /// Build a styled [`DownloadBar`] for a single-shot download.
 ///
-/// Creates an owned [`MultiProgress`] internally so the rendering pipeline
-/// matches the multi-bar path used by `konvoy update`'s parallel klib
-/// downloads. Caller must still emit a trailing `eprintln!()` after the
-/// download finishes (same as for multi-bar paths) so the next stderr line
-/// doesn't get concatenated onto the bar's row.
+/// Constructs a local [`MultiProgress`] and attaches one bar to it. The
+/// `MultiProgress` is dropped on return — that's safe because
+/// `MultiProgress::add` clones the inner `Arc<MultiState>` into the bar's
+/// draw target, so the state stays alive as long as the bar does.
+///
+/// Caller must emit a trailing `eprintln!()` after the download finishes
+/// so the next stderr line isn't concatenated onto the bar's row.
 #[must_use]
 pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> DownloadBar {
     let multi = MultiProgress::new();
     let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
     let pb = build_bar(&multi, prefix, DEFAULT_PREFIX_WIDTH, Arc::clone(&state));
-    DownloadBar {
-        bar: pb,
-        state,
-        _owned_multi: Some(multi),
-    }
+    DownloadBar { bar: pb, state }
 }
 
 /// Attach a styled bar to a caller-owned [`MultiProgress`] container.
@@ -138,11 +129,29 @@ pub fn add_download_bar(
 ) -> DownloadBar {
     let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
     let pb = build_bar(mp, prefix, prefix_width, Arc::clone(&state));
-    DownloadBar {
-        bar: pb,
-        state,
-        _owned_multi: None,
-    }
+    DownloadBar { bar: pb, state }
+}
+
+/// Build a [`MultiProgress`] + a stable-ordered `Vec<DownloadBar>` from
+/// per-bar labels.
+///
+/// Computes the max label length once so every bar gets the same prefix
+/// padding (so columns line up). The returned `MultiProgress` is held by
+/// the caller; each returned bar internally clones its `Arc<MultiState>`
+/// so dropping the `MultiProgress` early would still leave the bars
+/// rendering, but holding it is more explicit and lets the caller add
+/// more bars later if needed.
+///
+/// Caller emits a trailing `eprintln!()` after the bar block.
+#[must_use]
+pub fn pre_allocate_bars(labels: Vec<String>) -> (MultiProgress, Vec<DownloadBar>) {
+    let multi = MultiProgress::new();
+    let prefix_width = labels.iter().map(String::len).max().unwrap_or(0);
+    let bars: Vec<DownloadBar> = labels
+        .into_iter()
+        .map(|label| add_download_bar(&multi, label, prefix_width))
+        .collect();
+    (multi, bars)
 }
 
 /// Shared bar construction: attach to `mp`, apply the styled template,

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -133,6 +133,34 @@ where
     }
 }
 
+/// Fetch a Maven-style artifact: check the cache first, download (with the
+/// supplied bar) only on miss.
+///
+/// Composes [`crate::artifact::check_cached`] (no UI) and
+/// [`crate::artifact::download_artifact`] (with bar) so engine code can
+/// call one function instead of writing the match-on-cache pattern at
+/// every site. The `bar` parameter is `Option` so callers can suppress UI
+/// entirely (e.g. for already-known-cached items in a parallel batch).
+///
+/// # Errors
+/// - [`crate::error::UtilError::ArtifactHashMismatch`] if a cached file
+///   has the wrong hash, or the downloaded file has the wrong hash.
+/// - Other [`crate::error::UtilError`] variants for I/O / network failures.
+pub fn fetch(
+    url: &str,
+    dest: &std::path::Path,
+    expected_sha256: Option<&str>,
+    label: &str,
+    bar: Option<&DownloadBar>,
+) -> Result<crate::artifact::ArtifactResult, crate::error::UtilError> {
+    if let Some(cached) = crate::artifact::check_cached(dest, expected_sha256)? {
+        return Ok(cached);
+    }
+    run_with_optional_bar(bar, |pb| {
+        crate::artifact::download_artifact(url, dest, expected_sha256, label, pb)
+    })
+}
+
 /// Build a styled [`DownloadBar`] for a single-shot download.
 ///
 /// Constructs a local [`MultiProgress`] and attaches one bar to it. The

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -64,11 +64,14 @@ impl DownloadBar {
     /// Run a download function with this bar attached and finalise based on
     /// the result.
     ///
-    /// The closure receives a `&ProgressBar` it can hand to lower-level
-    /// download primitives (e.g. [`crate::artifact::ensure_artifact`] or
-    /// [`crate::download::download_with_progress`]). When the closure
-    /// returns, this bar's state flips to ✅ on `Ok` or ❌ on `Err`, and
-    /// the bar is abandoned so its final frame stays on screen.
+    /// The closure receives a `&ProgressBar`. Most callers won't use this
+    /// directly — prefer the higher-level helpers [`fetch`] and
+    /// [`stream_with_bar`] in this module, which adapt the lower-level
+    /// callback-based primitives ([`crate::artifact::download_artifact`]
+    /// and [`crate::download::stream_download`]) to a bar internally.
+    /// When the closure returns, this bar's state flips to ✅ on `Ok` or
+    /// ❌ on `Err`, and the bar is abandoned so its final frame stays on
+    /// screen.
     ///
     /// This is the recommended way to use a `DownloadBar` — callers should
     /// not need to touch the inner `ProgressBar` directly.
@@ -114,34 +117,19 @@ impl DownloadBar {
     }
 }
 
-/// Run a download function with an optional bar attached.
-///
-/// Mirrors [`DownloadBar::run`] but lets the caller pass `None` for the
-/// cache-hit path where no UI should appear. When `bar` is `None`, the
-/// closure receives a hidden `ProgressBar` and no state flip happens.
-///
-/// # Errors
-/// Returns whatever `Err` the closure produced, unchanged.
-pub fn run_with_optional_bar<F, T, E>(bar: Option<&DownloadBar>, f: F) -> Result<T, E>
-where
-    F: FnOnce(&ProgressBar) -> Result<T, E>,
-{
-    if let Some(b) = bar {
-        b.run(f)
-    } else {
-        f(&hidden_bar())
-    }
-}
-
 /// Build a progress callback that drives a [`ProgressBar`] from the
 /// `(downloaded, total)` events emitted by network primitives.
 ///
-/// The callback sets the bar's length from the first `Some(total)` it
-/// receives and updates its position on every chunk.
+/// `set_length` only fires on the first `Some(total)` we see — repeated
+/// calls each chunk would take indicatif's state lock unnecessarily.
 fn bar_progress(pb: &ProgressBar) -> impl FnMut(u64, Option<u64>) + '_ {
+    let mut length_set = false;
     move |downloaded, total| {
-        if let Some(t) = total {
-            pb.set_length(t);
+        if !length_set {
+            if let Some(t) = total {
+                pb.set_length(t);
+                length_set = true;
+            }
         }
         pb.set_position(downloaded);
     }
@@ -186,12 +174,14 @@ pub fn fetch(
 /// Stream a URL to `dest` with an optional bar; returns the SHA-256.
 ///
 /// Thin UI-aware wrapper over [`crate::download::stream_download`] for
-/// callers (toolchain tarballs, JRE tarballs) that don't need
-/// hash-verified atomic placement.
+/// callers (toolchain tarballs, JRE tarballs) that just need to drop
+/// bytes onto disk and get a hash back — no `expected_sha256`, no
+/// atomic-rename dance, no `freshly_downloaded` flag. The bar is wired
+/// up internally; pass `None` to suppress UI.
 ///
 /// # Errors
 /// Returns whatever [`crate::download::stream_download`] returns.
-pub fn stream_download(
+pub fn stream_with_bar(
     url: &str,
     dest: &std::path::Path,
     bar: Option<&DownloadBar>,

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -6,44 +6,105 @@
 
 use std::borrow::Cow;
 use std::fmt::Write;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 
 /// Default minimum prefix column width when the caller doesn't compute one
 /// from the full set of in-flight downloads. 36 is wide enough to fit a
 /// typical `"<dep> <version> [<target>]"` like
-/// `"kotlinx-coroutines-core 1.9.0 [macos_arm64]"` (42 chars overflows but
-/// that's only for single-download paths where alignment doesn't matter).
+/// `"kotlinx-coroutines-core 1.9.0 [macos_arm64]"`.
 const DEFAULT_PREFIX_WIDTH: usize = 36;
 
-/// Build a styled standalone [`ProgressBar`] for an HTTP download.
+/// Logical width of the progress bar (visible columns ≈ 2× this since each
+/// position is a 2-column emoji).
+const BAR_LOGICAL_WIDTH: usize = 20;
+
+/// State indicator emoji shown in the `{msg}` slot at the start of each row.
+const IN_PROGRESS_MARKER: &str = "\u{2699}\u{FE0F}"; // ⚙️ (gear)
+const SUCCESS_MARKER: &str = "\u{2705}"; // ✅
+const FAILURE_MARKER: &str = "\u{274C}"; // ❌
+
+/// State values driving the bar's trail-character rendering.
+const STATE_IN_PROGRESS: u8 = 0;
+const STATE_SUCCESS: u8 = 1;
+const STATE_FAILURE: u8 = 2;
+
+/// Glyphs used inside the bar.
+const ROAD_AHEAD: &str = "\u{2B1C}"; // ⬜ empty road in front of truck
+const TRUCK: &str = "\u{1F69A}"; // 🚚 the truck (edge / cursor)
+const CRASH: &str = "\u{1F4A5}"; // 💥 crash glyph drawn over the truck on failure
+const DUST_TRAIL: &str = "\u{1F4A8}"; // 💨 dust while the truck is moving
+const DELIVERED_CARGO: &str = "\u{1F7E9}"; // 🟩 green block left after delivery
+
+/// Handle bundling a bar with the atomic flag that drives its trail glyph.
+///
+/// Returned by [`add_download_bar`] / [`new_download_bar`]. The engine layer
+/// keeps the handle alive for the bar's lifetime and flips state via
+/// [`DownloadBar::mark_success`] / [`DownloadBar::mark_failure`] once the
+/// download result is known. The custom bar renderer reads the flag on each
+/// redraw to decide whether to draw dust (in progress / failure) or cargo
+/// (success) behind the truck.
+pub struct DownloadBar {
+    /// The underlying indicatif bar — pass `&bar.bar` to functions that
+    /// expect `&ProgressBar` (like [`crate::download::download_with_progress`]).
+    pub bar: ProgressBar,
+    state: Arc<AtomicU8>,
+}
+
+impl DownloadBar {
+    /// Flip state to success (✅ + 🟩 cargo) AND stop the bar so its final
+    /// frame is preserved. Order matters: the state has to be set before
+    /// `abandon` halts further redraws.
+    pub fn mark_success(&self) {
+        self.state.store(STATE_SUCCESS, Ordering::Relaxed);
+        self.bar.abandon();
+    }
+
+    /// Flip state to failure (❌ + 💥 over the truck, dust trail stays) AND
+    /// stop the bar so its final frame is preserved.
+    pub fn mark_failure(&self) {
+        self.state.store(STATE_FAILURE, Ordering::Relaxed);
+        self.bar.abandon();
+    }
+}
+
+/// Interval at which bars redraw to drive the blinking-gear indicator.
+const BLINK_TICK: Duration = Duration::from_millis(250);
+
+/// Build a styled standalone [`DownloadBar`] for an HTTP download.
 ///
 /// Used by single-shot download paths (toolchain install, detekt JAR, plugin
 /// JAR) that render one bar at a time.
 #[must_use]
-pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> ProgressBar {
+pub fn new_download_bar(prefix: impl Into<Cow<'static, str>>) -> DownloadBar {
+    let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
     let pb = ProgressBar::new(0);
-    pb.set_style(download_style(DEFAULT_PREFIX_WIDTH));
+    pb.set_style(download_style(DEFAULT_PREFIX_WIDTH, Arc::clone(&state)));
     pb.set_prefix(prefix);
-    pb
+    pb.enable_steady_tick(BLINK_TICK);
+    DownloadBar { bar: pb, state }
 }
 
 /// Attach a styled bar to a [`MultiProgress`] container with a caller-supplied
 /// prefix column width.
 ///
 /// `prefix_width` should be the max prefix length across every bar in the
-/// container so all bar columns line up vertically. Bars added later than this
-/// call still render correctly — they just don't influence the width.
+/// container so all bar columns line up vertically.
 #[must_use]
 pub fn add_download_bar(
     mp: &MultiProgress,
     prefix: impl Into<Cow<'static, str>>,
     prefix_width: usize,
-) -> ProgressBar {
+) -> DownloadBar {
+    let state = Arc::new(AtomicU8::new(STATE_IN_PROGRESS));
     let pb = mp.add(ProgressBar::new(0));
-    pb.set_style(download_style(prefix_width));
+    pb.set_style(download_style(prefix_width, Arc::clone(&state)));
     pb.set_prefix(prefix);
-    pb
+    pb.enable_steady_tick(BLINK_TICK);
+    DownloadBar { bar: pb, state }
 }
 
 /// Hidden bar for use in tests or non-interactive contexts.
@@ -67,27 +128,139 @@ fn write_elapsed_ms(state: &ProgressState, w: &mut dyn Write) {
     let _ = write!(w, "{}ms", state.elapsed().as_millis());
 }
 
-fn download_style(prefix_width: usize) -> ProgressStyle {
-    // 2-space indent matches Konvoy's existing eprintln output (e.g.
-    // "  Resolved N dependencies..."). Bar width is capped so wide terminals
-    // don't stretch a 50 KiB download across 200 columns. The prefix column
-    // is left-padded to `prefix_width` so MultiProgress children line up.
-    // Brackets around the bar give each row a visible boundary so a stack of
-    // fully-filled bars doesn't merge into one solid block.
-    // `bytes_per_sec` minimum width 12 fits "999.99 MiB/s" (longest typical
-    // value) so the elapsed-time column stays right-aligned across rows.
+/// Custom `{kbar}` renderer driven by the bar's state flag.
+///
+/// The bar's raw position tracks downloaded bytes (so `{bytes}` and
+/// `{bytes_per_sec}` in the template stay accurate). Right-to-left fill is
+/// done HERE by computing the edge index from `len - pos`:
+///
+///   start (pos=0):           `⬜⬜⬜⬜...⬜🚚`     (truck parked at right spot)
+///   half (pos=len/2):        `⬜⬜⬜🚚💨💨💨💨`   (road ahead, truck, dust)
+///   success (pos=len):       `🚚🟩🟩🟩🟩🟩🟩🟩`  (truck delivered)
+///   failure (pos<len, frozen): same as half-state but truck → 💥
+///
+/// The truck is clamped to `bar_width - 1` so it's always visible — even at
+/// pos == 0 (the moment before any bytes arrive), the truck appears at the
+/// far right edge instead of being hidden off-screen.
+fn render_truck_bar(state: &ProgressState, w: &mut dyn Write, current_state: u8) {
+    let bar_width = BAR_LOGICAL_WIDTH;
+    let len = state.len().unwrap_or(0);
+    let pos = state.pos();
+
+    if len == 0 {
+        // No Content-Length recorded — either the spinner-mode case (download
+        // succeeded but server didn't send a length) or an early connection
+        // failure where the body never started. On failure we still want
+        // 💥 visible, so park the crash glyph at the rightmost slot (the
+        // truck's pre-departure position) with empty road to its left.
+        let edge_glyph = if current_state == STATE_FAILURE {
+            CRASH
+        } else {
+            ROAD_AHEAD
+        };
+        for _ in 0..bar_width.saturating_sub(1) {
+            let _ = write!(w, "{ROAD_AHEAD}");
+        }
+        let _ = write!(w, "{edge_glyph}");
+        return;
+    }
+
+    // Invert here: truck_at decreases as pos increases. At pos=0, truck_at =
+    // bar_width-1 (far right). At pos=len, truck_at = 0 (far left). Cast via
+    // u128 so multi-GB downloads don't overflow.
+    let remaining = len.saturating_sub(pos);
+    #[allow(clippy::cast_possible_truncation)]
+    let truck_at = {
+        let raw = (u128::from(remaining) * (bar_width as u128)) / u128::from(len);
+        (raw as usize).min(bar_width.saturating_sub(1))
+    };
+
+    let trail = if current_state == STATE_SUCCESS {
+        DELIVERED_CARGO
+    } else {
+        DUST_TRAIL
+    };
+    let edge_glyph = if current_state == STATE_FAILURE {
+        CRASH
+    } else {
+        TRUCK
+    };
+
+    for i in 0..bar_width {
+        let glyph = if i < truck_at {
+            ROAD_AHEAD
+        } else if i == truck_at {
+            edge_glyph
+        } else {
+            trail
+        };
+        let _ = write!(w, "{glyph}");
+    }
+}
+
+fn download_style(prefix_width: usize, state: Arc<AtomicU8>) -> ProgressStyle {
+    // Konvoy-themed truck bar:
+    //
+    //   ⚙️  prefix [⬜⬜⬜🚚💨💨💨] bytes / total speed time
+    //   ✅  prefix [🚚🟩🟩🟩🟩🟩🟩] bytes / total speed time
+    //
+    //   - {indicator} reads the shared atomic state to render ⚙️/✅/❌. While
+    //     in progress, the gear blinks every 500ms (driven by
+    //     `enable_steady_tick(BLINK_TICK)` on the bar). When state flips to
+    //     success/failure, the renderer locks the indicator to ✅ or ❌.
+    //   - {kbar} is our custom bar renderer (`render_truck_bar`) reading the
+    //     same shared state to choose the trail glyph: 💨 dust while the
+    //     truck is moving (or stopped on failure), 🟩 delivered cargo on
+    //     success.
+    //   - [`{kbar}`] uses plain `[` `]` brackets — they read as parking spots
+    //     the truck pulls into when delivery completes.
+    //   - `prefix_width` left-pads the dep label so columns line up.
+    //   - `bytes_per_sec` min-width 12 fits "999.99 MiB/s" so the ms column
+    //     stays right-aligned across rows.
     let template = format!(
-        "  {{spinner:.green}} {{prefix:<{prefix_width}.bold}} [{{bar:40.green/dim}}] {{bytes:>10.cyan}} / {{total_bytes:<10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
+        "  {{indicator}}  {{prefix:<{prefix_width}.bold}} [{{kbar}}] {{bytes:>10.cyan}} / {{total_bytes:<10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
     );
+    let bar_state = Arc::clone(&state);
+    let bar_closure = move |s: &ProgressState, w: &mut dyn Write| {
+        render_truck_bar(s, w, bar_state.load(Ordering::Relaxed));
+    };
+    let indicator_state = state;
+    let indicator_closure = move |s: &ProgressState, w: &mut dyn Write| {
+        write_indicator(s, w, indicator_state.load(Ordering::Relaxed));
+    };
     ProgressStyle::with_template(&template)
         .unwrap_or_else(|_| ProgressStyle::default_bar())
         .with_key("elapsed_ms", write_elapsed_ms)
-        .progress_chars("=> ")
+        .with_key("indicator", indicator_closure)
+        .with_key("kbar", bar_closure)
+}
+
+/// Render the leading state indicator: blinking ⚙️ while in-progress, static
+/// ✅/❌ on completion.
+///
+/// The "off" frame is two spaces so the column width stays constant — the
+/// emoji is 2 cells wide; blinking to "  " keeps everything to the right of
+/// the indicator from shifting on each tick.
+fn write_indicator(state: &ProgressState, w: &mut dyn Write, current_state: u8) {
+    let glyph: &str = match current_state {
+        STATE_SUCCESS => SUCCESS_MARKER,
+        STATE_FAILURE => FAILURE_MARKER,
+        _ => {
+            // Blink every 500ms.
+            let tick = state.elapsed().as_millis() / 500;
+            if tick.is_multiple_of(2) {
+                IN_PROGRESS_MARKER
+            } else {
+                "  "
+            }
+        }
+    };
+    let _ = write!(w, "{glyph}");
 }
 
 fn spinner_style(prefix_width: usize) -> ProgressStyle {
     let template = format!(
-        "  {{spinner:.green}} {{prefix:<{prefix_width}.bold}} {{bytes:>10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
+        "  {{msg}}  {{prefix:<{prefix_width}.bold}} {{bytes:>10.cyan}} {{bytes_per_sec:>12.yellow}} {{elapsed_ms:>7.dim}}"
     );
     ProgressStyle::with_template(&template)
         .unwrap_or_else(|_| ProgressStyle::default_spinner())
@@ -101,8 +274,14 @@ mod tests {
 
     #[test]
     fn new_download_bar_sets_prefix() {
-        let pb = new_download_bar("test-prefix");
-        assert_eq!(pb.prefix(), "test-prefix");
+        let bar = new_download_bar("test-prefix");
+        assert_eq!(bar.bar.prefix(), "test-prefix");
+    }
+
+    #[test]
+    fn new_download_bar_starts_in_progress() {
+        let bar = new_download_bar("x");
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
     }
 
     #[test]
@@ -115,14 +294,29 @@ mod tests {
     #[test]
     fn add_download_bar_attaches_to_multiprogress() {
         let mp = MultiProgress::new();
-        let pb = add_download_bar(&mp, "child", 32);
-        assert_eq!(pb.prefix(), "child");
+        let bar = add_download_bar(&mp, "child", 32);
+        assert_eq!(bar.bar.prefix(), "child");
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
+    }
+
+    #[test]
+    fn mark_success_flips_state() {
+        let bar = new_download_bar("x");
+        bar.mark_success();
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_SUCCESS);
+    }
+
+    #[test]
+    fn mark_failure_flips_state() {
+        let bar = new_download_bar("x");
+        bar.mark_failure();
+        assert_eq!(bar.state.load(Ordering::Relaxed), STATE_FAILURE);
     }
 
     #[test]
     fn switch_to_spinner_changes_style() {
-        let pb = new_download_bar("a");
-        switch_to_spinner(&pb);
-        pb.set_position(100);
+        let bar = new_download_bar("a");
+        switch_to_spinner(&bar.bar);
+        bar.bar.set_position(100);
     }
 }

--- a/crates/konvoy-util/src/test_util.rs
+++ b/crates/konvoy-util/src/test_util.rs
@@ -1,0 +1,11 @@
+//! Test-only helpers shared across modules in the `konvoy-util` crate.
+//!
+//! Currently exposes a single process-wide mutex used to serialize tests
+//! that read or mutate `HOME` / `USERPROFILE`. Tests in different modules
+//! (`fs`, `pom`, `module_metadata`) all touch the same env vars, so they
+//! must share a single guard or they will race when `cargo test` runs them
+//! on multiple threads in the same binary.
+
+/// Guards tests that read or mutate HOME / USERPROFILE env vars so they
+/// don't race with each other (env vars are process-wide shared state).
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
Closes #267.

## Summary

Started as three perf items from #267, expanded mid-PR into a download-path UX overhaul (live progress bars) plus a layering refactor to keep the network code UI-free.

### Original scope (perf, from #267)

- **Plumb hash through `CompileContext`.** `resolve_maven_deps` returns `Vec<LibraryInput { path, precomputed_sha256: Option<String> }>`. `build_single` reuses the precomputed Maven hashes for cache-key inputs instead of re-running `sha256_file` on every dep klib. Path-deps and plugin jars remain rehashed (no expected hash known). Cache keys are byte-stable: precomputed values are byte-equivalent to `sha256_file`.
- **Parallelize `konvoy update`.** Outer dep loop partitions `already_locked` vs `needs_download` before any I/O, then downloads in parallel via rayon. The BFS in `resolve_transitive` drains each level into a Vec, fetches metadata in parallel (merge-after into the cache), and processes children sequentially — ~7× fewer sequential RTTs for a typical 3-level transitive graph.
- **POM disk cache.** Implemented the layout documented in `CLAUDE.md` at `~/.konvoy/cache/pom/<group>/<artifact>-<version>.{pom,module}`. 404 sentinels (`<artifact>-<version>.module.404`) so 404s aren't re-hit. Atomic-write pattern (temp + rename); `validate_identifier` rejects `..`-style path traversal.

### Added during development

- **Truck-themed progress bars** for every download path. `MultiProgress`-hosted bars render `[⬜⬜⬜🚚💨💨💨]` (truck driving right-to-left, dust trail) → `[🚚🟩🟩🟩🟩🟩🟩]` on success / `[⬜⬜🚚💨💨]` with 💥 over the truck on failure. Leading ⚙️ blinks at 2 Hz during work, swaps to ✅ / ❌ on completion. Bar columns auto-align across rows. Cache-hit paths skip bar creation entirely (no UI flash for zero-work operations).
- **Layering refactor.** `konvoy_util::artifact` and `konvoy_util::download` no longer take `&ProgressBar` — they emit progress as `FnMut(downloaded, total)` callbacks. The new `konvoy_util::progress` module is the only UI layer; it provides:
  - `DownloadBar::run(|pb| ...)` — closure-based bar attachment, finalises state on return
  - `progress::fetch(url, dest, expected_sha256, label, bar)` — hash-verified artifact fetch (cache check + atomic download)
  - `progress::stream_with_bar(url, dest, bar)` — raw tarball stream (no atomicity, no expected hash)
- **`ensure_artifact` split into `check_cached` + `download_artifact`** so cache-check is independently testable and stays UI-free.

## API at a glance

| Use case | Function | Module |
|---|---|---|
| Hash-verified Maven artifacts (klibs, plugin JARs, detekt JAR) | `progress::fetch` | UI layer |
| Raw tarballs (Kotlin/Native, JRE) | `progress::stream_with_bar` | UI layer |
| `progress::fetch`'s inner: cache check | `artifact::check_cached` | network/IO |
| `progress::fetch`'s inner: download + atomic place | `artifact::download_artifact` | network |
| `progress::stream_with_bar`'s inner: raw streaming | `download::stream_download` *(pub(crate))* | network |

## Output examples

### Fresh `konvoy update` (cold cache)

Live bars render the truck driving right-to-left with `💨` dust behind it. On success the trail flips to `🟩` cargo and the leading ⚙️ becomes ✅. Final frame (3 deps × 4 targets):

```
$ konvoy update
  Resolved 3 dependencies (2 direct, 1 transitive)
  ✅  atomicfu 0.25.0 [linux_x64]                    [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]  49.87 KiB / 49.87 KiB  695.29 KiB/s    71ms
  ✅  atomicfu 0.25.0 [linux_arm64]                  [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]  49.88 KiB / 49.88 KiB  844.17 KiB/s    59ms
  ✅  atomicfu 0.25.0 [macos_x64]                    [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]  49.97 KiB / 49.97 KiB  814.67 KiB/s    61ms
  ✅  atomicfu 0.25.0 [macos_arm64]                  [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]  49.99 KiB / 49.99 KiB  785.46 KiB/s    63ms
  ✅  atomicfu-cinterop-interop 0.25.0 [linux_x64]   [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]   3.65 KiB / 3.65 KiB    62.46 KiB/s    58ms
  ✅  atomicfu-cinterop-interop 0.25.0 [linux_arm64] [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]   3.65 KiB / 3.65 KiB    59.86 KiB/s    60ms
  ✅  atomicfu-cinterop-interop 0.25.0 [macos_x64]   [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]   3.71 KiB / 3.71 KiB    63.14 KiB/s    58ms
  ✅  atomicfu-cinterop-interop 0.25.0 [macos_arm64] [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩]   3.70 KiB / 3.70 KiB    58.63 KiB/s    63ms
  ✅  kotlinx-coroutines-core 1.9.0 [linux_x64]      [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩] 863.65 KiB / 863.65 KiB   5.21 MiB/s   162ms
  ✅  kotlinx-coroutines-core 1.9.0 [linux_arm64]    [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩] 863.67 KiB / 863.67 KiB   6.02 MiB/s   140ms
  ✅  kotlinx-coroutines-core 1.9.0 [macos_x64]      [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩] 868.16 KiB / 868.16 KiB   6.05 MiB/s   140ms
  ✅  kotlinx-coroutines-core 1.9.0 [macos_arm64]    [🚚🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩] 868.18 KiB / 868.18 KiB   6.00 MiB/s   141ms
  Updated 3 dependencies in konvoy.lock
```

### Re-run with full cache (warm cache)

No bars created — `progress::fetch` short-circuits via `check_cached` before any UI work:

```
$ konvoy update
  Resolved 3 dependencies (2 direct, 1 transitive)
  Resolving atomicfu 0.25.0...
    (already up to date)
  Resolving atomicfu-cinterop-interop 0.25.0...
    (already up to date)
  Resolving kotlinx-coroutines-core 1.9.0...
    (already up to date)
  Updated 3 dependencies in konvoy.lock
```

### Mid-progress frame (during fresh download)

While bytes are streaming the truck moves leftward with dust trailing; the gear ⚙️ blinks. Example mid-flight row:

```
  ⚙️  kotlinx-coroutines-core 1.9.0 [macos_arm64]    [⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜🚚💨💨💨💨💨💨💨💨] 387.20 KiB / 868.18 KiB   2.92 MiB/s   132ms
```

Failure rendering replaces 🚚 with 💥 and the indicator with ❌; the dust trail stays frozen at wherever the truck stopped.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — **855 tests pass** (19 new since baseline)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Smoke tests on Ubuntu via `gh workflow run` ([run 25777580943](https://github.com/arncore/konvoy/actions/runs/25777580943))

## Coverage (changed lines only)
| File | Coverage | Notes |
|---|---|---|
| `artifact.rs` | 100% | |
| `pom.rs` | 92.1% | |
| `module_metadata.rs` | 92.4% | |
| `progress.rs` | high | New module; cache-hit tests added |
| `build.rs` | 83.8% | Production pipeline; covered by smoke tests |
| `update.rs` | 52.9% | `download_target_klib` / BFS body need live Maven Central or an HTTP mock (out of scope) |
| `test_build.rs` | 14.3% | Needs real konanc toolchain |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
