### PR TITLE
[codex] Fix IntelliJ tag release workflow

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     name: Build & Test
     needs: [changes]
-    if: needs.changes.outputs.plugin == 'true'
+    if: startsWith(github.ref, 'refs/tags/intellij-v') || needs.changes.outputs.plugin == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix IntelliJ plugin tag releases by forcing `Build & Test` to run for `intellij-v*` tags
- Preserve path-filtered skips for normal PR/main runs with no IntelliJ changes

## Root cause
The `intellij-v1.0.1` tag workflow ran `Verify Compatibility`, but `Build & Test` was skipped because the job only checked `needs.changes.outputs.plugin == 'true'`. Since `Attach to Release` depends on `build`, it was skipped too and no plugin zip was attached to a GitHub release.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/intellij-plugin.yml"); puts "yaml ok"'`
- `git diff --check`

## Follow-up
After this lands, rerun/recreate the IntelliJ tag release so the fixed workflow builds and uploads `konvoy-intellij-1.0.1.zip`.
