### PR TITLE
codegen (2/5): shared managed-JAR-tool abstraction + Fabrikt generator + input hashing

### DIFF
--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -1,0 +1,261 @@
+//! Declarative source generation before Kotlin/Native compilation.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use konvoy_config::manifest::Codegen;
+
+use crate::error::EngineError;
+
+pub mod openapi;
+
+// The managed-JAR-tool abstraction is shared with the detekt linter, so it lives
+// at the engine root (`crate::managed_tool`); re-exported here for codegen callers.
+pub use crate::managed_tool::ManagedToolSpec;
+
+/// Display metadata for a configured generator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratorSummary {
+    /// Stable generator name used in paths and cache key tags.
+    pub name: String,
+    /// Human-readable generator label.
+    pub display_name: String,
+    /// Directory containing this generator's outputs.
+    pub output_dir: PathBuf,
+}
+
+/// A configured code generator.
+pub trait CodeGenerator {
+    /// Stable generator name used in paths and cache key tags.
+    fn name(&self) -> &str;
+
+    /// Human-readable generator label.
+    fn display_name(&self) -> &str;
+
+    /// Managed tool required by this generator.
+    fn managed_tool(&self) -> ManagedToolSpec;
+
+    /// Stable config fields that affect generated sources.
+    fn config_hash_parts(&self) -> Vec<String>;
+
+    /// Project-relative input files read by this generator.
+    ///
+    /// `project_root` lets generators enumerate inputs that live on disk (e.g.
+    /// every file under a configured spec directory). The returned paths are
+    /// project-relative and their contents are folded into the generator hash
+    /// (and thus the build cache key).
+    ///
+    /// # Errors
+    /// Returns an error if a configured input location (e.g. a spec directory)
+    /// is missing or cannot be read.
+    fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError>;
+
+    /// Generate sources into `output_dir`.
+    ///
+    /// # Errors
+    /// Returns an error if the generator process cannot be executed or fails.
+    fn generate(
+        &self,
+        project_root: &Path,
+        output_dir: &Path,
+        tool_path: &Path,
+        jre_home: &Path,
+        verbose: bool,
+    ) -> Result<(), EngineError>;
+}
+
+/// Return all active generators in stable order.
+pub fn active_generators(codegen: &Codegen) -> Vec<Box<dyn CodeGenerator>> {
+    let mut generators: Vec<Box<dyn CodeGenerator>> = Vec::new();
+    if let Some(openapi) = &codegen.openapi {
+        generators.push(Box::new(openapi::OpenApiGenerator::new(openapi.clone())));
+    }
+    generators
+}
+
+/// Return display summaries for all active generators.
+#[must_use]
+pub fn generator_summaries(project_root: &Path, codegen: &Codegen) -> Vec<GeneratorSummary> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| GeneratorSummary {
+            name: generator.name().to_owned(),
+            display_name: generator.display_name().to_owned(),
+            output_dir: generator_output_dir(project_root, generator.name()),
+        })
+        .collect()
+}
+
+/// Return managed tools for all active generators.
+#[must_use]
+pub fn managed_tools(codegen: &Codegen) -> Vec<ManagedToolSpec> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| generator.managed_tool())
+        .collect()
+}
+
+/// Compute `(generator name, input hash)` pairs for all active generators, in
+/// stable order.
+///
+/// This is the single place generator hashes are computed. A build computes them
+/// once for the cache key and threads them into `run_codegen` (via its
+/// `precomputed_hashes` argument) so neither the hash nor any spec /
+/// `extra_spec_dirs` file is read a second time on a cache-miss build.
+///
+/// # Errors
+/// Returns an error if a configured generator input cannot be read.
+pub fn compute_codegen_hash_pairs(
+    project_root: &Path,
+    codegen: &Codegen,
+) -> Result<Vec<(String, String)>, EngineError> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| {
+            let hash = compute_generator_hash(generator.as_ref(), project_root)?;
+            Ok((generator.name().to_owned(), hash))
+        })
+        .collect()
+}
+
+/// Compute tagged (`name:hash`) hashes for all active generators — the form
+/// folded into the build cache key.
+///
+/// # Errors
+/// Returns an error if a configured generator input cannot be read.
+pub fn compute_codegen_hashes(
+    project_root: &Path,
+    codegen: &Codegen,
+) -> Result<Vec<String>, EngineError> {
+    Ok(compute_codegen_hash_pairs(project_root, codegen)?
+        .into_iter()
+        .map(|(name, hash)| format!("{name}:{hash}"))
+        .collect())
+}
+
+/// Return the output directory for a generator under `.konvoy/gen/`.
+#[must_use]
+pub fn generator_output_dir(project_root: &Path, name: &str) -> PathBuf {
+    project_root.join(".konvoy").join("gen").join(name)
+}
+
+fn compute_generator_hash(
+    generator: &dyn CodeGenerator,
+    project_root: &Path,
+) -> Result<String, EngineError> {
+    let mut parts = vec![
+        "codegen-v1".to_owned(),
+        generator.name().to_owned(),
+        generator.display_name().to_owned(),
+    ];
+    parts.extend(generator.config_hash_parts());
+
+    for input in generator.input_files(project_root)? {
+        let full_path = project_root.join(&input);
+        // Hash the path's raw bytes (not Display, which is lossy for non-UTF-8
+        // names) so a rename always changes the key and the key is encoding-stable.
+        parts.push("file".to_owned());
+        parts.push(konvoy_util::hash::sha256_bytes(
+            input.as_os_str().as_encoded_bytes(),
+        ));
+        // Read content directly (no exists() pre-check): that races with the read
+        // and reports EACCES as "not found". Map only a genuine NotFound to the
+        // actionable codegen error; surface other I/O errors (e.g. permission) as-is.
+        match konvoy_util::hash::sha256_file(&full_path) {
+            Ok(hash) => parts.push(hash),
+            Err(konvoy_util::error::UtilError::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Err(EngineError::CodegenInputNotFound {
+                    name: generator.name().to_owned(),
+                    path: full_path.display().to_string(),
+                });
+            }
+            Err(e) => return Err(EngineError::from(e)),
+        }
+    }
+
+    let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
+    Ok(konvoy_util::hash::sha256_multi(&refs))
+}
+
+/// Run a managed Java JAR with normalized diagnostics.
+///
+/// # Errors
+/// Returns an error if Java is unavailable, the process cannot be spawned, or
+/// the process exits unsuccessfully.
+pub fn run_java_jar(
+    generator_name: &str,
+    tool_display_name: &str,
+    tool_path: &Path,
+    jre_home: &Path,
+    args: Vec<OsString>,
+    verbose: bool,
+) -> Result<(), EngineError> {
+    let java = java_bin(jre_home);
+    if !java.exists() {
+        return Err(EngineError::CodegenFailed {
+            name: generator_name.to_owned(),
+            message: format!(
+                "java not found at {} — run `konvoy toolchain install` to reinstall the managed JRE",
+                java.display()
+            ),
+        });
+    }
+
+    let output = Command::new(&java)
+        .arg("-jar")
+        .arg(tool_path)
+        .args(args)
+        .env("JAVA_HOME", jre_home)
+        .output()
+        .map_err(|e| EngineError::CodegenFailed {
+            name: generator_name.to_owned(),
+            message: e.to_string(),
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if verbose {
+        if !stdout.is_empty() {
+            eprintln!("{stdout}");
+        }
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
+    }
+
+    if !output.status.success() {
+        // JVM CLIs typically print the real error to stderr (and banners to
+        // stdout), so prefer stderr for the one-line hint and fall back to
+        // stdout. Never concatenate the streams — that can fuse an unrelated
+        // stdout line onto the first stderr line.
+        let hint_source = if stderr.trim().is_empty() {
+            stdout.as_ref()
+        } else {
+            stderr.as_ref()
+        };
+        let hint = first_non_empty_line(hint_source)
+            .map(|line| format!(" first message: {line}"))
+            .unwrap_or_default();
+        return Err(EngineError::CodegenFailed {
+            name: generator_name.to_owned(),
+            message: format!(
+                "{tool_display_name} exited with status {}.{hint} Run with --verbose to see full output.",
+                output.status
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn java_bin(jre_home: &Path) -> PathBuf {
+    let binary = if cfg!(windows) { "java.exe" } else { "java" };
+    jre_home.join("bin").join(binary)
+}
+
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().map(str::trim).find(|line| !line.is_empty())
+}

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -1,8 +1,6 @@
 //! Declarative source generation before Kotlin/Native compilation.
 
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use konvoy_config::manifest::Codegen;
 
@@ -10,8 +8,8 @@ use crate::error::EngineError;
 
 pub mod openapi;
 
-// The managed-JAR-tool abstraction is shared with the detekt linter, so it lives
-// at the engine root (`crate::managed_tool`); re-exported here for codegen callers.
+// The managed-tool abstraction is shared with the detekt linter, so it lives at
+// the engine root (`crate::managed_tool`); re-exported here for codegen callers.
 pub use crate::managed_tool::ManagedToolSpec;
 
 /// Display metadata for a configured generator.
@@ -53,14 +51,19 @@ pub trait CodeGenerator {
 
     /// Generate sources into `output_dir`.
     ///
+    /// The tool returned by [`managed_tool`](Self::managed_tool) must already be
+    /// downloaded; the generator runs it through
+    /// [`ManagedToolSpec::run`](crate::managed_tool::ManagedToolSpec::run). `jre_home`
+    /// is the managed JRE for JVM generators (e.g. Fabrikt) and `None` for a future
+    /// native generator — it is forwarded to `run` per the tool's runtime.
+    ///
     /// # Errors
     /// Returns an error if the generator process cannot be executed or fails.
     fn generate(
         &self,
         project_root: &Path,
         output_dir: &Path,
-        tool_path: &Path,
-        jre_home: &Path,
+        jre_home: Option<&Path>,
         verbose: bool,
     ) -> Result<(), EngineError>;
 }
@@ -178,84 +181,4 @@ fn compute_generator_hash(
 
     let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
     Ok(konvoy_util::hash::sha256_multi(&refs))
-}
-
-/// Run a managed Java JAR with normalized diagnostics.
-///
-/// # Errors
-/// Returns an error if Java is unavailable, the process cannot be spawned, or
-/// the process exits unsuccessfully.
-pub fn run_java_jar(
-    generator_name: &str,
-    tool_display_name: &str,
-    tool_path: &Path,
-    jre_home: &Path,
-    args: Vec<OsString>,
-    verbose: bool,
-) -> Result<(), EngineError> {
-    let java = java_bin(jre_home);
-    if !java.exists() {
-        return Err(EngineError::CodegenFailed {
-            name: generator_name.to_owned(),
-            message: format!(
-                "java not found at {} — run `konvoy toolchain install` to reinstall the managed JRE",
-                java.display()
-            ),
-        });
-    }
-
-    let output = Command::new(&java)
-        .arg("-jar")
-        .arg(tool_path)
-        .args(args)
-        .env("JAVA_HOME", jre_home)
-        .output()
-        .map_err(|e| EngineError::CodegenFailed {
-            name: generator_name.to_owned(),
-            message: e.to_string(),
-        })?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if verbose {
-        if !stdout.is_empty() {
-            eprintln!("{stdout}");
-        }
-        if !stderr.is_empty() {
-            eprintln!("{stderr}");
-        }
-    }
-
-    if !output.status.success() {
-        // JVM CLIs typically print the real error to stderr (and banners to
-        // stdout), so prefer stderr for the one-line hint and fall back to
-        // stdout. Never concatenate the streams — that can fuse an unrelated
-        // stdout line onto the first stderr line.
-        let hint_source = if stderr.trim().is_empty() {
-            stdout.as_ref()
-        } else {
-            stderr.as_ref()
-        };
-        let hint = first_non_empty_line(hint_source)
-            .map(|line| format!(" first message: {line}"))
-            .unwrap_or_default();
-        return Err(EngineError::CodegenFailed {
-            name: generator_name.to_owned(),
-            message: format!(
-                "{tool_display_name} exited with status {}.{hint} Run with --verbose to see full output.",
-                output.status
-            ),
-        });
-    }
-
-    Ok(())
-}
-
-fn java_bin(jre_home: &Path) -> PathBuf {
-    let binary = if cfg!(windows) { "java.exe" } else { "java" };
-    jre_home.join("bin").join(binary)
-}
-
-fn first_non_empty_line(output: &str) -> Option<&str> {
-    output.lines().map(str::trim).find(|line| !line.is_empty())
 }

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -1,0 +1,332 @@
+//! OpenAPI source generation using Fabrikt.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use konvoy_config::manifest::OpenApiCodegen;
+use konvoy_util::maven::MavenCoordinate;
+
+use crate::codegen::{run_java_jar, CodeGenerator, ManagedToolSpec};
+use crate::error::EngineError;
+
+const GENERATOR_NAME: &str = "openapi";
+const TOOL_NAME: &str = "fabrikt";
+/// Human-readable tool name, used consistently in the download bar, the
+/// generation message, and failure diagnostics.
+const TOOL_DISPLAY: &str = "Fabrikt";
+
+/// Fixed Fabrikt generation flags. These affect generated output, so they are
+/// also folded into the config hash (see `config_hash_parts`) — if any of them
+/// ever changes, the codegen hash and build cache key change with it.
+const FABRIKT_TARGETS: &str = "HTTP_MODELS";
+const FABRIKT_SERIALIZATION_LIBRARY: &str = "KOTLINX_SERIALIZATION";
+/// Fabrikt defaults to `JAVAX_VALIDATION`, which emits `javax.validation.*`
+/// annotations on required/constrained fields. Those are JVM-only and do not
+/// exist on Kotlin/Native, so generated models would not compile. Konvoy is
+/// native-first, so validation annotations are disabled.
+const FABRIKT_VALIDATION_LIBRARY: &str = "NO_VALIDATION";
+
+/// OpenAPI generator backed by the Fabrikt CLI JAR.
+#[derive(Debug, Clone)]
+pub struct OpenApiGenerator {
+    config: OpenApiCodegen,
+}
+
+impl OpenApiGenerator {
+    /// Create a generator from parsed manifest config.
+    #[must_use]
+    pub fn new(config: OpenApiCodegen) -> Self {
+        Self { config }
+    }
+}
+
+fn fabrikt_tool(version: &str) -> ManagedToolSpec {
+    ManagedToolSpec::maven_jar(
+        TOOL_NAME,
+        TOOL_DISPLAY,
+        MavenCoordinate::new("com.cjbooms", TOOL_NAME, version),
+    )
+}
+
+/// Return the managed Fabrikt JAR path for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn fabrikt_jar_path(version: &str) -> Result<PathBuf, EngineError> {
+    fabrikt_tool(version)
+        .artifact_path()
+        .map_err(EngineError::from)
+}
+
+/// Return the Maven Central URL for a Fabrikt JAR.
+#[must_use]
+pub fn fabrikt_download_url(version: &str) -> String {
+    fabrikt_tool(version).download_url()
+}
+
+/// Return whether Fabrikt is installed for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn is_installed(version: &str) -> Result<bool, EngineError> {
+    fabrikt_tool(version)
+        .is_installed()
+        .map_err(EngineError::from)
+}
+
+/// Download or verify the managed Fabrikt JAR.
+///
+/// # Errors
+/// Returns an error if the version is unsafe, the artifact cannot be
+/// downloaded, or the expected SHA-256 does not match.
+pub fn ensure_fabrikt(
+    version: &str,
+    expected_sha256: Option<&str>,
+) -> Result<(PathBuf, String), EngineError> {
+    // Pre-validate for an actionable, Fabrikt-specific message; the shared tool
+    // also validates, but its raw error would map to a generic one.
+    konvoy_util::artifact::validate_version(version).map_err(|_| EngineError::CodegenDownload {
+        name: TOOL_NAME.to_owned(),
+        version: version.to_owned(),
+        message: format!(
+            "invalid fabrikt version \"{version}\" — only alphanumeric characters, dots, hyphens, and underscores are allowed"
+        ),
+    })?;
+    fabrikt_tool(version)
+        .ensure(expected_sha256)
+        .map_err(|e| map_fabrikt_download_err(version, e))
+}
+
+/// Map a download/verify `UtilError` to the Fabrikt-specific engine error
+/// (mirrors the detekt and plugin paths via the shared mapper).
+fn map_fabrikt_download_err(version: &str, e: konvoy_util::error::UtilError) -> EngineError {
+    crate::error::map_artifact_download_err(
+        TOOL_NAME,
+        e,
+        |name, message| EngineError::CodegenDownload {
+            name,
+            version: version.to_owned(),
+            message,
+        },
+        |name, expected, actual| EngineError::CodegenHashMismatch {
+            name,
+            version: version.to_owned(),
+            expected,
+            actual,
+        },
+    )
+}
+
+impl CodeGenerator for OpenApiGenerator {
+    fn name(&self) -> &str {
+        GENERATOR_NAME
+    }
+
+    fn display_name(&self) -> &str {
+        "OpenAPI"
+    }
+
+    fn managed_tool(&self) -> ManagedToolSpec {
+        fabrikt_tool(&self.config.version)
+    }
+
+    fn config_hash_parts(&self) -> Vec<String> {
+        let mut parts = vec![
+            format!("tool_version={}", self.config.version),
+            format!("spec={}", self.config.spec),
+            format!("base_package={}", self.config.base_package),
+            format!("targets={FABRIKT_TARGETS}"),
+            format!("serialization_library={FABRIKT_SERIALIZATION_LIBRARY}"),
+            format!("validation_library={FABRIKT_VALIDATION_LIBRARY}"),
+        ];
+        // One part per dir (plus a count) rather than a joined string: joining
+        // with `,` is ambiguous — ["a,b"] and ["a","b"] would render identically,
+        // and sha256_multi only length-prefixes whole parts.
+        parts.push(format!(
+            "extra_spec_dirs_count={}",
+            self.config.extra_spec_dirs.len()
+        ));
+        for dir in &self.config.extra_spec_dirs {
+            parts.push(format!("extra_spec_dir={dir}"));
+        }
+        parts
+    }
+
+    /// Project-relative files whose contents feed the codegen cache key.
+    ///
+    /// Always includes the primary `spec`. When `extra_spec_dirs` is configured, also
+    /// includes every file under those directories so a change to any `$ref`'d
+    /// sibling (which Fabrikt resolves internally but never reports) regenerates
+    /// sources. Fabrikt exposes no resolved-input list — via CLI, library, or its
+    /// Gradle plugins — so we deliberately over-approximate by directory rather
+    /// than re-parse the spec in Rust.
+    fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+        // Normalize the spec the same way dir-collected files are normalized so a
+        // spec written as `./specs/api.yaml` dedups against a listed `specs` dir
+        // entry (`specs/api.yaml`) instead of hashing the same file twice.
+        let mut files = vec![project_relative(project_root, Path::new(&self.config.spec))];
+
+        for dir in &self.config.extra_spec_dirs {
+            let dir_abs = project_root.join(dir);
+            if !dir_abs.is_dir() {
+                return Err(EngineError::CodegenInputDirNotFound {
+                    name: GENERATOR_NAME.to_owned(),
+                    path: dir_abs.display().to_string(),
+                });
+            }
+            for file in konvoy_util::fs::collect_all_files(&dir_abs)? {
+                files.push(project_relative(project_root, &file));
+            }
+        }
+
+        files.sort();
+        files.dedup();
+        Ok(files)
+    }
+
+    fn generate(
+        &self,
+        project_root: &Path,
+        output_dir: &Path,
+        tool_path: &Path,
+        jre_home: &Path,
+        verbose: bool,
+    ) -> Result<(), EngineError> {
+        let spec_path = project_root.join(&self.config.spec);
+        eprintln!(
+            "    Generating OpenAPI sources with {TOOL_DISPLAY} {}...",
+            self.config.version
+        );
+
+        run_java_jar(
+            GENERATOR_NAME,
+            TOOL_DISPLAY,
+            tool_path,
+            jre_home,
+            vec![
+                OsString::from("--api-file"),
+                spec_path.into_os_string(),
+                OsString::from("--base-package"),
+                OsString::from(&self.config.base_package),
+                OsString::from("--output-directory"),
+                output_dir.as_os_str().to_owned(),
+                OsString::from("--targets"),
+                OsString::from(FABRIKT_TARGETS),
+                OsString::from("--serialization-library"),
+                OsString::from(FABRIKT_SERIALIZATION_LIBRARY),
+                OsString::from("--validation-library"),
+                OsString::from(FABRIKT_VALIDATION_LIBRARY),
+            ],
+            verbose,
+        )
+    }
+}
+
+/// Normalize a path to a clean project-relative form for stable, dedup-able
+/// hashing. Absolute inputs (dir-walk results under `project_root`) and relative
+/// inputs (the configured `spec`, possibly written with a leading `./`) both
+/// collapse to the same `specs/api.yaml`-style path. Joining onto `project_root`
+/// then stripping it also drops interior `.` components via `Path::components`.
+fn project_relative(project_root: &Path, path: &Path) -> PathBuf {
+    let joined = project_root.join(path);
+    joined
+        .strip_prefix(project_root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn generator(spec: &str, extra_spec_dirs: &[&str]) -> OpenApiGenerator {
+        OpenApiGenerator::new(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: spec.to_owned(),
+            base_package: "com.example.api".to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|s| (*s).to_owned()).collect(),
+        })
+    }
+
+    #[test]
+    fn input_files_without_extra_spec_dirs_is_just_the_spec() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = generator("specs/api.yaml", &[])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_with_spec_dir_hashes_every_file_relative_and_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(specs.join("nested")).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+        std::fs::write(specs.join("pet.yaml"), "Pet").unwrap();
+        std::fs::write(specs.join("nested").join("owner.yaml"), "Owner").unwrap();
+        // A non-spec file in the directory is also tracked (over-approximation).
+        std::fs::write(specs.join("README.md"), "notes").unwrap();
+
+        let files = generator("specs/api.yaml", &["specs"])
+            .input_files(tmp.path())
+            .unwrap();
+
+        // Project-relative, sorted, and the primary spec is not duplicated.
+        assert_eq!(
+            files,
+            vec![
+                PathBuf::from("specs/README.md"),
+                PathBuf::from("specs/api.yaml"),
+                PathBuf::from("specs/nested/owner.yaml"),
+                PathBuf::from("specs/pet.yaml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn input_files_dedups_dot_slash_spec_against_listed_dir() {
+        // A spec written with a leading `./` must collapse to the same relative
+        // path as the dir-collected entry, so the file is hashed once, not twice.
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(&specs).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+
+        let files = generator("./specs/api.yaml", &["specs"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_missing_spec_dir_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = generator("specs/api.yaml", &["does-not-exist"])
+            .input_files(tmp.path())
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::CodegenInputDirNotFound { .. }),
+            "expected CodegenInputDirNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn extra_spec_dirs_participate_in_config_hash() {
+        let with = generator("specs/api.yaml", &["specs"]).config_hash_parts();
+        let without = generator("specs/api.yaml", &[]).config_hash_parts();
+        assert_ne!(with, without);
+        assert!(with.iter().any(|p| p == "extra_spec_dir=specs"));
+        assert!(with.iter().any(|p| p == "extra_spec_dirs_count=1"));
+        assert!(without.iter().any(|p| p == "extra_spec_dirs_count=0"));
+    }
+
+    #[test]
+    fn config_hash_distinguishes_comma_dir_from_two_dirs() {
+        // ["a,b"] must not collide with ["a","b"] in the config hash.
+        let one = generator("specs/api.yaml", &["a,b"]).config_hash_parts();
+        let two = generator("specs/api.yaml", &["a", "b"]).config_hash_parts();
+        assert_ne!(one, two);
+    }
+}

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use konvoy_config::manifest::OpenApiCodegen;
 use konvoy_util::maven::MavenCoordinate;
 
-use crate::codegen::{run_java_jar, CodeGenerator, ManagedToolSpec};
+use crate::codegen::{CodeGenerator, ManagedToolSpec};
 use crate::error::EngineError;
 
 const GENERATOR_NAME: &str = "openapi";
@@ -188,8 +188,7 @@ impl CodeGenerator for OpenApiGenerator {
         &self,
         project_root: &Path,
         output_dir: &Path,
-        tool_path: &Path,
-        jre_home: &Path,
+        jre_home: Option<&Path>,
         verbose: bool,
     ) -> Result<(), EngineError> {
         let spec_path = project_root.join(&self.config.spec);
@@ -198,28 +197,54 @@ impl CodeGenerator for OpenApiGenerator {
             self.config.version
         );
 
-        run_java_jar(
-            GENERATOR_NAME,
-            TOOL_DISPLAY,
-            tool_path,
-            jre_home,
-            vec![
-                OsString::from("--api-file"),
-                spec_path.into_os_string(),
-                OsString::from("--base-package"),
-                OsString::from(&self.config.base_package),
-                OsString::from("--output-directory"),
-                output_dir.as_os_str().to_owned(),
-                OsString::from("--targets"),
-                OsString::from(FABRIKT_TARGETS),
-                OsString::from("--serialization-library"),
-                OsString::from(FABRIKT_SERIALIZATION_LIBRARY),
-                OsString::from("--validation-library"),
-                OsString::from(FABRIKT_VALIDATION_LIBRARY),
-            ],
-            verbose,
-        )
+        let args = [
+            OsString::from("--api-file"),
+            spec_path.into_os_string(),
+            OsString::from("--base-package"),
+            OsString::from(&self.config.base_package),
+            OsString::from("--output-directory"),
+            output_dir.as_os_str().to_owned(),
+            OsString::from("--targets"),
+            OsString::from(FABRIKT_TARGETS),
+            OsString::from("--serialization-library"),
+            OsString::from(FABRIKT_SERIALIZATION_LIBRARY),
+            OsString::from("--validation-library"),
+            OsString::from(FABRIKT_VALIDATION_LIBRARY),
+        ];
+
+        let output = self.managed_tool().run(jre_home, &args, verbose)?;
+
+        // A code generator treats a non-zero exit as a hard failure (unlike the
+        // linter, which reads it as "issues found").
+        if !output.success {
+            // JVM CLIs typically print the real error to stderr (and banners to
+            // stdout), so prefer stderr for the one-line hint and fall back to
+            // stdout. Never concatenate the streams — that can fuse an unrelated
+            // stdout line onto the first stderr line.
+            let hint_source = if output.stderr.trim().is_empty() {
+                &output.stdout
+            } else {
+                &output.stderr
+            };
+            let hint = first_non_empty_line(hint_source)
+                .map(|line| format!(" first message: {line}"))
+                .unwrap_or_default();
+            return Err(EngineError::CodegenFailed {
+                name: GENERATOR_NAME.to_owned(),
+                message: format!(
+                    "{TOOL_DISPLAY} failed.{hint} Run with --verbose to see full output."
+                ),
+            });
+        }
+
+        Ok(())
     }
+}
+
+/// First non-blank line of `output`, trimmed — used to surface a concise hint
+/// from a failed Fabrikt run without dumping its whole log.
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().map(str::trim).find(|line| !line.is_empty())
 }
 
 /// Normalize a path to a clean project-relative form for stable, dedup-able

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -3,8 +3,8 @@
 //! Downloads `detekt-cli` fat JARs from GitHub releases and runs them
 //! against Kotlin source files using the JRE bundled with managed toolchains.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::error::EngineError;
 use crate::managed_tool::ManagedToolSpec;
@@ -167,10 +167,12 @@ fn persist_detekt_hash(
     Ok(())
 }
 
-/// Resolve the JRE `java` binary from the managed Kotlin toolchain.
+/// Resolve the managed Kotlin toolchain's JRE home (which contains `bin/java`).
 ///
-/// Auto-installs the toolchain if it is not yet present.
-fn resolve_java_bin(kotlin_version: &str) -> Result<(PathBuf, PathBuf), EngineError> {
+/// Auto-installs the toolchain if it is not yet present. The actual `java`
+/// invocation is delegated to [`ManagedToolSpec::run`], which derives the binary
+/// from this home.
+fn resolve_jre_home(kotlin_version: &str) -> Result<PathBuf, EngineError> {
     if !konvoy_konanc::toolchain::is_installed(kotlin_version)? {
         eprintln!("    Installing Kotlin/Native {kotlin_version} (for JRE)...");
         konvoy_konanc::toolchain::install(kotlin_version)?;
@@ -178,12 +180,11 @@ fn resolve_java_bin(kotlin_version: &str) -> Result<(PathBuf, PathBuf), EngineEr
 
     let jre_home = konvoy_konanc::toolchain::jre_home_path(kotlin_version)?;
 
-    let java_bin = jre_home.join("bin").join("java");
-    if !java_bin.exists() {
+    if !jre_home.join("bin").join("java").exists() {
         return Err(EngineError::DetektNoJre);
     }
 
-    Ok((java_bin, jre_home))
+    Ok(jre_home)
 }
 
 /// Resolve the detekt config file path.
@@ -216,56 +217,32 @@ fn resolve_config(root: &Path, explicit: Option<&Path>) -> Result<Option<PathBuf
 
 /// Execute the detekt process and build a `LintResult` from its output.
 fn run_detekt_process(
-    java_bin: &Path,
     jre_home: &Path,
-    jar_path: &Path,
     src_dir: &Path,
     config_path: Option<&Path>,
     detekt_version: &str,
     verbose: bool,
 ) -> Result<LintResult, EngineError> {
-    let mut args = vec![
-        "-jar".to_owned(),
-        jar_path.display().to_string(),
-        "--input".to_owned(),
-        src_dir.display().to_string(),
-    ];
+    let mut args = vec![OsString::from("--input"), src_dir.as_os_str().to_owned()];
 
     if let Some(cfg) = config_path {
-        args.push("--config".to_owned());
-        args.push(cfg.display().to_string());
-        args.push("--build-upon-default-config".to_owned());
+        args.push(OsString::from("--config"));
+        args.push(cfg.as_os_str().to_owned());
+        args.push(OsString::from("--build-upon-default-config"));
     }
 
     eprintln!("    Linting with detekt {detekt_version}...");
 
-    let output = Command::new(java_bin)
-        .args(&args)
-        .env("JAVA_HOME", jre_home)
-        .output()
-        .map_err(|e| EngineError::DetektExec {
-            message: e.to_string(),
-        })?;
+    let output = detekt_tool(detekt_version).run(Some(jre_home), &args, verbose)?;
 
-    let raw_stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let raw_stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    let raw_output = format!("{raw_stdout}{raw_stderr}");
-
-    if verbose {
-        if !raw_stdout.is_empty() {
-            eprintln!("{raw_stdout}");
-        }
-        if !raw_stderr.is_empty() {
-            eprintln!("{raw_stderr}");
-        }
-    }
-
+    let raw_output = format!("{}{}", output.stdout, output.stderr);
     let diagnostics = parse_detekt_output(&raw_output);
     let finding_count = diagnostics.len();
-    let success = output.status.success();
 
+    // A non-zero detekt exit means "findings", not a tool failure, so the run's
+    // `success` flag maps straight onto the lint result.
     Ok(LintResult {
-        success,
+        success: output.success,
         diagnostics,
         raw_output,
         finding_count,
@@ -305,8 +282,9 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
         }
     }
 
-    // Ensure detekt jar is available and hash-verified.
-    let (jar_path, actual_hash) = ensure_detekt(detekt_version, expected_hash)?;
+    // Ensure detekt jar is available and hash-verified. The path is derived again
+    // (from the same spec) inside `run_detekt_process`, so it is discarded here.
+    let (_, actual_hash) = ensure_detekt(detekt_version, expected_hash)?;
 
     // Persist hash to lockfile if not already stored.
     if expected_hash.is_none() {
@@ -320,7 +298,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     }
 
     // Resolve JRE.
-    let (java_bin, jre_home) = resolve_java_bin(&manifest.toolchain.kotlin)?;
+    let jre_home = resolve_jre_home(&manifest.toolchain.kotlin)?;
 
     // Check for sources.
     let src_dir = root.join("src");
@@ -337,9 +315,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     // Resolve config and run detekt.
     let config_path = resolve_config(root, options.config.as_deref())?;
     run_detekt_process(
-        &java_bin,
         &jre_home,
-        &jar_path,
         &src_dir,
         config_path.as_deref(),
         detekt_version,

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::error::EngineError;
+use crate::managed_tool::ManagedToolSpec;
 
 /// Map a `UtilError` from artifact operations to the corresponding `EngineError`.
 fn map_download_err(version: &str, e: konvoy_util::error::UtilError) -> EngineError {
@@ -59,14 +60,16 @@ pub struct DetektDiagnostic {
     pub line: Option<u32>,
 }
 
-/// Return the root directory for managed tools: `~/.konvoy/tools/`.
-fn tools_dir() -> Result<PathBuf, EngineError> {
-    Ok(konvoy_util::fs::konvoy_home()?.join("tools"))
-}
-
-/// Return the directory for a specific detekt version.
-fn detekt_dir(version: &str) -> Result<PathBuf, EngineError> {
-    Ok(tools_dir()?.join("detekt").join(version))
+/// The managed-JAR-tool spec for a detekt version — a GitHub release downloaded
+/// into `~/.konvoy/tools/detekt/<version>/`.
+fn detekt_tool(version: &str) -> ManagedToolSpec {
+    ManagedToolSpec::direct_url(
+        "detekt",
+        "detekt",
+        version,
+        detekt_download_url(version),
+        format!("detekt-cli-{version}-all.jar"),
+    )
 }
 
 /// Return the path to the detekt-cli JAR for a specific version.
@@ -74,7 +77,9 @@ fn detekt_dir(version: &str) -> Result<PathBuf, EngineError> {
 /// # Errors
 /// Returns an error if the home directory cannot be determined.
 pub fn detekt_jar_path(version: &str) -> Result<PathBuf, EngineError> {
-    Ok(detekt_dir(version)?.join(format!("detekt-cli-{version}-all.jar")))
+    detekt_tool(version)
+        .artifact_path()
+        .map_err(EngineError::from)
 }
 
 /// Construct the download URL for a detekt-cli release.
@@ -87,8 +92,9 @@ pub(crate) fn detekt_download_url(version: &str) -> String {
 /// # Errors
 /// Returns an error if the home directory cannot be determined.
 pub fn is_installed(version: &str) -> Result<bool, EngineError> {
-    let jar = detekt_jar_path(version)?;
-    Ok(jar.exists())
+    detekt_tool(version)
+        .is_installed()
+        .map_err(EngineError::from)
 }
 
 /// Download detekt-cli if not already present, returning the path to the JAR.
@@ -111,22 +117,9 @@ pub fn ensure_detekt(
         ),
     })?;
 
-    let jar = detekt_jar_path(version)?;
-    let url = detekt_download_url(version);
-
-    // Only show a download bar when the JAR isn't already cached — a
-    // cached re-verify completes in milliseconds and the flash of ⚙️ → ✅
-    // is more noise than information.
-    let progress = (!jar.exists())
-        .then(|| konvoy_util::progress::new_download_bar(format!("detekt {version}")));
-    let result =
-        konvoy_util::progress::fetch(&url, &jar, expected_sha256, "detekt", progress.as_ref())
-            .map_err(|e| map_download_err(version, e))?;
-    if progress.is_some() {
-        eprintln!();
-    }
-
-    Ok((result.path, result.sha256))
+    detekt_tool(version)
+        .ensure(expected_sha256)
+        .map_err(|e| map_download_err(version, e))
 }
 
 /// Resolve the expected detekt hash from the lockfile.

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -101,9 +101,12 @@ pub enum EngineError {
     #[error("cannot download detekt {version}: {message}")]
     DetektDownload { version: String, message: String },
 
-    /// Failed to run detekt.
-    #[error("cannot run detekt: {message}")]
-    DetektExec { message: String },
+    /// A managed tool's process could not be executed (shared by detekt and
+    /// codegen). A non-zero exit is *not* this error — that outcome is reported
+    /// via [`ToolOutput::success`](crate::managed_tool::ToolOutput) and
+    /// interpreted by the caller.
+    #[error("cannot run tool `{tool}`: {message}")]
+    ToolExecFailed { tool: String, message: String },
 
     /// No JRE available to run detekt.
     #[error("jre not available for running detekt — run `konvoy toolchain install` first")]

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -121,6 +121,43 @@ pub enum EngineError {
     #[error("detekt not configured — add `detekt = \"1.23.7\"` to [toolchain] in konvoy.toml")]
     LintNotConfigured,
 
+    /// No code generators are configured.
+    #[error("no codegen configured — add [codegen.openapi] to konvoy.toml")]
+    CodegenNotConfigured,
+
+    /// A configured codegen input file is missing.
+    #[error("codegen input for `{name}` not found at {path} — create the file, or fix `spec`/`extra_spec_dirs` in [codegen.{name}]")]
+    CodegenInputNotFound { name: String, path: String },
+
+    /// A configured codegen spec directory is missing.
+    #[error("codegen spec directory for `{name}` not found at {path} — create the directory or fix `extra_spec_dirs` in [codegen.{name}]")]
+    CodegenInputDirNotFound { name: String, path: String },
+
+    /// A codegen tool is not available in a mode that forbids downloads.
+    #[error("codegen tool `{name}` {version} is not downloaded and --locked prevents downloads — run `konvoy generate` without --locked first")]
+    CodegenToolNotFound { name: String, version: String },
+
+    /// A codegen tool download failed.
+    #[error("cannot download codegen tool `{name}` {version}: {message}")]
+    CodegenDownload {
+        name: String,
+        version: String,
+        message: String,
+    },
+
+    /// A codegen tool artifact hash does not match the lockfile.
+    #[error("codegen tool `{name}` {version} hash mismatch — expected {expected}, got {actual}; delete ~/.konvoy/tools/{name}/{version}/ and re-run `konvoy generate`, or verify the artifact upstream")]
+    CodegenHashMismatch {
+        name: String,
+        version: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// Code generation process failed.
+    #[error("cannot run codegen `{name}`: {message}")]
+    CodegenFailed { name: String, message: String },
+
     /// The project name supplied to `konvoy init` is invalid.
     #[error("invalid project name \"{name}\": {reason}")]
     InvalidProjectName { name: String, reason: String },

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -4,11 +4,13 @@
 pub mod artifact;
 pub mod build;
 pub mod cache;
+pub mod codegen;
 mod common;
 pub mod detekt;
 mod diagnostics;
 pub mod error;
 pub mod init;
+pub mod managed_tool;
 pub mod plugin;
 pub mod resolve;
 pub mod test_build;

--- a/crates/konvoy-engine/src/managed_tool.rs
+++ b/crates/konvoy-engine/src/managed_tool.rs
@@ -1,20 +1,34 @@
-//! Managed JAR tools: download, cache, and SHA-verify a versioned JAR into
-//! `~/.konvoy/tools/<id>/<version>/`. Shared by the detekt linter and the
-//! codegen tools (e.g. Fabrikt) — both fetch a versioned JAR and run it via the
-//! managed JRE.
+//! Managed external tools: download, cache, SHA-verify, and run a versioned
+//! artifact from `~/.konvoy/tools/<id>/<version>/`. Shared by the detekt linter
+//! and the codegen tools (e.g. Fabrikt) through the same
+//! [`ensure`](ManagedToolSpec::ensure) + [`run`](ManagedToolSpec::run) interface.
 //!
-//! This type owns only *fetching and locating* the artifact. Domain-specific
-//! error mapping (`DetektDownload` vs `CodegenDownload`, …) and lockfile pinning
-//! stay with the caller: [`ensure`](ManagedToolSpec::ensure) returns the raw
-//! [`UtilError`] so each caller can map it via `error::map_artifact_download_err`
-//! and persist the hash wherever its lockfile section lives.
+//! Two orthogonal axes are modeled as closed enums, each dispatched by an
+//! exhaustive `match`: [`ToolSource`] is *where* the artifact comes from (Maven vs
+//! a direct URL), and [`ToolRuntime`] is *how* it is launched (a JVM JAR via the
+//! managed JRE, or a native binary exec'd directly). They are independent — a
+//! `DirectUrl` artifact can be a JAR (detekt) or a native binary, and a `Maven`
+//! artifact is a JAR today (Fabrikt) but nothing here assumes the JVM.
+//!
+//! Download error mapping (`DetektDownload` vs `CodegenDownload`, …) and lockfile
+//! pinning stay with the caller: [`ensure`](ManagedToolSpec::ensure) returns the
+//! raw [`UtilError`] so each caller can map it via `error::map_artifact_download_err`
+//! and persist the hash wherever its lockfile section lives. Execution, by
+//! contrast, is uniform across tools: [`run`](ManagedToolSpec::run) reports only
+//! whether the tool *could be executed* (a shared [`EngineError::ToolExecFailed`])
+//! and hands back a [`ToolOutput`] whose `success` flag the caller interprets —
+//! a generator treats a failed run as an error, a linter as "issues found".
 
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use konvoy_util::error::UtilError;
 use konvoy_util::maven::{MavenCoordinate, MAVEN_CENTRAL};
 
-/// Where a managed tool's JAR is fetched from.
+use crate::error::EngineError;
+
+/// Where a managed tool's artifact is fetched from. Orthogonal to [`ToolRuntime`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolSource {
     /// A Maven Central artifact addressed by coordinate (e.g. Fabrikt).
@@ -23,11 +37,42 @@ pub enum ToolSource {
     DirectUrl { url: String, filename: String },
 }
 
-/// A managed JAR tool downloaded into `~/.konvoy/tools/<id>/<version>/`.
+/// How a managed tool is launched once downloaded. Orthogonal to [`ToolSource`]:
+/// a `DirectUrl` artifact may be a JVM JAR (detekt) or a native binary, and a
+/// `Maven` artifact is a JAR today (Fabrikt) but the runtime axis does not assume it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolRuntime {
+    /// Launched as `<jre_home>/bin/java -jar <artifact> <args>` with
+    /// `JAVA_HOME=<jre_home>`. Requires a managed JRE supplied to [`run`](ManagedToolSpec::run).
+    #[default]
+    Jvm,
+    /// The downloaded artifact is itself an executable; exec it directly, no JRE.
+    Native,
+}
+
+/// Captured result of running a managed tool (see [`ManagedToolSpec::run`]).
+///
+/// `success` is a plain pass/fail flag derived from the process exit status; the
+/// raw exit code is deliberately not surfaced. Callers decide what a failed run
+/// means — a code generator treats `!success` as an error, while a linter treats
+/// it as "issues were found".
+#[derive(Debug, Clone)]
+pub struct ToolOutput {
+    /// Captured standard output (lossy UTF-8).
+    pub stdout: String,
+    /// Captured standard error (lossy UTF-8).
+    pub stderr: String,
+    /// Whether the process exited successfully (exit status 0).
+    pub success: bool,
+}
+
+/// A managed external tool downloaded into `~/.konvoy/tools/<id>/<version>/`.
 ///
 /// Fields are private so the validating constructors ([`maven_jar`](Self::maven_jar)
 /// / [`direct_url`](Self::direct_url)) are the only construction path — callers
 /// can't assemble a spec whose `version`/`filename` would escape the tools dir.
+/// The runtime defaults to [`ToolRuntime::Jvm`]; chain [`native`](Self::native)
+/// for a native tool.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedToolSpec {
     /// Stable lockfile/cache id, e.g. `"fabrikt"` or `"detekt"`.
@@ -36,12 +81,15 @@ pub struct ManagedToolSpec {
     display_name: String,
     /// Tool version.
     version: String,
-    /// Where the JAR comes from.
+    /// Where the artifact comes from.
     source: ToolSource,
+    /// How the downloaded artifact is launched.
+    runtime: ToolRuntime,
 }
 
 impl ManagedToolSpec {
     /// A managed Maven Central JAR; the version is taken from the coordinate.
+    /// Defaults to the [`ToolRuntime::Jvm`] runtime.
     #[must_use]
     pub fn maven_jar(id: &str, display_name: &str, coordinate: MavenCoordinate) -> Self {
         Self {
@@ -49,10 +97,13 @@ impl ManagedToolSpec {
             display_name: display_name.to_owned(),
             version: coordinate.version.clone(),
             source: ToolSource::Maven(coordinate),
+            runtime: ToolRuntime::Jvm,
         }
     }
 
-    /// A managed JAR fetched from a direct release URL with a fixed filename.
+    /// A managed artifact fetched from a direct release URL with a fixed filename.
+    /// Defaults to the [`ToolRuntime::Jvm`] runtime; chain [`native`](Self::native)
+    /// for a native binary.
     #[must_use]
     pub fn direct_url(
         id: &str,
@@ -66,13 +117,29 @@ impl ManagedToolSpec {
             display_name: display_name.to_owned(),
             version: version.to_owned(),
             source: ToolSource::DirectUrl { url, filename },
+            runtime: ToolRuntime::Jvm,
         }
+    }
+
+    /// Mark this tool as a native binary: [`run`](Self::run) execs the downloaded
+    /// artifact directly with no JRE. (The on-disk `filename` must already encode
+    /// any platform suffix such as `.exe`.)
+    #[must_use]
+    pub fn native(mut self) -> Self {
+        self.runtime = ToolRuntime::Native;
+        self
     }
 
     /// The stable lockfile/cache id.
     #[must_use]
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// How this tool is launched.
+    #[must_use]
+    pub fn runtime(&self) -> ToolRuntime {
+        self.runtime
     }
 
     /// The tool version.
@@ -163,6 +230,85 @@ impl ManagedToolSpec {
         Ok((result.path, result.sha256))
     }
 
+    /// Run this tool's downloaded artifact, capturing stdout/stderr.
+    ///
+    /// The artifact must already be present — call [`ensure`](Self::ensure) first.
+    /// The launch mechanism depends on [`runtime`](Self::runtime):
+    /// - [`ToolRuntime::Jvm`] runs `<jre_home>/bin/java -jar <artifact> <args>` with
+    ///   `JAVA_HOME=<jre_home>`, so `jre_home` must be `Some`.
+    /// - [`ToolRuntime::Native`] execs the artifact directly and ignores `jre_home`.
+    ///
+    /// Reports only *whether the tool could be executed*: a non-zero exit is
+    /// surfaced as `ToolOutput::success == false`, not an error, so each caller can
+    /// interpret it (a generator treats it as failure, a linter as "issues found").
+    /// The raw exit code is intentionally not exposed.
+    ///
+    /// # Errors
+    /// Returns [`EngineError::ToolExecFailed`] if the artifact path cannot be
+    /// resolved, a JVM tool is given no `jre_home` or the managed `java` is missing,
+    /// a native binary is missing, or the process cannot be spawned.
+    pub fn run(
+        &self,
+        jre_home: Option<&Path>,
+        args: &[OsString],
+        verbose: bool,
+    ) -> Result<ToolOutput, EngineError> {
+        let artifact = self.artifact_path().map_err(EngineError::from)?;
+
+        // Build the Command per runtime; the spawn/capture/verbose/success tail is
+        // shared (see `capture`). Each arm does its own no-spawn pre-check so a
+        // missing program is an actionable ToolExecFailed, never a raw ENOENT.
+        let cmd = match self.runtime {
+            ToolRuntime::Jvm => {
+                // The JRE is JVM-only; a Jvm tool without one is a wiring/setup
+                // error, surfaced as the same no-spawn ToolExecFailed as missing java.
+                let jre = jre_home.ok_or_else(|| {
+                    self.exec_failed(
+                        "this tool runs on the managed JRE but no JRE was provided — \
+                         run `konvoy toolchain install`"
+                            .to_owned(),
+                    )
+                })?;
+                let java = jre
+                    .join("bin")
+                    .join(if cfg!(windows) { "java.exe" } else { "java" });
+                if !java.exists() {
+                    return Err(self.exec_failed(format!(
+                        "java not found at {} — run `konvoy toolchain install` to reinstall the managed JRE",
+                        java.display()
+                    )));
+                }
+                let mut cmd = Command::new(&java);
+                cmd.arg("-jar")
+                    .arg(&artifact)
+                    .args(args)
+                    .env("JAVA_HOME", jre);
+                cmd
+            }
+            ToolRuntime::Native => {
+                if !artifact.exists() {
+                    return Err(self.exec_failed(format!(
+                        "tool binary not found at {} — re-run to download it",
+                        artifact.display()
+                    )));
+                }
+                let mut cmd = Command::new(&artifact);
+                cmd.args(args);
+                cmd
+            }
+        };
+
+        capture(&self.id, cmd, verbose)
+    }
+
+    /// Build an [`EngineError::ToolExecFailed`] for this tool (the `id` is private).
+    fn exec_failed(&self, message: String) -> EngineError {
+        EngineError::ToolExecFailed {
+            tool: self.id.clone(),
+            message,
+        }
+    }
+
     /// Reject any component that could escape `~/.konvoy/tools/<id>/<version>/`.
     /// `validate_identifier` allows `[A-Za-z0-9._-]` but rejects `..`, covering
     /// the id, version, and the on-disk filename (Maven `artifact-version.ext`
@@ -176,5 +322,106 @@ impl ManagedToolSpec {
             konvoy_util::artifact::validate_identifier(&coordinate.artifact_id)?;
         }
         Ok(())
+    }
+}
+
+/// Single owner of the spawn + capture + verbose-echo + success contract shared by
+/// every runtime (mirrors konanc's build/execute split). Turns a configured
+/// `Command` into a [`ToolOutput`]; the raw exit code is never surfaced, and a
+/// spawn failure becomes a [`EngineError::ToolExecFailed`].
+fn capture(tool_id: &str, mut cmd: Command, verbose: bool) -> Result<ToolOutput, EngineError> {
+    let output = cmd.output().map_err(|e| EngineError::ToolExecFailed {
+        tool: tool_id.to_owned(),
+        message: e.to_string(),
+    })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if verbose {
+        if !stdout.is_empty() {
+            eprintln!("{stdout}");
+        }
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
+    }
+
+    Ok(ToolOutput {
+        stdout,
+        stderr,
+        success: output.status.success(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn demo_jvm() -> ManagedToolSpec {
+        ManagedToolSpec::direct_url(
+            "demo",
+            "Demo",
+            "1.0.0",
+            "https://example.invalid/demo.jar".to_owned(),
+            "demo-1.0.0.jar".to_owned(),
+        )
+    }
+
+    /// A JVM tool with a `jre_home` that has no `java` must fail with the shared
+    /// `ToolExecFailed` (not a leaked exit code or a panic) — and never spawn.
+    #[test]
+    fn run_errors_when_java_missing() {
+        let tool = demo_jvm();
+        // A jre_home that does not contain bin/java — run must bail before spawning.
+        let bogus_jre = Path::new("/konvoy/definitely/not/a/jre");
+
+        match tool.run(Some(bogus_jre), &[], false) {
+            Err(EngineError::ToolExecFailed { tool, message }) => {
+                assert_eq!(tool, "demo");
+                assert!(
+                    message.contains("java not found"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected ToolExecFailed, got {other:?}"),
+        }
+    }
+
+    /// A JVM tool given no JRE at all bails with `ToolExecFailed` before spawning.
+    #[test]
+    fn run_errors_when_jvm_tool_has_no_jre() {
+        match demo_jvm().run(None, &[], false) {
+            Err(EngineError::ToolExecFailed { tool, message }) => {
+                assert_eq!(tool, "demo");
+                assert!(message.contains("no JRE"), "unexpected message: {message}");
+            }
+            other => panic!("expected ToolExecFailed, got {other:?}"),
+        }
+    }
+
+    /// A native tool whose binary is absent bails with `ToolExecFailed` before
+    /// spawning, and ignores `jre_home` entirely (passing `None` is fine).
+    #[test]
+    fn run_native_errors_when_binary_missing() {
+        let tool = ManagedToolSpec::direct_url(
+            "demo-native",
+            "DemoNative",
+            "1.0.0",
+            "https://example.invalid/demo".to_owned(),
+            "demo-1.0.0".to_owned(),
+        )
+        .native();
+        assert_eq!(tool.runtime(), ToolRuntime::Native);
+
+        match tool.run(None, &[], false) {
+            Err(EngineError::ToolExecFailed { tool, message }) => {
+                assert_eq!(tool, "demo-native");
+                assert!(
+                    message.contains("tool binary not found"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected ToolExecFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/konvoy-engine/src/managed_tool.rs
+++ b/crates/konvoy-engine/src/managed_tool.rs
@@ -1,0 +1,180 @@
+//! Managed JAR tools: download, cache, and SHA-verify a versioned JAR into
+//! `~/.konvoy/tools/<id>/<version>/`. Shared by the detekt linter and the
+//! codegen tools (e.g. Fabrikt) — both fetch a versioned JAR and run it via the
+//! managed JRE.
+//!
+//! This type owns only *fetching and locating* the artifact. Domain-specific
+//! error mapping (`DetektDownload` vs `CodegenDownload`, …) and lockfile pinning
+//! stay with the caller: [`ensure`](ManagedToolSpec::ensure) returns the raw
+//! [`UtilError`] so each caller can map it via `error::map_artifact_download_err`
+//! and persist the hash wherever its lockfile section lives.
+
+use std::path::PathBuf;
+
+use konvoy_util::error::UtilError;
+use konvoy_util::maven::{MavenCoordinate, MAVEN_CENTRAL};
+
+/// Where a managed tool's JAR is fetched from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolSource {
+    /// A Maven Central artifact addressed by coordinate (e.g. Fabrikt).
+    Maven(MavenCoordinate),
+    /// A direct release URL with a fixed filename (e.g. detekt's GitHub release).
+    DirectUrl { url: String, filename: String },
+}
+
+/// A managed JAR tool downloaded into `~/.konvoy/tools/<id>/<version>/`.
+///
+/// Fields are private so the validating constructors ([`maven_jar`](Self::maven_jar)
+/// / [`direct_url`](Self::direct_url)) are the only construction path — callers
+/// can't assemble a spec whose `version`/`filename` would escape the tools dir.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedToolSpec {
+    /// Stable lockfile/cache id, e.g. `"fabrikt"` or `"detekt"`.
+    id: String,
+    /// Human-readable name used in progress output / diagnostics.
+    display_name: String,
+    /// Tool version.
+    version: String,
+    /// Where the JAR comes from.
+    source: ToolSource,
+}
+
+impl ManagedToolSpec {
+    /// A managed Maven Central JAR; the version is taken from the coordinate.
+    #[must_use]
+    pub fn maven_jar(id: &str, display_name: &str, coordinate: MavenCoordinate) -> Self {
+        Self {
+            id: id.to_owned(),
+            display_name: display_name.to_owned(),
+            version: coordinate.version.clone(),
+            source: ToolSource::Maven(coordinate),
+        }
+    }
+
+    /// A managed JAR fetched from a direct release URL with a fixed filename.
+    #[must_use]
+    pub fn direct_url(
+        id: &str,
+        display_name: &str,
+        version: &str,
+        url: String,
+        filename: String,
+    ) -> Self {
+        Self {
+            id: id.to_owned(),
+            display_name: display_name.to_owned(),
+            version: version.to_owned(),
+            source: ToolSource::DirectUrl { url, filename },
+        }
+    }
+
+    /// The stable lockfile/cache id.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The tool version.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// The artifact filename on disk.
+    #[must_use]
+    pub fn filename(&self) -> String {
+        match &self.source {
+            ToolSource::Maven(coordinate) => coordinate.filename(),
+            ToolSource::DirectUrl { filename, .. } => filename.clone(),
+        }
+    }
+
+    /// The download URL for this tool.
+    #[must_use]
+    pub fn download_url(&self) -> String {
+        match &self.source {
+            ToolSource::Maven(coordinate) => coordinate.to_url(MAVEN_CENTRAL),
+            ToolSource::DirectUrl { url, .. } => url.clone(),
+        }
+    }
+
+    /// The managed artifact path under `~/.konvoy/tools/<id>/<version>/`.
+    ///
+    /// This is a pure path computation (read-only callers like `is_installed`
+    /// rely on it not erroring on a malformed version). The traversal guard lives
+    /// in [`ensure`](Self::ensure), the only method that *writes* — see `validate`.
+    ///
+    /// # Errors
+    /// Returns an error if the Konvoy home directory cannot be resolved.
+    pub fn artifact_path(&self) -> Result<PathBuf, UtilError> {
+        Ok(konvoy_util::fs::konvoy_home()?
+            .join("tools")
+            .join(&self.id)
+            .join(&self.version)
+            .join(self.filename()))
+    }
+
+    /// Whether the artifact already exists locally.
+    ///
+    /// # Errors
+    /// Returns an error if the Konvoy home directory cannot be resolved.
+    pub fn is_installed(&self) -> Result<bool, UtilError> {
+        Ok(self.artifact_path()?.exists())
+    }
+
+    /// Download (or verify a cached) artifact, returning `(path, sha256)`.
+    ///
+    /// Domain error mapping is the caller's job: map the returned `UtilError`
+    /// via `error::map_artifact_download_err`.
+    ///
+    /// # Errors
+    /// Returns an error if the id/version/filename is unsafe, the artifact cannot
+    /// be downloaded, or the expected SHA-256 does not match.
+    pub fn ensure(&self, expected_sha256: Option<&str>) -> Result<(PathBuf, String), UtilError> {
+        // Validate here (the only method that writes), so a traversal-laden
+        // version/filename can never escape the tools dir during a download.
+        self.validate()?;
+
+        let artifact_path = self.artifact_path()?;
+        // Only show a download bar when the JAR isn't already cached — a cached
+        // re-verify completes in milliseconds and the flash is more noise than
+        // information.
+        let progress = (!artifact_path.exists()).then(|| {
+            konvoy_util::progress::new_download_bar(format!(
+                "{} {}",
+                self.display_name, self.version
+            ))
+        });
+        // Pass the validated `id` (not the free-text display_name) as the fetch
+        // label — download_artifact embeds it in a temp filename, so a separator
+        // in display_name would point the temp path at a missing directory.
+        let result = konvoy_util::progress::fetch(
+            &self.download_url(),
+            &artifact_path,
+            expected_sha256,
+            &self.id,
+            progress.as_ref(),
+        )?;
+        if progress.is_some() {
+            eprintln!();
+        }
+
+        Ok((result.path, result.sha256))
+    }
+
+    /// Reject any component that could escape `~/.konvoy/tools/<id>/<version>/`.
+    /// `validate_identifier` allows `[A-Za-z0-9._-]` but rejects `..`, covering
+    /// the id, version, and the on-disk filename (Maven `artifact-version.ext`
+    /// or the caller-supplied direct-URL filename).
+    fn validate(&self) -> Result<(), UtilError> {
+        konvoy_util::artifact::validate_identifier(&self.id)?;
+        konvoy_util::artifact::validate_identifier(&self.version)?;
+        konvoy_util::artifact::validate_identifier(&self.filename())?;
+        if let ToolSource::Maven(coordinate) = &self.source {
+            konvoy_util::artifact::validate_identifier(&coordinate.group_id)?;
+            konvoy_util::artifact::validate_identifier(&coordinate.artifact_id)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/konvoy-engine/tests/codegen_openapi.rs
+++ b/crates/konvoy-engine/tests/codegen_openapi.rs
@@ -1,0 +1,353 @@
+use std::fs;
+
+use konvoy_config::manifest::{Codegen, OpenApiCodegen};
+use konvoy_engine::codegen::ManagedToolSpec;
+use konvoy_util::maven::MavenCoordinate;
+
+/// Removes a managed-tool version directory on drop, so tests that write fake
+/// JARs under the real `~/.konvoy/tools/` don't leave junk behind — even when an
+/// assertion panics mid-test.
+struct CleanupDir(std::path::PathBuf);
+impl Drop for CleanupDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn managed_tool_spec_formats_maven_jar_url_and_path() {
+    let spec = ManagedToolSpec::maven_jar(
+        "grpc",
+        "gRPC Kotlin generator",
+        MavenCoordinate::new("io.grpc", "protoc-gen-grpc-kotlin", "1.4.1"),
+    );
+
+    assert_eq!(
+        spec.download_url(),
+        "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.4.1/protoc-gen-grpc-kotlin-1.4.1.jar"
+    );
+    let path = spec.artifact_path().unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/grpc/1.4.1"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("protoc-gen-grpc-kotlin-1.4.1.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_includes_generator_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+
+    let first = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.first".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+    let second = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.second".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+
+    let first_hashes = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &first).unwrap();
+    let second_hashes =
+        konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &second).unwrap();
+
+    assert_ne!(first_hashes, second_hashes);
+}
+
+fn openapi_codegen(version: &str, spec: &str, base_package: &str) -> Codegen {
+    openapi_codegen_with_dirs(version, spec, base_package, &[])
+}
+
+fn openapi_codegen_with_dirs(
+    version: &str,
+    spec: &str,
+    base_package: &str,
+    extra_spec_dirs: &[&str],
+) -> Codegen {
+    Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: version.to_owned(),
+            spec: spec.to_owned(),
+            base_package: base_package.to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|d| (*d).to_owned()).collect(),
+        }),
+    }
+}
+
+#[test]
+fn openapi_codegen_hash_changes_when_spec_content_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: A\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    // Same path, different bytes — the cache key MUST change.
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: B\n  version: 2.0.0\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing the spec content must change the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_tracks_files_under_extra_spec_dirs() {
+    // Fabrikt resolves `$ref`'d sibling files internally but never reports them,
+    // so Konvoy tracks them by directory: listing the sub-spec's directory in
+    // `extra_spec_dirs` makes a change to ANY file under it invalidate the hash.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: integer\n",
+    )
+    .unwrap();
+
+    let codegen =
+        openapi_codegen_with_dirs("20.0.0", "openapi.yaml", "com.example.api", &["components"]);
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    // Changing ONLY the referenced sub-spec must change the hash.
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing a file under a spec_dir must change the codegen hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_ignores_siblings_without_extra_spec_dirs() {
+    // The flip side of the accepted tradeoff: without `extra_spec_dirs`, only the
+    // primary spec is tracked. A change to a sibling `$ref`'d file is NOT picked
+    // up — users must opt in by listing the directory. This documents (and locks)
+    // that Konvoy does not parse the spec to discover `$ref` targets.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(components.join("pet.yaml"), "Pet:\n  type: object\n").unwrap();
+
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_eq!(
+        before, after,
+        "without extra_spec_dirs, a sibling file change must not affect the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_dir_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen_with_dirs(
+        "20.0.0",
+        "openapi.yaml",
+        "com.example.api",
+        &["does-not-exist"],
+    );
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen);
+    assert!(
+        matches!(
+            result,
+            Err(konvoy_engine::EngineError::CodegenInputDirNotFound { .. })
+        ),
+        "expected CodegenInputDirNotFound, got {result:?}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_is_stable_across_runs_and_project_roots() {
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let spec_bytes = "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n";
+
+    let dir1 = tempfile::tempdir().unwrap();
+    fs::write(dir1.path().join("openapi.yaml"), spec_bytes).unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    fs::write(dir2.path().join("openapi.yaml"), spec_bytes).unwrap();
+
+    let h1a = konvoy_engine::codegen::compute_codegen_hashes(dir1.path(), &codegen).unwrap();
+    let h1b = konvoy_engine::codegen::compute_codegen_hashes(dir1.path(), &codegen).unwrap();
+    let h2 = konvoy_engine::codegen::compute_codegen_hashes(dir2.path(), &codegen).unwrap();
+
+    assert_eq!(h1a, h1b, "identical inputs must produce identical hashes");
+    assert_eq!(
+        h1a, h2,
+        "the hash must be independent of the absolute project location"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let codegen = openapi_codegen("20.0.0", "missing.yaml", "com.example.api");
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen);
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("missing.yaml"),
+        "error should name the missing spec, was: {message}"
+    );
+}
+
+#[test]
+fn codegen_hash_pairs_match_tagged_hashes() {
+    // compute_codegen_hashes (cache-key form) must be exactly the tagged
+    // rendering of compute_codegen_hash_pairs, so threading the pairs into the
+    // build does not change the cache key bytes.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    let pairs = konvoy_engine::codegen::compute_codegen_hash_pairs(dir.path(), &codegen).unwrap();
+    let tagged = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    let from_pairs: Vec<String> = pairs.iter().map(|(n, h)| format!("{n}:{h}")).collect();
+    assert_eq!(tagged, from_pairs);
+    assert!(pairs.iter().any(|(name, _)| name == "openapi"));
+}
+
+#[test]
+fn fabrikt_download_url_format() {
+    let url = konvoy_engine::codegen::openapi::fabrikt_download_url("20.0.0");
+    assert_eq!(
+        url,
+        "https://repo1.maven.org/maven2/com/cjbooms/fabrikt/20.0.0/fabrikt-20.0.0.jar"
+    );
+}
+
+#[test]
+fn fabrikt_jar_path_format() {
+    let path = konvoy_engine::codegen::openapi::fabrikt_jar_path("20.0.0").unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/fabrikt/20.0.0"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("fabrikt-20.0.0.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_rejects_invalid_version() {
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("../bad", None);
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("invalid fabrikt version"),
+        "error was: {message}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_hash_mismatch_on_existing_jar() {
+    let version = format!("99.0.0-test-mismatch-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"not the expected jar").unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        &version,
+        Some("0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(message.contains("hash mismatch"), "error was: {message}");
+    let _ = fs::remove_file(&jar);
+}
+
+#[test]
+fn ensure_fabrikt_accepts_matching_hash_on_existing_jar() {
+    let version = format!("99.0.0-test-match-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"already cached").unwrap();
+    let real_hash = konvoy_util::hash::sha256_file(&jar).unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(&version, Some(&real_hash));
+
+    assert!(result.is_ok(), "matching hash should pass: {result:?}");
+    let (path, hash) = result.unwrap();
+    assert_eq!(path, jar);
+    assert_eq!(hash, real_hash);
+    let _ = fs::remove_file(&path);
+}

--- a/crates/konvoy-util/src/fs.rs
+++ b/crates/konvoy-util/src/fs.rs
@@ -125,7 +125,18 @@ pub fn prepend_to_environment_path(
 /// Returns an error if `dir` cannot be read.
 pub fn collect_files(dir: &Path, extension: &str) -> Result<Vec<PathBuf>, UtilError> {
     let mut files = Vec::new();
-    collect_files_recursive(dir, extension, &mut files)?;
+    collect_files_recursive(dir, Some(extension), &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+/// Collect every file under `dir`, recursively, sorted by path (no extension filter).
+///
+/// # Errors
+/// Returns an error if `dir` cannot be read.
+pub fn collect_all_files(dir: &Path) -> Result<Vec<PathBuf>, UtilError> {
+    let mut files = Vec::new();
+    collect_files_recursive(dir, None, &mut files)?;
     files.sort();
     Ok(files)
 }
@@ -137,12 +148,16 @@ fn has_extension(path: &Path, ext: &str) -> bool {
         .is_some_and(|e| e == ext)
 }
 
+/// Recursively collect files under `dir`. When `extension` is `Some`, only files
+/// with that extension are collected; when `None`, every file is collected.
 fn collect_files_recursive(
     dir: &Path,
-    extension: &str,
+    extension: Option<&str>,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), UtilError> {
     let entries = std::fs::read_dir(dir).map_err(io_err(dir))?;
+
+    let matches = |path: &Path| extension.is_none_or(|ext| has_extension(path, ext));
 
     for entry in entries {
         let entry = entry.map_err(io_err(dir))?;
@@ -163,7 +178,7 @@ fn collect_files_recursive(
 
             // Only include symlinked regular files; skip directory symlinks
             // to prevent infinite recursion from symlink cycles.
-            if target_meta.is_file() && has_extension(&path, extension) {
+            if target_meta.is_file() && matches(&path) {
                 out.push(path);
             }
             continue;
@@ -173,7 +188,7 @@ fn collect_files_recursive(
 
         if file_type.is_dir() {
             collect_files_recursive(&path, extension, out)?;
-        } else if has_extension(&path, extension) {
+        } else if matches(&path) {
             out.push(path);
         }
     }


### PR DESCRIPTION
Second layer of the OpenAPI codegen stack, on top of #283 (merged). This is the **declarative half** of the engine — it defines generators, hashes their inputs, and fetches the managed tool, but does **not** run codegen or touch the build path yet. Safe to merge alone (all pub API + unit-tested).

## Managed-JAR-tool abstraction (shared with detekt)
A codebase sweep confirmed detekt, plugins, and codegen tools all reimplement "download + SHA-verify + pin a versioned JAR" over the same `konvoy_util` primitives, with no shared construct. So this PR introduces the canonical one and folds **detekt** onto it:
- **`crate::managed_tool::ManagedToolSpec`** — downloads/caches/SHA-verifies a versioned JAR into `~/.konvoy/tools/<id>/<version>/`, from either a **Maven coordinate** or a **direct release URL** (`ToolSource` enum). It owns *fetch + locate* only; domain error mapping (`Detekt*` / `Codegen*` via the shared `map_artifact_download_err`) and lockfile pinning stay **caller-side**.
- **detekt migrated** onto it — its download functions are now thin wrappers; the actionable `Detekt*` messages and `[toolchain]` pinning are preserved.

## Codegen
- `CodeGenerator` trait + `OpenApiGenerator` (Fabrikt) using `ManagedToolSpec`.
- `config_hash_parts`, `input_files` (primary `spec` + every file under `extra_spec_dirs`, deduped), `compute_codegen_hash_pairs`/`compute_codegen_hashes`.
- `konvoy_util::fs::collect_all_files` + codegen `EngineError` variants.

## Deferred → PR3
`run_codegen`, tool-pin resolve/persist (`ManagedToolResolution`), the `[codegen_tools]` lockfile schema, `ensure_jre`, and the `build.rs`/`test_build.rs`/`cache.rs` wiring + run-tests.

## Verification
`cargo build/test --workspace` (13 binaries), `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` — all green.

## Stack
1. ✅ #283 — manifest schema + validation (merged)
2. **(this)** managed-tool abstraction (detekt + Fabrikt) + generator + input hashing
3. codegen execution (`run_codegen`) + build/test cache integration + lockfile pins
4. `konvoy generate` CLI + doctor
5. real e2e smoke tests + Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)