### PR TITLE
Fix spurious one-time recompile of projects with plugins

### DIFF
--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
-use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile};
+use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile, PluginLock};
 use konvoy_config::manifest::{Manifest, PackageKind};
 use konvoy_config::Profile;
 use konvoy_konanc::detect::{resolve_konanc, KonancInfo};
@@ -110,7 +110,7 @@ pub(crate) fn library_paths_of(libs: &[LibraryInput]) -> Vec<PathBuf> {
     libs.iter().map(|l| l.path.clone()).collect()
 }
 
-/// Common state resolved during steps 1–7b of the build pipeline.
+/// Common state resolved during steps 1–7a of the build pipeline.
 ///
 /// Shared between `build()` and `build_tests()` to avoid duplicating the
 /// manifest, lockfile, toolchain, and dependency resolution logic.
@@ -152,7 +152,69 @@ pub(crate) struct LockfileWriteInputs {
     pub jre_tarball_sha256: Option<String>,
 }
 
-/// Resolve the common build pipeline state (steps 1–7b).
+/// Compute the pre-stabilized "effective" lockfile used for the cache key.
+///
+/// Predicts the `konvoy.lock` that `update_lockfile_if_needed` will write after
+/// the build, so the cache key is identical on the first and on subsequent
+/// builds (issue #133):
+///
+/// - In `--locked` mode the on-disk lockfile is authoritative and returned
+///   unchanged (the user explicitly forbids any modification; it already
+///   contains the plugin entries, enforced by the staleness check).
+/// - Otherwise the toolchain section is stabilized to the detected konanc
+///   version (predicting the post-build write), existing dependencies are
+///   preserved, and the predicted `[[plugins]]` entries (`plugin_locks`,
+///   resolved before the cache key is computed) are folded in.
+///
+/// Folding the plugin entries in BOTH the version-matches branch and the
+/// stabilized branch is what fixes the spurious one-time recompile of projects
+/// with plugins: the first build's on-disk lockfile has no `[[plugins]]`
+/// entries yet, but the second build reads them back from disk. Without folding,
+/// the two builds produce different `lockfile_content` and therefore different
+/// cache keys. Plugins genuinely affect compilation, so they must stay in the
+/// cache key — folding the predicted entries in is what keeps it stable.
+fn predicted_effective_lockfile(
+    lockfile: &Lockfile,
+    konanc_version: &str,
+    konanc_tarball_sha256: Option<&str>,
+    jre_tarball_sha256: Option<&str>,
+    plugin_locks: &[PluginLock],
+    locked: bool,
+) -> Lockfile {
+    // In --locked mode the lockfile must not change. It already contains the
+    // plugin entries (the staleness check enforces this), so no fold is needed.
+    if locked {
+        return lockfile.clone();
+    }
+
+    let mut effective = match &lockfile.toolchain {
+        // Lockfile already has the correct version — use as-is (preserves any
+        // existing tarball hashes and detekt info).
+        Some(tc) if tc.konanc_version == konanc_version => lockfile.clone(),
+        // Lockfile is missing or has a different version. Build the same
+        // lockfile that will eventually be written so the cache key is stable
+        // from the first build. Preserve existing dependencies (e.g. Maven deps
+        // written by `konvoy update`).
+        _ => {
+            let mut stabilized = Lockfile::with_managed_toolchain(
+                konanc_version,
+                konanc_tarball_sha256,
+                jre_tarball_sha256,
+            );
+            stabilized.dependencies = lockfile.dependencies.clone();
+            stabilized
+        }
+    };
+
+    // Fold the predicted [[plugins]] entries into the effective lockfile in
+    // BOTH branches above, matching what `update_lockfile_if_needed` writes
+    // (`updated.plugins = plugin_locks`). This keeps the cache key identical
+    // across the first and second builds of a project with plugins.
+    effective.plugins = plugin_locks.to_vec();
+    effective
+}
+
+/// Resolve the common build pipeline state (steps 1–7a).
 ///
 /// This is the shared core of both `build()` and `build_tests()`:
 /// 1. Read `konvoy.toml` and `konvoy.lock`
@@ -160,9 +222,11 @@ pub(crate) struct LockfileWriteInputs {
 /// 3. Check lockfile staleness in `--locked` mode
 /// 4. Resolve target and profile
 /// 5. Resolve managed konanc toolchain
-/// 6. Pre-stabilize lockfile for cache key consistency
-/// 7. Resolve + build path dependencies in topological order,
-///    resolve plugin artifacts, and download Maven dependency klibs
+/// 6. Resolve plugin artifacts, then pre-stabilize the lockfile for cache-key
+///    consistency (the predicted `[[plugins]]` entries are folded in so the
+///    cache key is stable from the first build)
+/// 7. Resolve + build path dependencies in topological order, then download
+///    Maven dependency klibs
 pub(crate) fn resolve_build_context(
     project_root: &Path,
     options: &BuildOptions,
@@ -204,7 +268,8 @@ pub(crate) fn resolve_build_context(
     let konanc_tarball_sha256 = resolved.konanc_tarball_sha256;
     let jre_tarball_sha256 = resolved.jre_tarball_sha256;
 
-    // 6. Pre-stabilize the lockfile for cache key consistency (issue #133).
+    // 6. Resolve plugin artifacts, then pre-stabilize the lockfile for
+    //    cache-key consistency (issue #133).
     //
     // When `konvoy.lock` does not exist (first build) or the toolchain version
     // has changed, the lockfile read at step 2 will differ from what
@@ -213,32 +278,38 @@ pub(crate) fn resolve_build_context(
     // stale/empty lockfile, then the lockfile is updated on disk, and the
     // second build sees different content and misses the cache.
     //
+    // Plugins are part of this prediction: their `[[plugins]]` lock entries are
+    // only written at the END of the build, so we must resolve them HERE —
+    // before computing `lockfile_content` — and fold the predicted entries into
+    // the effective lockfile. Otherwise a project with a `[plugins]` section
+    // recompiles once unnecessarily after its first build (issue #133 class).
+    //
+    // Hash lookup uses the on-disk `lockfile` (its `[[plugins]]` entries, if
+    // any), which is exactly what the effective lockfile carried before folding.
+    // On a warm cache the artifacts are already present and pinned, so
+    // `ensure_plugin_artifacts` only re-verifies hashes — it does not download.
+    let (plugin_jars, plugin_locks) = if !manifest.plugins.is_empty() {
+        let resolved_artifacts = crate::plugin::resolve_plugin_artifacts(&manifest)?;
+        let results =
+            crate::plugin::ensure_plugin_artifacts(&resolved_artifacts, &lockfile, options.locked)?;
+        let locks = crate::plugin::build_plugin_locks(&results);
+        let jars: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
+        (jars, locks)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     // We predict the lockfile content that will eventually be written, so the
     // cache key is the same in the first and second builds. In `--locked` mode
-    // we must use the lockfile as-is because the user explicitly forbids changes.
-    let effective_lockfile = if options.locked {
-        lockfile.clone()
-    } else {
-        match &lockfile.toolchain {
-            // Lockfile already has the correct version — use as-is
-            // (preserves any existing tarball hashes and detekt info).
-            Some(tc) if tc.konanc_version == konanc.version => lockfile.clone(),
-            // Lockfile is missing or has a different version. Build the same
-            // lockfile that will eventually be written so the cache key is
-            // stable from the first build. Preserve existing dependencies and
-            // plugins (e.g. Maven deps written by `konvoy update`).
-            _ => {
-                let mut stabilized = Lockfile::with_managed_toolchain(
-                    &konanc.version,
-                    konanc_tarball_sha256.as_deref(),
-                    jre_tarball_sha256.as_deref(),
-                );
-                stabilized.dependencies = lockfile.dependencies.clone();
-                stabilized.plugins = lockfile.plugins.clone();
-                stabilized
-            }
-        }
-    };
+    // the lockfile is used as-is because the user explicitly forbids changes.
+    let effective_lockfile = predicted_effective_lockfile(
+        &lockfile,
+        &konanc.version,
+        konanc_tarball_sha256.as_deref(),
+        jre_tarball_sha256.as_deref(),
+        &plugin_locks,
+        options.locked,
+    );
 
     // 7. Resolve dependencies and build them in topological order.
     let dep_graph = resolve_dependencies(project_root, &manifest)?;
@@ -290,22 +361,7 @@ pub(crate) fn resolve_build_context(
         .map(LibraryInput::unhashed)
         .collect();
 
-    // 7a. Resolve and download plugin artifacts.
-    let (plugin_jars, plugin_locks) = if !manifest.plugins.is_empty() {
-        let resolved_artifacts = crate::plugin::resolve_plugin_artifacts(&manifest)?;
-        let results = crate::plugin::ensure_plugin_artifacts(
-            &resolved_artifacts,
-            &effective_lockfile,
-            options.locked,
-        )?;
-        let locks = crate::plugin::build_plugin_locks(&results);
-        let jars: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
-        (jars, locks)
-    } else {
-        (Vec::new(), Vec::new())
-    };
-
-    // 7b. Resolve and download Maven dependency klibs for the current target.
+    // 7a. Resolve and download Maven dependency klibs for the current target.
     //     Each Maven klib comes back with a precomputed sha256 from
     //     `download_artifact`, which the cache-key code reuses to skip rehashing.
     let maven_klibs = resolve_maven_deps(&effective_lockfile, &target)?;
@@ -341,11 +397,12 @@ pub(crate) fn resolve_build_context(
 /// 3. Check lockfile staleness (in --locked mode)
 /// 4. Detect host target (or resolve `--target` flag)
 /// 5. Detect `konanc` and get version + fingerprint
-/// 6. Pre-stabilize lockfile for cache key consistency (issue #133)
+/// 6. Resolve plugin artifacts and pre-stabilize the lockfile (including the
+///    predicted `[[plugins]]` entries) for cache key consistency (issue #133)
 /// 7. Resolve dependencies and build them in topological order
 /// 8. Build the root project (collect sources, compute cache key,
 ///    check cache, invoke compiler, store artifact)
-/// 9. Update `konvoy.lock` if toolchain version changed
+/// 9. Update `konvoy.lock` if toolchain, dependencies, or plugins changed
 ///
 /// # Errors
 /// Returns an error if any step fails (config parsing, compiler detection,
@@ -2434,6 +2491,70 @@ mod tests {
         assert_eq!(
             content_first_h, content_second_h,
             "cache key lockfile content must be identical between first and second builds (with hashes)"
+        );
+    }
+
+    /// Like `pre_stabilized_lockfile_matches_post_update_lockfile` but for a
+    /// project with a `[plugins]` section. The pre-stabilized lockfile content
+    /// computed on the first build (when the on-disk lockfile has no plugin
+    /// entries yet) MUST equal the content computed on the second build (when
+    /// the lockfile has been populated with plugin entries by the first build).
+    ///
+    /// Otherwise the cache key differs and the project recompiles once
+    /// unnecessarily after its first build (issue #133 class). Plugins genuinely
+    /// affect compilation, so they must stay in the cache key — they cannot be
+    /// excluded; instead the predicted entries are folded in on the first build.
+    #[test]
+    fn pre_stabilized_lockfile_matches_post_update_lockfile_with_plugins() {
+        let konanc_version = "2.1.0";
+
+        // The plugin lock entries resolved during the build — these are what
+        // `update_lockfile_if_needed` writes to disk (`updated.plugins`).
+        let plugin_locks = vec![PluginLock {
+            name: "kotlin-serialization".to_owned(),
+            maven: "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin".to_owned(),
+            version: konanc_version.to_owned(),
+            sha256: "plugin-sha-deadbeef".to_owned(),
+            url: "https://repo.maven.apache.org/plugin.jar".to_owned(),
+        }];
+
+        // First build: no lockfile on disk (default — no toolchain, no plugins).
+        let first_on_disk = Lockfile::default();
+        let effective_first = predicted_effective_lockfile(
+            &first_on_disk,
+            konanc_version,
+            None,
+            None,
+            &plugin_locks,
+            false,
+        );
+
+        // After the first build, `update_lockfile_if_needed` writes a lockfile
+        // with the managed toolchain plus the resolved plugin entries.
+        let mut written = Lockfile::with_managed_toolchain(konanc_version, None, None);
+        written.plugins = plugin_locks.clone();
+
+        // Second build reads `written` from disk (version matches) and resolves
+        // the same plugin locks again.
+        let effective_second = predicted_effective_lockfile(
+            &written,
+            konanc_version,
+            None,
+            None,
+            &plugin_locks,
+            false,
+        );
+
+        let content_first = lockfile_toml_content(&effective_first).unwrap();
+        let content_second = lockfile_toml_content(&effective_second).unwrap();
+        assert_eq!(
+            content_first, content_second,
+            "cache key lockfile content must be identical between the first and second \
+             builds of a project with plugins"
+        );
+        assert!(
+            content_first.contains("kotlin-serialization"),
+            "predicted plugin entries must be folded into the cache-key lockfile content"
         );
     }
 

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -28,7 +28,7 @@ pub struct TestBuildResult {
 /// sources (`src/test/**/*.kt`), then invokes konanc with `-generate-test-runner`
 /// to produce a test binary.
 ///
-/// Uses `resolve_build_context()` for the shared pipeline (steps 1–7b), then
+/// Uses `resolve_build_context()` for the shared pipeline (steps 1–7a), then
 /// adds test-specific source collection and compilation.
 ///
 /// # Errors

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -521,10 +521,20 @@ KOTLIN
     assert_file_contains konvoy.lock "maven ="
     assert_file_contains konvoy.lock "version ="
 
-    # --locked should succeed now that the lockfile has plugin entries.
-    # (May recompile due to lockfile content change — that's fine,
-    #  the key assertion is that --locked doesn't error out.)
-    konvoy build --locked 2>&1
+    # A second unchanged build MUST be a cache hit, not a recompile (issue #133
+    # class). The plugin lock entries are folded into the cache key on the first
+    # build, so the first and second builds compute the same key.
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked should also be a cache hit now that the lockfile has plugin
+    # entries (and must not error out).
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+    assert_not_contains "$out3" "Compiling"
 }
 
 test_plugin_kotlin_placeholder_resolves() {


### PR DESCRIPTION
## Problem

Every project with a `[plugins]` section recompiled **once unnecessarily** after its first build — a determinism wart (issue #133 class). The smoke test `test_plugin_build_lifecycle` explicitly tolerated it ("May recompile due to lockfile content change — that's fine").

**Root cause:** `crates/konvoy-engine/src/build.rs` `resolve_build_context` computed the cache-key `lockfile_content` during pre-stabilization (step 6) **before** plugin artifacts were resolved (old step 7a) and **before** `update_lockfile_if_needed` wrote the `[[plugins]]` lock entries at the end of the build.

- **Build 1**: on-disk lockfile has no `[[plugins]]` → cache key omits them.
- **Build 2**: lockfile is now populated → cache key includes them → different key → spurious recompile.

(`konvoy update` writes the toolchain + Maven deps but **not** plugin locks, so build 1 hits the version-matches branch with empty plugins.)

Plugins genuinely affect compilation, so they **must stay in** the cache key; the fix makes the first build predict them rather than excluding them.

## Fix

- **Extracted** the pre-stabilization match into a pure, testable helper `predicted_effective_lockfile`, which folds the predicted `[[plugins]]` entries into the effective lockfile in **both** non-locked branches (the version-matches clone branch *and* the stabilized branch).
- **Reordered** `resolve_build_context`: plugin artifacts are now resolved in step 6, **before** `lockfile_content` is computed, and the resulting `plugin_locks` are folded in. Hash lookup uses the on-disk `lockfile` (equivalent to what the effective lockfile carried before folding).
- `--locked` mode is untouched (on-disk lockfile is authoritative; the staleness check already guarantees plugin entries).

### Performance

No new network on a warm cache. Plugin resolution already ran inside `resolve_build_context` before the root cache check (in `build()` step 8) — this change only moves it earlier *within* that function. `ensure_plugin_artifacts` is a no-op for cached artifacts (existence check + local hash verify via `progress::fetch`'s `check_cached`, no download).

## Tests

- **New unit test** `pre_stabilized_lockfile_matches_post_update_lockfile_with_plugins`, mirroring the existing pre-stabilization test but for plugin entries. Written TDD-first: watched it fail (build 1 omitted `[[plugins]]`, build 2 included them — exactly the bug), then pass after the fold.
- **Updated smoke test** `test_plugin_build_lifecycle`: replaced the "may recompile — that's fine" tolerance with assertions that the second unchanged build **and** the `--locked` build are cache hits (`(cached)`, no `Compiling`).

`build_tests()` shares `resolve_build_context`, so it inherits the fix automatically.

## Verification

- `cargo test --workspace` → all pass (engine: 314, +1 new).
- `cargo clippy --workspace -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- `bash -n tests/smoke/tests.sh` → syntax OK; test registered in run list.

⚠️ The smoke shell test itself was **not executed** in the dev sandbox — it runs the real `konvoy` binary in Docker and downloads the Kotlin/Native toolchain + plugin jars from Maven (network), which wasn't available. The build-1/build-2 scenario was traced manually to confirm the new assertions hold; the test should be run via `tests/smoke/run.sh` (Docker) before merge for full confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)