### PR TITLE
[codex] Rename agent instructions file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to coding agents when working with code in this repository.
 
 ## Project overview
 

--- a/crates/konvoy-util/src/pom.rs
+++ b/crates/konvoy-util/src/pom.rs
@@ -303,7 +303,7 @@ pub fn pom_url(group_id: &str, artifact_id: &str, version: &str) -> String {
 
 /// Build the on-disk cache path for a Maven artifact metadata file.
 ///
-/// Layout matches the contract in CLAUDE.md:
+/// Layout matches the contract in AGENTS.md:
 /// `~/.konvoy/cache/pom/<group_path>/<artifact_id>-<version>.<extension>`.
 ///
 /// `group_id` is split on `.` so that `org.jetbrains.kotlinx` becomes
@@ -981,7 +981,7 @@ mod tests {
     }
 
     #[test]
-    fn pom_cache_path_layout_matches_claude_md_contract() {
+    fn pom_cache_path_layout_matches_agents_md_contract() {
         // Verify the layout suffix without depending on HOME (env mutation in
         // tests races with other tests in the crate). The suffix is the
         // load-bearing part — the prefix is `konvoy_home()` which is tested

--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -10,13 +10,13 @@ Design crate APIs, data flow, and structural decisions before implementation beg
 - Design the data flow between crates (what types cross crate boundaries)
 - Decide where new functionality belongs in the crate hierarchy
 - Ensure no circular dependencies between crates
-- Validate that proposed changes align with CLAUDE.md philosophy (no task graphs, no DSLs, no JVM)
+- Validate that proposed changes align with AGENTS.md philosophy (no task graphs, no DSLs, no JVM)
 - Reject scope creep beyond MVP boundaries
 
 ## Inputs
 
 - Feature requests or bug reports
-- CLAUDE.md (project philosophy and constraints)
+- AGENTS.md (project philosophy and constraints)
 - Current crate structure and public APIs
 
 ## Outputs

--- a/docs/agents/implementer.md
+++ b/docs/agents/implementer.md
@@ -16,7 +16,7 @@ Write production code across all crates. The implementer receives designs from t
 ## Workflow
 
 1. Read the architect's design (type signatures, data flow, module placement)
-2. Read CLAUDE.md for project constraints
+2. Read AGENTS.md for project constraints
 3. Implement in dependency order (leaf crates first: `konvoy-util` → `konvoy-config` / `konvoy-targets` → `konvoy-konanc` → `konvoy-engine` → `konvoy-cli`)
 4. Write tests for each public function
 5. Run `cargo test --workspace` and `cargo clippy --workspace -- -D warnings` before marking work complete
@@ -25,6 +25,6 @@ Write production code across all crates. The implementer receives designs from t
 
 - Never use `.unwrap()`, `.expect()`, `panic!()`, or direct indexing (`slice[i]`)
 - Never introduce dependencies not listed in the workspace `Cargo.toml`
-- Never exceed MVP scope (see CLAUDE.md) without explicit direction
+- Never exceed MVP scope (see AGENTS.md) without explicit direction
 - Error types use `thiserror` — error messages must be lowercase and actionable
 - No dead code — if something isn't used yet, don't write it

--- a/docs/agents/reviewer.md
+++ b/docs/agents/reviewer.md
@@ -7,7 +7,7 @@ Review code changes for correctness, style compliance, and alignment with projec
 ## Responsibilities
 
 - Verify code follows `docs/code-style.md` conventions
-- Verify code respects CLAUDE.md non-negotiables (no DSLs, no JVM, declarative config, stable output paths, determinism, actionable errors)
+- Verify code respects AGENTS.md non-negotiables (no DSLs, no JVM, declarative config, stable output paths, determinism, actionable errors)
 - Check that lint rules pass: `cargo clippy --workspace -- -D warnings`
 - Check that formatting passes: `cargo fmt --all -- --check`
 - Check that all tests pass: `cargo test --workspace`
@@ -32,7 +32,7 @@ Review code changes for correctness, style compliance, and alignment with projec
 
 Every valid suggestion is blocking. There is no "non-blocking" category.
 
-If a finding is valid — meaning it violates a code style rule, a CLAUDE.md non-negotiable, a crate boundary convention, or a project quality standard — it blocks approval. Do not soften valid findings into optional suggestions. Small issues compound as the codebase grows, and the reviewer exists to catch them before they accumulate.
+If a finding is valid — meaning it violates a code style rule, an AGENTS.md non-negotiable, a crate boundary convention, or a project quality standard — it blocks approval. Do not soften valid findings into optional suggestions. Small issues compound as the codebase grows, and the reviewer exists to catch them before they accumulate.
 
 - If it violates a documented rule, it blocks.
 - If it introduces an unnecessary dependency, it blocks.


### PR DESCRIPTION
## Summary
- Rename `CLAUDE.md` to `AGENTS.md`
- Update agent docs and code comments to reference `AGENTS.md`
- Remove remaining Claude-specific wording from the agent guidance file and test names

## Validation
- `rg -n "Claude|claude|CLAUDE\.md" .` returned no matches
- `git diff --check`
