### PR TITLE
[codex] Add IntelliJ target selector

### DIFF
--- a/editors/intellij/README.md
+++ b/editors/intellij/README.md
@@ -60,6 +60,10 @@ Run configurations for all Konvoy commands:
 
 Right-click on `konvoy.toml` to create a run configuration, or use the run menu.
 
+Run configurations include a target selector with `Host`, `linux_x64`,
+`linux_arm64`, `macos_x64`, and `macos_arm64`. The selected target is passed
+as `--target` for build, run, and test configurations.
+
 The plugin runs Konvoy through IntelliJ's colored process handler and sets
 `KONVOY_PROGRESS=plain`, so downloads leave readable completed truck rows in
 the Run tool window without ANSI cursor-control redraws.

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfiguration.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfiguration.kt
@@ -20,6 +20,7 @@ class KonvoyRunConfiguration(
 ) : RunConfigurationBase<RunConfigurationOptions>(project, factory, name) {
 
     var command: KonvoyCommand = KonvoyCommand.RUN
+    var target: KonvoyTarget = KonvoyTarget.HOST
     var extraArgs: String = ""
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
@@ -42,6 +43,7 @@ class KonvoyRunConfiguration(
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
         element.setAttribute("konvoy-command", command.name)
+        element.setAttribute("konvoy-target", target.name)
         element.setAttribute("konvoy-extra-args", extraArgs)
     }
 
@@ -50,6 +52,9 @@ class KonvoyRunConfiguration(
         command = element.getAttributeValue("konvoy-command")
             ?.let { name -> KonvoyCommand.entries.find { it.name == name } }
             ?: KonvoyCommand.RUN
+        target = element.getAttributeValue("konvoy-target")
+            ?.let { name -> KonvoyTarget.entries.find { it.name == name } }
+            ?: KonvoyTarget.HOST
         extraArgs = element.getAttributeValue("konvoy-extra-args") ?: ""
     }
 }
@@ -61,12 +66,29 @@ enum class KonvoyCommand(val displayName: String, val subcommand: String) {
     LINT("Lint", "lint"),
 }
 
+internal val KonvoyCommand.supportsTarget: Boolean
+    get() = this != KonvoyCommand.LINT
+
+enum class KonvoyTarget(val displayName: String, val cliValue: String?) {
+    HOST("Host", null),
+    LINUX_X64("linux_x64", "linux_x64"),
+    LINUX_ARM64("linux_arm64", "linux_arm64"),
+    MACOS_X64("macos_x64", "macos_x64"),
+    MACOS_ARM64("macos_arm64", "macos_arm64");
+
+    override fun toString(): String = displayName
+}
+
 internal fun createKonvoyCommandLine(
     workDirectory: File,
     command: KonvoyCommand,
+    target: KonvoyTarget,
     extraArgs: String,
 ): GeneralCommandLine {
     val cmd = GeneralCommandLine("konvoy", command.subcommand)
+    if (command.supportsTarget && target.cliValue != null) {
+        cmd.addParameters("--target", target.cliValue)
+    }
     if (extraArgs.isNotBlank()) {
         cmd.addParameters(ParametersList.parse(extraArgs).toList())
     }
@@ -88,6 +110,7 @@ class KonvoyCommandLineState(
         val cmd = createKonvoyCommandLine(
             File(config.project.basePath!!),
             config.command,
+            config.target,
             config.extraArgs,
         )
         return ProcessHandlerFactory.getInstance().createColoredProcessHandler(cmd)

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoySettingsEditor.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoySettingsEditor.kt
@@ -11,11 +11,22 @@ import javax.swing.JTextField
  */
 class KonvoySettingsEditor : SettingsEditor<KonvoyRunConfiguration>() {
     private val commandCombo = ComboBox(KonvoyCommand.entries.toTypedArray())
+    private val targetCombo = ComboBox(KonvoyTarget.entries.toTypedArray())
     private val extraArgsField = JTextField()
+
+    init {
+        commandCombo.addActionListener {
+            updateTargetSelector()
+        }
+        updateTargetSelector()
+    }
 
     override fun createEditor(): JComponent = panel {
         row("Command:") {
             cell(commandCombo)
+        }
+        row("Target:") {
+            cell(targetCombo)
         }
         row("Extra arguments:") {
             cell(extraArgsField).resizableColumn()
@@ -24,11 +35,22 @@ class KonvoySettingsEditor : SettingsEditor<KonvoyRunConfiguration>() {
 
     override fun applyEditorTo(config: KonvoyRunConfiguration) {
         config.command = commandCombo.selectedItem as KonvoyCommand
+        config.target = targetCombo.selectedItem as KonvoyTarget
         config.extraArgs = extraArgsField.text
     }
 
     override fun resetEditorFrom(config: KonvoyRunConfiguration) {
         commandCombo.selectedItem = config.command
+        targetCombo.selectedItem = config.target
         extraArgsField.text = config.extraArgs
+        updateTargetSelector()
+    }
+
+    private fun updateTargetSelector() {
+        val selectedCommand = commandCombo.selectedItem as? KonvoyCommand ?: KonvoyCommand.RUN
+        targetCombo.isEnabled = isTargetSelectorEnabled(selectedCommand)
     }
 }
+
+internal fun isTargetSelectorEnabled(command: KonvoyCommand): Boolean =
+    command.supportsTarget

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationCommandLineTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationCommandLineTest.kt
@@ -7,13 +7,13 @@ import java.io.File
 class KonvoyRunConfigurationCommandLineTest : TestCase() {
 
     fun testCommandLineRequestsPlainProgressForRunConsole() {
-        val cmd = createKonvoyCommandLine(File("/tmp/project"), KonvoyCommand.RUN, "")
+        val cmd = createKonvoyCommandLine(File("/tmp/project"), KonvoyCommand.RUN, KonvoyTarget.HOST, "")
 
         assertEquals("plain", cmd.environment["KONVOY_PROGRESS"])
     }
 
     fun testCommandLineUsesConsoleParentEnvironment() {
-        val cmd = createKonvoyCommandLine(File("/tmp/project"), KonvoyCommand.TEST, "")
+        val cmd = createKonvoyCommandLine(File("/tmp/project"), KonvoyCommand.TEST, KonvoyTarget.HOST, "")
 
         assertEquals(
             GeneralCommandLine.ParentEnvironmentType.CONSOLE,
@@ -25,10 +25,49 @@ class KonvoyRunConfigurationCommandLineTest : TestCase() {
         val cmd = createKonvoyCommandLine(
             File("/tmp/project"),
             KonvoyCommand.TEST,
+            KonvoyTarget.HOST,
             "--filter \"OtherTest.i am a test\"",
         )
 
         assertEquals("/tmp/project", cmd.workDirectory.path)
         assertEquals(listOf("test", "--filter", "OtherTest.i am a test"), cmd.parametersList.parameters)
+    }
+
+    fun testCommandLineAddsSpecificTargetBeforeExtraArgs() {
+        val cmd = createKonvoyCommandLine(
+            File("/tmp/project"),
+            KonvoyCommand.TEST,
+            KonvoyTarget.MACOS_ARM64,
+            "--filter MainTest.*",
+        )
+
+        assertEquals(
+            listOf("test", "--target", "macos_arm64", "--filter", "MainTest.*"),
+            cmd.parametersList.parameters,
+        )
+    }
+
+    fun testCommandLineOmitsHostTarget() {
+        val cmd = createKonvoyCommandLine(File("/tmp/project"), KonvoyCommand.BUILD, KonvoyTarget.HOST, "")
+
+        assertEquals(listOf("build"), cmd.parametersList.parameters)
+    }
+
+    fun testCommandLineDoesNotAddTargetForLint() {
+        val cmd = createKonvoyCommandLine(
+            File("/tmp/project"),
+            KonvoyCommand.LINT,
+            KonvoyTarget.LINUX_X64,
+            "--verbose",
+        )
+
+        assertEquals(listOf("lint", "--verbose"), cmd.parametersList.parameters)
+    }
+
+    fun testTargetSelectorIsOnlyEnabledForCommandsThatAcceptTargets() {
+        assertTrue(isTargetSelectorEnabled(KonvoyCommand.BUILD))
+        assertTrue(isTargetSelectorEnabled(KonvoyCommand.RUN))
+        assertTrue(isTargetSelectorEnabled(KonvoyCommand.TEST))
+        assertFalse(isTargetSelectorEnabled(KonvoyCommand.LINT))
     }
 }


### PR DESCRIPTION
## Summary

Adds a target selector to Konvoy IntelliJ run configurations so users can choose Host, linux_x64, linux_arm64, macos_x64, or macos_arm64 from the configuration editor.

The selected target is persisted with the run configuration and passed as `--target <value>` for build, run, and test commands. Host keeps the existing behavior by omitting `--target`, and lint ignores target selection.

## Validation

- `JAVA_HOME='/Applications/IntelliJ IDEA 2026.2 EAP.app/Contents/jbr/Contents/Home' ./gradlew test --tests 'com.konvoy.ide.run.*' checkPluginConfiguration`
- Built and installed the branch plugin in IntelliJ IDEA 2026.2 EAP
- Verified the Run window executes `konvoy run --target macos_arm64` for a run config with `konvoy-target="MACOS_ARM64"`
