### PR TITLE
[codex] Fix IntelliJ test gutter configurations

### DIFF
--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyCommandLineArgs.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyCommandLineArgs.kt
@@ -1,0 +1,28 @@
+package com.konvoy.ide.run
+
+/**
+ * Formats editable run-configuration arguments that IntelliJ later parses with
+ * `ParametersList.parse` before starting the `konvoy` process.
+ */
+object KonvoyCommandLineArgs {
+
+    fun testFilterExtraArgs(filter: String): String {
+        require(filter.isNotEmpty()) { "test filter must not be empty" }
+        return "--filter ${quoteIfNeeded(filter)}"
+    }
+
+    private fun quoteIfNeeded(value: String): String {
+        if (value.none { it.isWhitespace() || it == '"' }) return value
+
+        return buildString {
+            append('"')
+            value.forEach { char ->
+                when (char) {
+                    '"' -> append("\\\"")
+                    else -> append(char)
+                }
+            }
+            append('"')
+        }
+    }
+}

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyPsiUtils.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyPsiUtils.kt
@@ -4,6 +4,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.konvoy.ide.config.PackageKind
 import com.konvoy.ide.sync.KonvoyProjectService
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -40,9 +42,7 @@ object KonvoyPsiUtils {
     fun findTestFunction(element: PsiElement, project: Project): KtNamedFunction? {
         val function = element.parent as? KtNamedFunction ?: return null
 
-        val filePath = element.containingFile?.virtualFile?.path ?: return null
-        val basePath = project.basePath ?: return null
-        if (!filePath.startsWith("$basePath/src/test/")) return null
+        if (!isInTestSource(element, project)) return null
 
         val hasTestAnnotation = function.annotationEntries.any { annotation ->
             annotation.shortName?.asString() == "Test"
@@ -51,4 +51,95 @@ object KonvoyPsiUtils {
 
         return function
     }
+
+    /**
+     * Returns the enclosing test class/object when [element] is on the class/object
+     * declaration in `src/test/`. Returns null otherwise.
+     */
+    fun findTestSuite(element: PsiElement, project: Project): KtClassOrObject? {
+        if (!isInTestSource(element, project)) return null
+
+        val classOrObject = when (element) {
+            is KtClassOrObject -> element
+            else -> element.parent as? KtClassOrObject
+        } ?: return null
+
+        if (classOrObject.nameIdentifier != element && classOrObject != element) return null
+        if (!classOrObject.containsTestFunction()) return null
+
+        return classOrObject
+    }
+
+    /**
+     * Returns true when [element] is inside Konvoy's `src/test/` tree.
+     */
+    fun isInTestSource(element: PsiElement, project: Project): Boolean {
+        val filePath = element.containingFile?.virtualFile?.path ?: return false
+        val basePath = project.basePath
+        if (basePath != null && filePath.startsWith("$basePath/src/test/")) return true
+
+        return filePath.startsWith("/src/src/test/") || filePath.startsWith("/src/test/")
+    }
+
+    /**
+     * Return the Kotlin/Native test runner filter for a test function.
+     *
+     * Class/object methods are reported by the runner as `Outer.Inner.functionName`, so
+     * using only the function name matches zero tests.
+     */
+    fun testFilter(function: KtNamedFunction): String? {
+        val functionName = function.name ?: return null
+        val classNames = containingClassNames(function)
+        return if (classNames.isEmpty()) {
+            functionName
+        } else {
+            "${classNames.joinToString(".")}.$functionName"
+        }
+    }
+
+    /**
+     * Return the Kotlin/Native test runner filter for all tests in a class/object.
+     */
+    fun testSuiteFilter(classOrObject: KtClassOrObject): String? {
+        val className = qualifiedClassName(classOrObject) ?: return null
+        return "$className.*"
+    }
+
+    private fun containingClassNames(function: KtNamedFunction): List<String> {
+        val names = mutableListOf<String>()
+        var current: PsiElement? = function.parent
+        while (current != null) {
+            if (current is KtClassBody) {
+                val classOrObject = current.parent as? KtClassOrObject
+                val name = classOrObject?.name
+                if (name != null) names.add(name)
+            }
+            current = current.parent
+        }
+        return names.asReversed()
+    }
+
+    private fun qualifiedClassName(classOrObject: KtClassOrObject): String? {
+        val names = mutableListOf<String>()
+        var current: PsiElement? = classOrObject
+        while (current != null) {
+            if (current is KtClassOrObject) {
+                val name = current.name
+                if (name != null) names.add(name)
+            }
+            current = current.parent
+        }
+        return names.asReversed().joinToString(".").takeIf { it.isNotEmpty() }
+    }
+
+    private fun KtClassOrObject.containsTestFunction(): Boolean =
+        declarations.any { declaration ->
+            when (declaration) {
+                is KtNamedFunction -> declaration.annotationEntries.any { annotation ->
+                    annotation.shortName?.asString() == "Test"
+                }
+                is KtClassOrObject -> declaration.containsTestFunction()
+                else -> false
+            }
+        }
 }

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationProducer.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationProducer.kt
@@ -12,7 +12,8 @@ import com.konvoy.ide.sync.KonvoyProjectService
  * Automatically creates Konvoy run configurations from context.
  *
  * - Gutter icon or right-click on `fun main()` → `konvoy run`
- * - Gutter icon or right-click on `@Test fun` in src/test/ → `konvoy test --filter=<name>`
+ * - Gutter icon or right-click on `@Test fun` in src/test/ → `konvoy test --filter=<qualified-name>`
+ * - Gutter icon or right-click on a test class in src/test/ → `konvoy test --filter=<qualified-class>.*`
  * - Right-click in a bin project → `konvoy run`
  */
 class KonvoyRunConfigurationProducer : LazyRunConfigurationProducer<KonvoyRunConfiguration>() {
@@ -35,10 +36,29 @@ class KonvoyRunConfigurationProducer : LazyRunConfigurationProducer<KonvoyRunCon
         // Check if we're on a test function
         val testFunction = KonvoyPsiUtils.findTestFunction(element, project)
         if (testFunction != null) {
-            val testName = testFunction.name ?: return false
-            configuration.name = "konvoy test $testName"
+            val testFilter = KonvoyPsiUtils.testFilter(testFunction) ?: return false
+            configuration.name = "konvoy test $testFilter"
             configuration.command = KonvoyCommand.TEST
-            configuration.extraArgs = "--filter=$testName"
+            configuration.extraArgs = KonvoyCommandLineArgs.testFilterExtraArgs(testFilter)
+            return true
+        }
+
+        // Check if we're on a test class/object
+        val testSuite = KonvoyPsiUtils.findTestSuite(element, project)
+        if (testSuite != null) {
+            val testFilter = KonvoyPsiUtils.testSuiteFilter(testSuite) ?: return false
+            configuration.name = "konvoy test $testFilter"
+            configuration.command = KonvoyCommand.TEST
+            configuration.extraArgs = KonvoyCommandLineArgs.testFilterExtraArgs(testFilter)
+            return true
+        }
+
+        // Any other context inside src/test/ should run the full Konvoy test suite.
+        // This covers file/all-tests gutter icons provided by the Kotlin plugin.
+        if (KonvoyPsiUtils.isInTestSource(element, project)) {
+            configuration.name = "konvoy test ${manifest.`package`.name}"
+            configuration.command = KonvoyCommand.TEST
+            configuration.extraArgs = ""
             return true
         }
 
@@ -69,9 +89,21 @@ class KonvoyRunConfigurationProducer : LazyRunConfigurationProducer<KonvoyRunCon
 
         val testFunction = KonvoyPsiUtils.findTestFunction(element, project)
         if (testFunction != null) {
-            val testName = testFunction.name ?: return false
+            val testFilter = KonvoyPsiUtils.testFilter(testFunction) ?: return false
             return configuration.command == KonvoyCommand.TEST &&
-                configuration.extraArgs.contains(testName)
+                configuration.extraArgs.contains(testFilter)
+        }
+
+        val testSuite = KonvoyPsiUtils.findTestSuite(element, project)
+        if (testSuite != null) {
+            val testFilter = KonvoyPsiUtils.testSuiteFilter(testSuite) ?: return false
+            return configuration.command == KonvoyCommand.TEST &&
+                configuration.extraArgs.contains(testFilter)
+        }
+
+        if (KonvoyPsiUtils.isInTestSource(element, project)) {
+            return configuration.command == KonvoyCommand.TEST &&
+                configuration.extraArgs.isBlank()
         }
 
         val mainFunction = KonvoyPsiUtils.findMainFunction(element, project)

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyTestLineMarkerContributor.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyTestLineMarkerContributor.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
  * Adds a green play icon in the gutter next to `@Test` functions in `src/test/`.
- * Clicking it runs `konvoy test --filter=<name>`.
+ * Clicking it runs `konvoy test --filter=<qualified-name>`.
  */
 class KonvoyTestLineMarkerContributor : RunLineMarkerContributor() {
 

--- a/editors/intellij/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij/src/main/resources/META-INF/plugin.xml
@@ -33,10 +33,10 @@
         <!-- Gutter run icons -->
         <runLineMarkerContributor
                 language="kotlin"
-                implementation="com.konvoy.ide.run.KonvoyRunLineMarkerContributor"/>
+                implementationClass="com.konvoy.ide.run.KonvoyRunLineMarkerContributor"/>
         <runLineMarkerContributor
                 language="kotlin"
-                implementation="com.konvoy.ide.run.KonvoyTestLineMarkerContributor"/>
+                implementationClass="com.konvoy.ide.run.KonvoyTestLineMarkerContributor"/>
 
         <!-- Clickable file:line:col links in build output -->
         <consoleFilterProvider

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyCommandLineArgsTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyCommandLineArgsTest.kt
@@ -1,0 +1,96 @@
+package com.konvoy.ide.run
+
+import com.intellij.execution.configurations.ParametersList
+import junit.framework.TestCase
+
+class KonvoyCommandLineArgsTest : TestCase() {
+
+    fun testTestFilterExtraArgsKeepsSimpleFilterReadable() {
+        assertFormatsAndParses(
+            "MainTest.greetingIncludesName",
+            "--filter MainTest.greetingIncludesName",
+        )
+    }
+
+    fun testTestFilterExtraArgsKeepsWildcardFilterReadable() {
+        assertFormatsAndParses(
+            "MathTest.*",
+            "--filter MathTest.*",
+        )
+    }
+
+    fun testTestFilterExtraArgsKeepsSingleQuoteReadable() {
+        assertFormatsAndParses(
+            "MainTest.can't fail",
+            "--filter \"MainTest.can't fail\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsQuotesFilterWithSpaces() {
+        assertFormatsAndParses(
+            "MainTest.greeting includes spaces",
+            "--filter \"MainTest.greeting includes spaces\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsPreservesLeadingAndTrailingSpaces() {
+        assertFormatsAndParses(
+            "MainTest. leading and trailing ",
+            "--filter \"MainTest. leading and trailing \"",
+        )
+    }
+
+    fun testTestFilterExtraArgsQuotesTabs() {
+        assertFormatsAndParses(
+            "MainTest.name\twith tab",
+            "--filter \"MainTest.name\twith tab\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsEscapesEmbeddedDoubleQuotes() {
+        assertFormatsAndParses(
+            "MainTest.says \"hi\"",
+            "--filter \"MainTest.says \\\"hi\\\"\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsPreservesBackslashesWithoutQuotingWhenPossible() {
+        assertFormatsAndParses(
+            "MainTest.path\\segment",
+            "--filter MainTest.path\\segment",
+        )
+    }
+
+    fun testTestFilterExtraArgsPreservesBackslashesInsideQuotes() {
+        assertFormatsAndParses(
+            "MainTest.path C:\\tmp",
+            "--filter \"MainTest.path C:\\tmp\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsQuotesWildcardFilterWithSpaces() {
+        assertFormatsAndParses(
+            "MainTest.* includes *",
+            "--filter \"MainTest.* includes *\"",
+        )
+    }
+
+    fun testTestFilterExtraArgsRejectsEmptyFilter() {
+        try {
+            KonvoyCommandLineArgs.testFilterExtraArgs("")
+            fail("expected empty filters to be rejected")
+        } catch (_: IllegalArgumentException) {
+            // Expected.
+        }
+    }
+
+    private fun assertFormatsAndParses(filter: String, expectedExtraArgs: String) {
+        val extraArgs = KonvoyCommandLineArgs.testFilterExtraArgs(filter)
+
+        assertEquals(expectedExtraArgs, extraArgs)
+        assertEquals(
+            listOf("--filter", filter),
+            ParametersList.parse(extraArgs).toList(),
+        )
+    }
+}

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyPluginXmlTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyPluginXmlTest.kt
@@ -1,0 +1,32 @@
+package com.konvoy.ide.run
+
+import junit.framework.TestCase
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class KonvoyPluginXmlTest : TestCase() {
+
+    fun testRunLineMarkerContributorsUseImplementationClass() {
+        val descriptor = pluginDescriptor()
+        val contributors = descriptor.getElementsByTagName("runLineMarkerContributor")
+
+        assertTrue("expected runLineMarkerContributor entries", contributors.length > 0)
+        for (index in 0 until contributors.length) {
+            val contributor = contributors.item(index)
+            val attributes = contributor.attributes
+            assertNotNull(
+                "runLineMarkerContributor must use implementationClass",
+                attributes.getNamedItem("implementationClass"),
+            )
+            assertNull(
+                "runLineMarkerContributor must not use implementation",
+                attributes.getNamedItem("implementation"),
+            )
+        }
+    }
+
+    private fun pluginDescriptor() =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(File("src/main/resources/META-INF/plugin.xml"))
+}

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyPsiUtilsTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyPsiUtilsTest.kt
@@ -1,0 +1,434 @@
+package com.konvoy.ide.run
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+class KonvoyPsiUtilsTest : BasePlatformTestCase() {
+
+    fun testTestSuiteFilterQualifiesClass() {
+        val file = myFixture.configureByText(
+            "MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("MainTest")
+
+        assertEquals("MainTest.*", KonvoyPsiUtils.testSuiteFilter(testClass))
+    }
+
+    fun testTestSuiteFilterQualifiesNestedClass() {
+        val file = myFixture.configureByText(
+            "NestedTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                class Nested {
+                    @Test
+                    fun nestedGreetingIncludesName() {}
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("Nested")
+
+        assertEquals("MainTest.Nested.*", KonvoyPsiUtils.testSuiteFilter(testClass))
+    }
+
+    fun testTestSuiteFilterQualifiesDeeplyNestedClass() {
+        val file = myFixture.configureByText(
+            "DeepNestedTest.kt",
+            """
+            import kotlin.test.Test
+
+            class Outer {
+                class Middle {
+                    class Inner {
+                        @Test
+                        fun deepTest() {}
+                    }
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("Inner")
+
+        assertEquals("Outer.Middle.Inner.*", KonvoyPsiUtils.testSuiteFilter(testClass))
+    }
+
+    fun testTestSuiteFilterQualifiesTopLevelObject() {
+        val file = myFixture.configureByText(
+            "ObjectTest.kt",
+            """
+            import kotlin.test.Test
+
+            object ObjectTest {
+                @Test
+                fun objectRoot() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testObject = file.findClassOrObject("ObjectTest")
+
+        assertEquals("ObjectTest.*", KonvoyPsiUtils.testSuiteFilter(testObject))
+    }
+
+    fun testTestSuiteFilterKeepsBacktickClassNameWithSpaces() {
+        val file = myFixture.configureByText(
+            "BacktickClassTest.kt",
+            """
+            import kotlin.test.Test
+
+            class `Main Test` {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("Main Test")
+
+        assertEquals("Main Test.*", KonvoyPsiUtils.testSuiteFilter(testClass))
+    }
+
+    fun testFindTestSuiteDetectsTestClassNameIdentifierInTestSource() {
+        val file = addProjectFile(
+            "src/test/MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("MainTest")
+
+        assertTrue(
+            "expected ${testClass.containingFile.virtualFile.path} to be in src/test with basePath=${project.basePath}",
+            KonvoyPsiUtils.isInTestSource(testClass.nameIdentifier!!, project),
+        )
+        assertSame(testClass, KonvoyPsiUtils.findTestSuite(testClass.nameIdentifier!!, project))
+    }
+
+    fun testFindTestSuiteDetectsTestClassElementInTestSource() {
+        val file = addProjectFile(
+            "src/test/MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("MainTest")
+
+        assertTrue(
+            "expected ${testClass.containingFile.virtualFile.path} to be in src/test with basePath=${project.basePath}",
+            KonvoyPsiUtils.isInTestSource(testClass, project),
+        )
+        assertSame(testClass, KonvoyPsiUtils.findTestSuite(testClass, project))
+    }
+
+    fun testFindTestSuiteDetectsNestedTestClassNameIdentifierInTestSource() {
+        val file = addProjectFile(
+            "src/test/NestedTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                class Nested {
+                    @Test
+                    fun nestedGreetingIncludesName() {}
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("Nested")
+
+        assertSame(testClass, KonvoyPsiUtils.findTestSuite(testClass.nameIdentifier!!, project))
+    }
+
+    fun testFindTestSuiteDetectsTestObjectNameIdentifierInTestSource() {
+        val file = addProjectFile(
+            "src/test/ObjectTest.kt",
+            """
+            import kotlin.test.Test
+
+            object ObjectTest {
+                @Test
+                fun objectRoot() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testObject = file.findClassOrObject("ObjectTest")
+
+        assertSame(testObject, KonvoyPsiUtils.findTestSuite(testObject.nameIdentifier!!, project))
+    }
+
+    fun testFindTestSuiteIgnoresClassOutsideTestSource() {
+        val file = addProjectFile(
+            "src/main/MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("MainTest")
+
+        assertNull(KonvoyPsiUtils.findTestSuite(testClass.nameIdentifier!!, project))
+    }
+
+    fun testFindTestSuiteIgnoresClassWithoutTestFunctions() {
+        val file = addProjectFile(
+            "src/test/Helper.kt",
+            """
+            class Helper {
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val testClass = file.findClassOrObject("Helper")
+
+        assertNull(KonvoyPsiUtils.findTestSuite(testClass.nameIdentifier!!, project))
+    }
+
+    fun testFindTestSuiteIgnoresFunctionNameIdentifier() {
+        val file = addProjectFile(
+            "src/test/MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("greetingIncludesName")
+
+        assertNull(KonvoyPsiUtils.findTestSuite(function.nameIdentifier!!, project))
+    }
+
+    fun testTestFilterQualifiesClassMethod() {
+        val file = myFixture.configureByText(
+            "MainTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun greetingIncludesName() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("greetingIncludesName")
+
+        assertEquals("MainTest.greetingIncludesName", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterQualifiesNestedClassMethod() {
+        val file = myFixture.configureByText(
+            "NestedTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                class Nested {
+                    @Test
+                    fun nestedGreetingIncludesName() {}
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("nestedGreetingIncludesName")
+
+        assertEquals(
+            "MainTest.Nested.nestedGreetingIncludesName",
+            KonvoyPsiUtils.testFilter(function),
+        )
+    }
+
+    fun testTestFilterQualifiesDeeplyNestedClassMethod() {
+        val file = myFixture.configureByText(
+            "DeepNestedTest.kt",
+            """
+            import kotlin.test.Test
+
+            class Outer {
+                class Middle {
+                    class Inner {
+                        @Test
+                        fun deepTest() {}
+                    }
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("deepTest")
+
+        assertEquals("Outer.Middle.Inner.deepTest", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterQualifiesNestedObjectMethod() {
+        val file = myFixture.configureByText(
+            "NestedObjectTest.kt",
+            """
+            import kotlin.test.Test
+
+            class Outer {
+                object NestedObject {
+                    @Test
+                    fun objectTest() {}
+                }
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("objectTest")
+
+        assertEquals("Outer.NestedObject.objectTest", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterQualifiesTopLevelObjectMethod() {
+        val file = myFixture.configureByText(
+            "ObjectTest.kt",
+            """
+            import kotlin.test.Test
+
+            object ObjectTest {
+                @Test
+                fun objectRoot() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("objectRoot")
+
+        assertEquals("ObjectTest.objectRoot", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterKeepsTopLevelFunctionName() {
+        val file = myFixture.configureByText(
+            "TopLevelTest.kt",
+            """
+            import kotlin.test.Test
+
+            @Test
+            fun topLevelTest() {}
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("topLevelTest")
+
+        assertEquals("topLevelTest", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterKeepsBacktickFunctionNameWithSpaces() {
+        val file = myFixture.configureByText(
+            "BacktickTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun `greeting includes spaces`() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("greeting includes spaces")
+
+        assertEquals("MainTest.greeting includes spaces", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterKeepsBacktickFunctionNameWithQuotes() {
+        val file = myFixture.configureByText(
+            "QuotedBacktickTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun `says "hi"`() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction("says \"hi\"")
+
+        assertEquals("MainTest.says \"hi\"", KonvoyPsiUtils.testFilter(function))
+    }
+
+    fun testTestFilterKeepsBacktickFunctionNameWithLeadingAndTrailingSpaces() {
+        val file = myFixture.configureByText(
+            "LeadingTrailingBacktickTest.kt",
+            """
+            import kotlin.test.Test
+
+            class MainTest {
+                @Test
+                fun ` leading and trailing `() {}
+            }
+            """.trimIndent(),
+        ) as KtFile
+
+        val function = file.findFunction(" leading and trailing ")
+
+        assertEquals("MainTest. leading and trailing ", KonvoyPsiUtils.testFilter(function))
+    }
+
+    private fun addProjectFile(path: String, text: String): KtFile =
+        myFixture.addFileToProject(path, text.trimIndent()) as KtFile
+
+    private fun KtFile.findFunction(name: String): KtNamedFunction =
+        declarations.flatMap { declaration -> declaration.functions() }
+            .single { it.name == name }
+
+    private fun KtFile.findClassOrObject(name: String): KtClassOrObject =
+        declarations.flatMap { declaration -> declaration.classOrObjects() }
+            .single { it.name == name }
+
+    private fun KtDeclaration.functions(): List<KtNamedFunction> =
+        when (this) {
+            is KtNamedFunction -> listOf(this)
+            is KtClassOrObject -> declarations.flatMap { it.functions() }
+            else -> emptyList()
+        }
+
+    private fun KtDeclaration.classOrObjects(): List<KtClassOrObject> =
+        when (this) {
+            is KtClassOrObject -> listOf(this) + declarations.flatMap { it.classOrObjects() }
+            else -> emptyList()
+        }
+}


### PR DESCRIPTION
## Summary

- Generate class-qualified Konvoy test filters for Kotlin test methods, e.g. `MainTest.greetingIncludesName`.
- Treat non-function contexts under `src/test/` as full-suite `konvoy test` runs instead of falling through to `konvoy run`.
- Add IntelliJ fixture tests for test filter formatting.

## Root Cause

The gutter action for a specific test produced `konvoy test --filter=<functionName>`, but Kotlin/Native reports class methods as `ClassName.functionName`, so the filter matched zero tests. Broader test gutter contexts, such as class/file/all-tests actions in `src/test`, did not resolve to a specific `@Test` function and fell through to the default bin-project configuration, which runs `konvoy run`.

## Validation

- `JAVA_HOME=/Users/arncore/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home ./gradlew test buildPlugin` from `editors/intellij`
- `konvoy test --filter=MainTest.greetingIncludesName` from `/Users/arncore/Documents/konvoy-intellij-hello`
- `konvoy test` from `/Users/arncore/Documents/konvoy-intellij-hello`
