### PR TITLE
[codex] Bump release versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap",
  "konvoy-config",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proptest",
  "serde",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-engine"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "indicatif",
  "konvoy-config",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-konanc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "flate2",
  "indicatif",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-targets"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proptest",
  "serde",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-util"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "glob",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/editors/intellij/gradle.properties
+++ b/editors/intellij/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup = com.konvoy.ide
 pluginName = Konvoy
-pluginVersion = 1.0.0
+pluginVersion = 1.0.1
 
 platformType = IC
 platformVersion = 2024.2.1


### PR DESCRIPTION
## Summary
- Bump Rust workspace packages to `1.2.1`
- Refresh workspace package versions in `Cargo.lock`
- Bump IntelliJ plugin version to `1.0.1`

## Validation
- `cargo test --workspace --locked`
- `JAVA_HOME=/Users/arncore/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.10+7/Contents/Home ./gradlew test buildPlugin`

## Release plan
After this lands on `main`, tag:
- `v1.2.1` for the CLI release workflow
- `intellij-v1.0.1` for the IntelliJ plugin release workflow
