### PR TITLE
codegen (2.2/5): OpenAPI source generation via Fabrikt, on ManagedToolSpec

### DIFF
--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -1,0 +1,184 @@
+//! Declarative source generation before Kotlin/Native compilation.
+
+use std::path::{Path, PathBuf};
+
+use konvoy_config::manifest::Codegen;
+
+use crate::error::EngineError;
+
+pub mod openapi;
+
+// The managed-tool abstraction is shared with the detekt linter, so it lives at
+// the engine root (`crate::managed_tool`); re-exported here for codegen callers.
+pub use crate::managed_tool::ManagedToolSpec;
+
+/// Display metadata for a configured generator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratorSummary {
+    /// Stable generator name used in paths and cache key tags.
+    pub name: String,
+    /// Human-readable generator label.
+    pub display_name: String,
+    /// Directory containing this generator's outputs.
+    pub output_dir: PathBuf,
+}
+
+/// A configured code generator.
+pub trait CodeGenerator {
+    /// Stable generator name used in paths and cache key tags.
+    fn name(&self) -> &str;
+
+    /// Human-readable generator label.
+    fn display_name(&self) -> &str;
+
+    /// Managed tool required by this generator.
+    fn managed_tool(&self) -> ManagedToolSpec;
+
+    /// Stable config fields that affect generated sources.
+    fn config_hash_parts(&self) -> Vec<String>;
+
+    /// Project-relative input files read by this generator.
+    ///
+    /// `project_root` lets generators enumerate inputs that live on disk (e.g.
+    /// every file under a configured spec directory). The returned paths are
+    /// project-relative and their contents are folded into the generator hash
+    /// (and thus the build cache key).
+    ///
+    /// # Errors
+    /// Returns an error if a configured input location (e.g. a spec directory)
+    /// is missing or cannot be read.
+    fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError>;
+
+    /// Generate sources into `output_dir`.
+    ///
+    /// The tool returned by [`managed_tool`](Self::managed_tool) must already be
+    /// downloaded; the generator runs it through
+    /// [`ManagedToolSpec::run`](crate::managed_tool::ManagedToolSpec::run). `jre_home`
+    /// is the managed JRE for JVM generators (e.g. Fabrikt) and `None` for a future
+    /// native generator — it is forwarded to `run` per the tool's runtime.
+    ///
+    /// # Errors
+    /// Returns an error if the generator process cannot be executed or fails.
+    fn generate(
+        &self,
+        project_root: &Path,
+        output_dir: &Path,
+        jre_home: Option<&Path>,
+        verbose: bool,
+    ) -> Result<(), EngineError>;
+}
+
+/// Return all active generators in stable order.
+pub fn active_generators(codegen: &Codegen) -> Vec<Box<dyn CodeGenerator>> {
+    let mut generators: Vec<Box<dyn CodeGenerator>> = Vec::new();
+    if let Some(openapi) = &codegen.openapi {
+        generators.push(Box::new(openapi::OpenApiGenerator::new(openapi.clone())));
+    }
+    generators
+}
+
+/// Return display summaries for all active generators.
+#[must_use]
+pub fn generator_summaries(project_root: &Path, codegen: &Codegen) -> Vec<GeneratorSummary> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| GeneratorSummary {
+            name: generator.name().to_owned(),
+            display_name: generator.display_name().to_owned(),
+            output_dir: generator_output_dir(project_root, generator.name()),
+        })
+        .collect()
+}
+
+/// Return managed tools for all active generators.
+#[must_use]
+pub fn managed_tools(codegen: &Codegen) -> Vec<ManagedToolSpec> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| generator.managed_tool())
+        .collect()
+}
+
+/// Compute `(generator name, input hash)` pairs for all active generators, in
+/// stable order.
+///
+/// This is the single place generator hashes are computed. A build computes them
+/// once for the cache key and threads them into `run_codegen` (via its
+/// `precomputed_hashes` argument) so neither the hash nor any spec /
+/// `extra_spec_dirs` file is read a second time on a cache-miss build.
+///
+/// # Errors
+/// Returns an error if a configured generator input cannot be read.
+pub fn compute_codegen_hash_pairs(
+    project_root: &Path,
+    codegen: &Codegen,
+) -> Result<Vec<(String, String)>, EngineError> {
+    active_generators(codegen)
+        .into_iter()
+        .map(|generator| {
+            let hash = compute_generator_hash(generator.as_ref(), project_root)?;
+            Ok((generator.name().to_owned(), hash))
+        })
+        .collect()
+}
+
+/// Compute tagged (`name:hash`) hashes for all active generators — the form
+/// folded into the build cache key.
+///
+/// # Errors
+/// Returns an error if a configured generator input cannot be read.
+pub fn compute_codegen_hashes(
+    project_root: &Path,
+    codegen: &Codegen,
+) -> Result<Vec<String>, EngineError> {
+    Ok(compute_codegen_hash_pairs(project_root, codegen)?
+        .into_iter()
+        .map(|(name, hash)| format!("{name}:{hash}"))
+        .collect())
+}
+
+/// Return the output directory for a generator under `.konvoy/gen/`.
+#[must_use]
+pub fn generator_output_dir(project_root: &Path, name: &str) -> PathBuf {
+    project_root.join(".konvoy").join("gen").join(name)
+}
+
+fn compute_generator_hash(
+    generator: &dyn CodeGenerator,
+    project_root: &Path,
+) -> Result<String, EngineError> {
+    let mut parts = vec![
+        "codegen-v1".to_owned(),
+        generator.name().to_owned(),
+        generator.display_name().to_owned(),
+    ];
+    parts.extend(generator.config_hash_parts());
+
+    for input in generator.input_files(project_root)? {
+        let full_path = project_root.join(&input);
+        // Hash the path's raw bytes (not Display, which is lossy for non-UTF-8
+        // names) so a rename always changes the key and the key is encoding-stable.
+        parts.push("file".to_owned());
+        parts.push(konvoy_util::hash::sha256_bytes(
+            input.as_os_str().as_encoded_bytes(),
+        ));
+        // Read content directly (no exists() pre-check): that races with the read
+        // and reports EACCES as "not found". Map only a genuine NotFound to the
+        // actionable codegen error; surface other I/O errors (e.g. permission) as-is.
+        match konvoy_util::hash::sha256_file(&full_path) {
+            Ok(hash) => parts.push(hash),
+            Err(konvoy_util::error::UtilError::Io { source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                return Err(EngineError::CodegenInputNotFound {
+                    name: generator.name().to_owned(),
+                    path: full_path.display().to_string(),
+                });
+            }
+            Err(e) => return Err(EngineError::from(e)),
+        }
+    }
+
+    let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
+    Ok(konvoy_util::hash::sha256_multi(&refs))
+}

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -1,0 +1,441 @@
+//! OpenAPI source generation using Fabrikt.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+use konvoy_config::manifest::OpenApiCodegen;
+use konvoy_util::maven::MavenCoordinate;
+
+use crate::codegen::{CodeGenerator, ManagedToolSpec};
+use crate::error::EngineError;
+
+const GENERATOR_NAME: &str = "openapi";
+const TOOL_NAME: &str = "fabrikt";
+/// Human-readable tool name, used consistently in the download bar, the
+/// generation message, and failure diagnostics.
+const TOOL_DISPLAY: &str = "Fabrikt";
+
+/// Fixed Fabrikt generation flags. These affect generated output, so they are
+/// also folded into the config hash (see `config_hash_parts`) — if any of them
+/// ever changes, the codegen hash and build cache key change with it.
+const FABRIKT_TARGETS: &str = "HTTP_MODELS";
+const FABRIKT_SERIALIZATION_LIBRARY: &str = "KOTLINX_SERIALIZATION";
+/// Fabrikt defaults to `JAVAX_VALIDATION`, which emits `javax.validation.*`
+/// annotations on required/constrained fields. Those are JVM-only and do not
+/// exist on Kotlin/Native, so generated models would not compile. Konvoy is
+/// native-first, so validation annotations are disabled.
+const FABRIKT_VALIDATION_LIBRARY: &str = "NO_VALIDATION";
+
+/// OpenAPI generator backed by the Fabrikt CLI JAR.
+#[derive(Debug, Clone)]
+pub struct OpenApiGenerator {
+    config: OpenApiCodegen,
+}
+
+impl OpenApiGenerator {
+    /// Create a generator from parsed manifest config.
+    #[must_use]
+    pub fn new(config: OpenApiCodegen) -> Self {
+        Self { config }
+    }
+}
+
+fn fabrikt_tool(version: &str) -> ManagedToolSpec {
+    ManagedToolSpec::maven_jar(
+        TOOL_NAME,
+        TOOL_DISPLAY,
+        MavenCoordinate::new("com.cjbooms", TOOL_NAME, version),
+    )
+}
+
+/// Return the managed Fabrikt JAR path for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn fabrikt_jar_path(version: &str) -> Result<PathBuf, EngineError> {
+    fabrikt_tool(version)
+        .artifact_path()
+        .map_err(EngineError::from)
+}
+
+/// Return the Maven Central URL for a Fabrikt JAR.
+#[must_use]
+pub fn fabrikt_download_url(version: &str) -> String {
+    fabrikt_tool(version).download_url()
+}
+
+/// Return whether Fabrikt is installed for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn is_installed(version: &str) -> Result<bool, EngineError> {
+    fabrikt_tool(version)
+        .is_installed()
+        .map_err(EngineError::from)
+}
+
+/// Download or verify the managed Fabrikt JAR.
+///
+/// # Errors
+/// Returns an error if the version is unsafe, the artifact cannot be
+/// downloaded, or the expected SHA-256 does not match.
+pub fn ensure_fabrikt(
+    version: &str,
+    expected_sha256: Option<&str>,
+) -> Result<(PathBuf, String), EngineError> {
+    // Pre-validate for an actionable, Fabrikt-specific message; the shared tool
+    // also validates, but its raw error would map to a generic one. Use the same
+    // `validate_identifier` the spec uses (it rejects `..`), so a traversal-laden
+    // version yields this clear message rather than falling through to the generic
+    // download mapping.
+    konvoy_util::artifact::validate_identifier(version).map_err(|_| EngineError::CodegenDownload {
+        name: TOOL_NAME.to_owned(),
+        version: version.to_owned(),
+        message: format!(
+            "invalid fabrikt version \"{version}\" — only alphanumeric characters, dots, hyphens, and underscores are allowed, and it cannot be `..`"
+        ),
+    })?;
+    fabrikt_tool(version)
+        .ensure(expected_sha256)
+        .map_err(|e| map_fabrikt_download_err(version, e))
+}
+
+/// Map a download/verify `UtilError` to the Fabrikt-specific engine error
+/// (mirrors the detekt and plugin paths via the shared mapper).
+fn map_fabrikt_download_err(version: &str, e: konvoy_util::error::UtilError) -> EngineError {
+    crate::error::map_artifact_download_err(
+        TOOL_NAME,
+        e,
+        |name, message| EngineError::CodegenDownload {
+            name,
+            version: version.to_owned(),
+            message,
+        },
+        |name, expected, actual| EngineError::CodegenHashMismatch {
+            name,
+            version: version.to_owned(),
+            expected,
+            actual,
+        },
+    )
+}
+
+impl CodeGenerator for OpenApiGenerator {
+    fn name(&self) -> &str {
+        GENERATOR_NAME
+    }
+
+    fn display_name(&self) -> &str {
+        "OpenAPI"
+    }
+
+    fn managed_tool(&self) -> ManagedToolSpec {
+        fabrikt_tool(&self.config.version)
+    }
+
+    fn config_hash_parts(&self) -> Vec<String> {
+        // Only non-file config that affects generated output. `spec` and
+        // `extra_spec_dirs` are deliberately NOT folded in here: `input_files`
+        // already contributes their (normalized, sorted, deduped) paths *and*
+        // contents to the same generator hash. Repeating the raw config strings
+        // would only over-invalidate the cache on cosmetic edits (a leading `./`,
+        // an interior `.`) or a reorder of `extra_spec_dirs` — neither of which
+        // changes the resolved input set or the generated sources.
+        vec![
+            format!("tool_version={}", self.config.version),
+            format!("base_package={}", self.config.base_package),
+            format!("targets={FABRIKT_TARGETS}"),
+            format!("serialization_library={FABRIKT_SERIALIZATION_LIBRARY}"),
+            format!("validation_library={FABRIKT_VALIDATION_LIBRARY}"),
+        ]
+    }
+
+    /// Project-relative files whose contents feed the codegen cache key.
+    ///
+    /// Always includes the primary `spec`. When `extra_spec_dirs` is configured, also
+    /// includes every file under those directories so a change to any `$ref`'d
+    /// sibling (which Fabrikt resolves internally but never reports) regenerates
+    /// sources. Fabrikt exposes no resolved-input list — via CLI, library, or its
+    /// Gradle plugins — so we deliberately over-approximate by directory rather
+    /// than re-parse the spec in Rust.
+    fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+        // Normalize the spec the same way dir-collected files are normalized so a
+        // spec written as `./specs/api.yaml` dedups against a listed `specs` dir
+        // entry (`specs/api.yaml`) instead of hashing the same file twice.
+        let mut files = vec![project_relative(project_root, Path::new(&self.config.spec))];
+
+        for dir in &self.config.extra_spec_dirs {
+            let dir_abs = project_root.join(dir);
+            if !dir_abs.is_dir() {
+                return Err(EngineError::CodegenInputDirNotFound {
+                    name: GENERATOR_NAME.to_owned(),
+                    path: dir_abs.display().to_string(),
+                });
+            }
+            for file in konvoy_util::fs::collect_all_files(&dir_abs)? {
+                // Skip hidden entries (a path component below the dir that starts
+                // with `.`): OS/editor/VCS noise like `.DS_Store`, `.git/`, and
+                // editor swap files, plus the `.konvoy` output dir when a spec dir
+                // contains it (e.g. extra_spec_dirs = ["."]). These are never spec
+                // input, and folding them in would make the cache key depend on
+                // platform/editor state, breaking deterministic, stable hashing.
+                if has_hidden_component(&dir_abs, &file) {
+                    continue;
+                }
+                files.push(project_relative(project_root, &file));
+            }
+        }
+
+        files.sort();
+        files.dedup();
+        Ok(files)
+    }
+
+    fn generate(
+        &self,
+        project_root: &Path,
+        output_dir: &Path,
+        jre_home: Option<&Path>,
+        verbose: bool,
+    ) -> Result<(), EngineError> {
+        let spec_path = project_root.join(&self.config.spec);
+        eprintln!(
+            "    Generating OpenAPI sources with {TOOL_DISPLAY} {}...",
+            self.config.version
+        );
+
+        let args = [
+            OsString::from("--api-file"),
+            spec_path.into_os_string(),
+            OsString::from("--base-package"),
+            OsString::from(&self.config.base_package),
+            OsString::from("--output-directory"),
+            output_dir.as_os_str().to_owned(),
+            OsString::from("--targets"),
+            OsString::from(FABRIKT_TARGETS),
+            OsString::from("--serialization-library"),
+            OsString::from(FABRIKT_SERIALIZATION_LIBRARY),
+            OsString::from("--validation-library"),
+            OsString::from(FABRIKT_VALIDATION_LIBRARY),
+        ];
+
+        let output = self.managed_tool().run(jre_home, &args, verbose)?;
+
+        // A code generator treats a non-zero exit as a hard failure (unlike the
+        // linter, which reads it as "issues found").
+        if !output.success {
+            // JVM CLIs typically print the real error to stderr (and banners to
+            // stdout), so prefer stderr for the one-line hint and fall back to
+            // stdout. Never concatenate the streams — that can fuse an unrelated
+            // stdout line onto the first stderr line.
+            let hint_source = if output.stderr.trim().is_empty() {
+                &output.stdout
+            } else {
+                &output.stderr
+            };
+            let hint = first_non_empty_line(hint_source)
+                .map(|line| format!(" first message: {line}"))
+                .unwrap_or_default();
+            return Err(EngineError::CodegenFailed {
+                name: GENERATOR_NAME.to_owned(),
+                message: format!(
+                    "{TOOL_DISPLAY} failed.{hint} Run with --verbose to see full output."
+                ),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// First non-blank line of `output`, trimmed — used to surface a concise hint
+/// from a failed Fabrikt run without dumping its whole log.
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().map(str::trim).find(|line| !line.is_empty())
+}
+
+/// Whether `file` (a walk result under `base`) has any path component, below
+/// `base`, that is hidden (starts with `.`). Used to exclude OS/editor/VCS noise
+/// (`.DS_Store`, `.git/`, swap files) and the `.konvoy` output dir from the
+/// codegen input set, keeping the cache key deterministic and platform-stable.
+fn has_hidden_component(base: &Path, file: &Path) -> bool {
+    file.strip_prefix(base)
+        .unwrap_or(file)
+        .components()
+        .any(|c| matches!(c, Component::Normal(name) if name.to_string_lossy().starts_with('.')))
+}
+
+/// Normalize a path to a clean project-relative form for stable, dedup-able
+/// hashing. Absolute inputs (dir-walk results under `project_root`) and relative
+/// inputs (the configured `spec`, possibly written with a leading `./`) both
+/// collapse to the same `specs/api.yaml`-style path. Joining onto `project_root`
+/// then stripping it also drops interior `.` components via `Path::components`.
+fn project_relative(project_root: &Path, path: &Path) -> PathBuf {
+    let joined = project_root.join(path);
+    joined
+        .strip_prefix(project_root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn generator(spec: &str, extra_spec_dirs: &[&str]) -> OpenApiGenerator {
+        OpenApiGenerator::new(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: spec.to_owned(),
+            base_package: "com.example.api".to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|s| (*s).to_owned()).collect(),
+        })
+    }
+
+    #[test]
+    fn input_files_without_extra_spec_dirs_is_just_the_spec() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = generator("specs/api.yaml", &[])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_with_spec_dir_hashes_every_file_relative_and_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(specs.join("nested")).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+        std::fs::write(specs.join("pet.yaml"), "Pet").unwrap();
+        std::fs::write(specs.join("nested").join("owner.yaml"), "Owner").unwrap();
+        // A non-spec file in the directory is also tracked (over-approximation).
+        std::fs::write(specs.join("README.md"), "notes").unwrap();
+
+        let files = generator("specs/api.yaml", &["specs"])
+            .input_files(tmp.path())
+            .unwrap();
+
+        // Project-relative, sorted, and the primary spec is not duplicated.
+        assert_eq!(
+            files,
+            vec![
+                PathBuf::from("specs/README.md"),
+                PathBuf::from("specs/api.yaml"),
+                PathBuf::from("specs/nested/owner.yaml"),
+                PathBuf::from("specs/pet.yaml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn input_files_dedups_dot_slash_spec_against_listed_dir() {
+        // A spec written with a leading `./` must collapse to the same relative
+        // path as the dir-collected entry, so the file is hashed once, not twice.
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(&specs).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+
+        let files = generator("./specs/api.yaml", &["specs"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_missing_spec_dir_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = generator("specs/api.yaml", &["does-not-exist"])
+            .input_files(tmp.path())
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::CodegenInputDirNotFound { .. }),
+            "expected CodegenInputDirNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn config_hash_parts_is_stable_across_spec_and_dir_cosmetics() {
+        // spec / extra_spec_dirs are tracked by input_files (normalized + sorted +
+        // content), NOT config_hash_parts — so a leading `./` on the spec or a
+        // reorder of extra_spec_dirs must not change config_hash_parts (those edits
+        // don't change the resolved input set or the generated sources).
+        let a = generator("./specs/api.yaml", &["a", "b"]).config_hash_parts();
+        let b = generator("specs/api.yaml", &["b", "a"]).config_hash_parts();
+        assert_eq!(a, b);
+        assert!(
+            a.iter()
+                .all(|p| !p.starts_with("spec=") && !p.starts_with("extra_spec_dir")),
+            "config_hash_parts must not fold in raw spec/extra_spec_dir paths: {a:?}"
+        );
+    }
+
+    #[test]
+    fn input_files_is_insensitive_to_extra_spec_dirs_order() {
+        // The actual determinism guarantee: reordering extra_spec_dirs yields an
+        // identical (sorted, deduped) input set, so the codegen hash is unchanged.
+        let tmp = tempfile::tempdir().unwrap();
+        for d in ["a", "b"] {
+            std::fs::create_dir_all(tmp.path().join(d)).unwrap();
+            std::fs::write(tmp.path().join(d).join("s.yaml"), d).unwrap();
+        }
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+
+        let ab = generator("api.yaml", &["a", "b"])
+            .input_files(tmp.path())
+            .unwrap();
+        let ba = generator("api.yaml", &["b", "a"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(ab, ba);
+    }
+
+    #[test]
+    fn input_files_skips_hidden_files_and_dirs() {
+        // OS/editor/VCS noise under a spec dir must not enter the cache key, or the
+        // hash would flip on a `.DS_Store` write and differ across platforms.
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(specs.join(".git")).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+        std::fs::write(specs.join(".DS_Store"), "junk").unwrap();
+        std::fs::write(specs.join(".git").join("config"), "vcs").unwrap();
+
+        let files = generator("specs/api.yaml", &["specs"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_with_dot_dir_excludes_konvoy_output_dir() {
+        // extra_spec_dirs = ["."] walks the whole project; the generator's own
+        // output under `.konvoy` (a hidden dir) must be excluded, or the input hash
+        // would depend on its own output (self-referential cache key).
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+        let gen_out = tmp.path().join(".konvoy").join("gen").join("openapi");
+        std::fs::create_dir_all(&gen_out).unwrap();
+        std::fs::write(gen_out.join("Models.kt"), "generated").unwrap();
+
+        let files = generator("api.yaml", &["."])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_empty_extra_spec_dir_contributes_nothing() {
+        // A configured-but-empty spec dir is valid (no error) and adds no inputs,
+        // so it can't perturb the hash until a file actually appears in it.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+        std::fs::create_dir_all(tmp.path().join("extra")).unwrap();
+
+        let files = generator("api.yaml", &["extra"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("api.yaml")]);
+    }
+}

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -132,6 +132,43 @@ pub enum EngineError {
     #[error("detekt not configured — add `detekt = \"1.23.7\"` to [toolchain] in konvoy.toml")]
     LintNotConfigured,
 
+    /// No code generators are configured.
+    #[error("no codegen configured — add [codegen.openapi] to konvoy.toml")]
+    CodegenNotConfigured,
+
+    /// A configured codegen input file is missing.
+    #[error("codegen input for `{name}` not found at {path} — create the file, or fix `spec`/`extra_spec_dirs` in [codegen.{name}]")]
+    CodegenInputNotFound { name: String, path: String },
+
+    /// A configured codegen spec directory is missing.
+    #[error("codegen spec directory for `{name}` not found at {path} — create the directory or fix `extra_spec_dirs` in [codegen.{name}]")]
+    CodegenInputDirNotFound { name: String, path: String },
+
+    /// A codegen tool is not available in a mode that forbids downloads.
+    #[error("codegen tool `{name}` {version} is not downloaded and --locked prevents downloads — run `konvoy generate` without --locked first")]
+    CodegenToolNotFound { name: String, version: String },
+
+    /// A codegen tool download failed.
+    #[error("cannot download codegen tool `{name}` {version}: {message}")]
+    CodegenDownload {
+        name: String,
+        version: String,
+        message: String,
+    },
+
+    /// A codegen tool artifact hash does not match the lockfile.
+    #[error("codegen tool `{name}` {version} hash mismatch — expected {expected}, got {actual}; delete ~/.konvoy/tools/{name}/{version}/ and re-run `konvoy generate`, or verify the artifact upstream")]
+    CodegenHashMismatch {
+        name: String,
+        version: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// Code generation process failed.
+    #[error("cannot run codegen `{name}`: {message}")]
+    CodegenFailed { name: String, message: String },
+
     /// The project name supplied to `konvoy init` is invalid.
     #[error("invalid project name \"{name}\": {reason}")]
     InvalidProjectName { name: String, reason: String },

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod artifact;
 pub mod build;
 pub mod cache;
+pub mod codegen;
 mod common;
 pub mod detekt;
 mod diagnostics;

--- a/crates/konvoy-engine/tests/codegen_openapi.rs
+++ b/crates/konvoy-engine/tests/codegen_openapi.rs
@@ -1,0 +1,369 @@
+use std::fs;
+
+use konvoy_config::manifest::{Codegen, OpenApiCodegen};
+use konvoy_engine::codegen::ManagedToolSpec;
+use konvoy_util::maven::MavenCoordinate;
+
+/// Removes a managed-tool version directory on drop, so tests that write fake
+/// JARs under the real `~/.konvoy/tools/` don't leave junk behind — even when an
+/// assertion panics mid-test.
+struct CleanupDir(std::path::PathBuf);
+impl Drop for CleanupDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn managed_tool_spec_formats_maven_jar_url_and_path() {
+    let spec = ManagedToolSpec::maven_jar(
+        "grpc",
+        "gRPC Kotlin generator",
+        MavenCoordinate::new("io.grpc", "protoc-gen-grpc-kotlin", "1.4.1"),
+    );
+
+    assert_eq!(
+        spec.download_url(),
+        "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.4.1/protoc-gen-grpc-kotlin-1.4.1.jar"
+    );
+    let path = spec.artifact_path().unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/grpc/1.4.1"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("protoc-gen-grpc-kotlin-1.4.1.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_includes_generator_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+
+    let first = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.first".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+    let second = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.second".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+
+    let first_hashes = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &first).unwrap();
+    let second_hashes =
+        konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &second).unwrap();
+
+    assert_ne!(first_hashes, second_hashes);
+}
+
+fn openapi_codegen(version: &str, spec: &str, base_package: &str) -> Codegen {
+    openapi_codegen_with_dirs(version, spec, base_package, &[])
+}
+
+fn openapi_codegen_with_dirs(
+    version: &str,
+    spec: &str,
+    base_package: &str,
+    extra_spec_dirs: &[&str],
+) -> Codegen {
+    Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: version.to_owned(),
+            spec: spec.to_owned(),
+            base_package: base_package.to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|d| (*d).to_owned()).collect(),
+        }),
+    }
+}
+
+#[test]
+fn openapi_codegen_hash_changes_when_spec_content_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: A\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    // Same path, different bytes — the cache key MUST change.
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: B\n  version: 2.0.0\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing the spec content must change the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_tracks_files_under_extra_spec_dirs() {
+    // Fabrikt resolves `$ref`'d sibling files internally but never reports them,
+    // so Konvoy tracks them by directory: listing the sub-spec's directory in
+    // `extra_spec_dirs` makes a change to ANY file under it invalidate the hash.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: integer\n",
+    )
+    .unwrap();
+
+    let codegen =
+        openapi_codegen_with_dirs("20.0.0", "openapi.yaml", "com.example.api", &["components"]);
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    // Changing ONLY the referenced sub-spec must change the hash.
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing a file under a spec_dir must change the codegen hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_ignores_siblings_without_extra_spec_dirs() {
+    // The flip side of the accepted tradeoff: without `extra_spec_dirs`, only the
+    // primary spec is tracked. A change to a sibling `$ref`'d file is NOT picked
+    // up — users must opt in by listing the directory. This documents (and locks)
+    // that Konvoy does not parse the spec to discover `$ref` targets.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(components.join("pet.yaml"), "Pet:\n  type: object\n").unwrap();
+
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let before = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    assert_eq!(
+        before, after,
+        "without extra_spec_dirs, a sibling file change must not affect the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_dir_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen_with_dirs(
+        "20.0.0",
+        "openapi.yaml",
+        "com.example.api",
+        &["does-not-exist"],
+    );
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen);
+    assert!(
+        matches!(
+            result,
+            Err(konvoy_engine::EngineError::CodegenInputDirNotFound { .. })
+        ),
+        "expected CodegenInputDirNotFound, got {result:?}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_is_stable_across_runs_and_project_roots() {
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let spec_bytes = "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n";
+
+    let dir1 = tempfile::tempdir().unwrap();
+    fs::write(dir1.path().join("openapi.yaml"), spec_bytes).unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    fs::write(dir2.path().join("openapi.yaml"), spec_bytes).unwrap();
+
+    let h1a = konvoy_engine::codegen::compute_codegen_hashes(dir1.path(), &codegen).unwrap();
+    let h1b = konvoy_engine::codegen::compute_codegen_hashes(dir1.path(), &codegen).unwrap();
+    let h2 = konvoy_engine::codegen::compute_codegen_hashes(dir2.path(), &codegen).unwrap();
+
+    assert_eq!(h1a, h1b, "identical inputs must produce identical hashes");
+    assert_eq!(
+        h1a, h2,
+        "the hash must be independent of the absolute project location"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let codegen = openapi_codegen("20.0.0", "missing.yaml", "com.example.api");
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen);
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("missing.yaml"),
+        "error should name the missing spec, was: {message}"
+    );
+}
+
+#[test]
+fn codegen_hash_pairs_match_tagged_hashes() {
+    // compute_codegen_hashes (cache-key form) must be exactly the tagged
+    // rendering of compute_codegen_hash_pairs, so threading the pairs into the
+    // build does not change the cache key bytes.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    let pairs = konvoy_engine::codegen::compute_codegen_hash_pairs(dir.path(), &codegen).unwrap();
+    let tagged = konvoy_engine::codegen::compute_codegen_hashes(dir.path(), &codegen).unwrap();
+
+    let from_pairs: Vec<String> = pairs.iter().map(|(n, h)| format!("{n}:{h}")).collect();
+    assert_eq!(tagged, from_pairs);
+    assert!(pairs.iter().any(|(name, _)| name == "openapi"));
+}
+
+#[test]
+fn fabrikt_download_url_format() {
+    let url = konvoy_engine::codegen::openapi::fabrikt_download_url("20.0.0");
+    assert_eq!(
+        url,
+        "https://repo1.maven.org/maven2/com/cjbooms/fabrikt/20.0.0/fabrikt-20.0.0.jar"
+    );
+}
+
+#[test]
+fn fabrikt_jar_path_format() {
+    let path = konvoy_engine::codegen::openapi::fabrikt_jar_path("20.0.0").unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/fabrikt/20.0.0"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("fabrikt-20.0.0.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_rejects_invalid_version() {
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("../bad", None);
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("invalid fabrikt version"),
+        "error was: {message}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_rejects_dotdot_version() {
+    // Charset-valid but contains `..` (e.g. a `1..2` typo): the weaker
+    // validate_version would have let this through, so this is the regression guard
+    // for the validate_identifier fix. `../bad` above does NOT exercise it (the `/`
+    // is rejected by either check).
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("1..2", None);
+    let message = result
+        .expect_err("a `..` version must be rejected")
+        .to_string();
+    assert!(
+        message.contains("invalid fabrikt version"),
+        "expected the curated fabrikt message, got: {message}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_hash_mismatch_on_existing_jar() {
+    let version = format!("99.0.0-test-mismatch-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"not the expected jar").unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        &version,
+        Some("0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(message.contains("hash mismatch"), "error was: {message}");
+    let _ = fs::remove_file(&jar);
+}
+
+#[test]
+fn ensure_fabrikt_accepts_matching_hash_on_existing_jar() {
+    let version = format!("99.0.0-test-match-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"already cached").unwrap();
+    let real_hash = konvoy_util::hash::sha256_file(&jar).unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(&version, Some(&real_hash));
+
+    assert!(result.is_ok(), "matching hash should pass: {result:?}");
+    let (path, hash) = result.unwrap();
+    assert_eq!(path, jar);
+    assert_eq!(hash, real_hash);
+    let _ = fs::remove_file(&path);
+}

--- a/crates/konvoy-util/src/fs.rs
+++ b/crates/konvoy-util/src/fs.rs
@@ -125,7 +125,18 @@ pub fn prepend_to_environment_path(
 /// Returns an error if `dir` cannot be read.
 pub fn collect_files(dir: &Path, extension: &str) -> Result<Vec<PathBuf>, UtilError> {
     let mut files = Vec::new();
-    collect_files_recursive(dir, extension, &mut files)?;
+    collect_files_recursive(dir, Some(extension), &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+/// Collect every file under `dir`, recursively, sorted by path (no extension filter).
+///
+/// # Errors
+/// Returns an error if `dir` cannot be read.
+pub fn collect_all_files(dir: &Path) -> Result<Vec<PathBuf>, UtilError> {
+    let mut files = Vec::new();
+    collect_files_recursive(dir, None, &mut files)?;
     files.sort();
     Ok(files)
 }
@@ -137,12 +148,16 @@ fn has_extension(path: &Path, ext: &str) -> bool {
         .is_some_and(|e| e == ext)
 }
 
+/// Recursively collect files under `dir`. When `extension` is `Some`, only files
+/// with that extension are collected; when `None`, every file is collected.
 fn collect_files_recursive(
     dir: &Path,
-    extension: &str,
+    extension: Option<&str>,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), UtilError> {
     let entries = std::fs::read_dir(dir).map_err(io_err(dir))?;
+
+    let matches = |path: &Path| extension.is_none_or(|ext| has_extension(path, ext));
 
     for entry in entries {
         let entry = entry.map_err(io_err(dir))?;
@@ -163,7 +178,7 @@ fn collect_files_recursive(
 
             // Only include symlinked regular files; skip directory symlinks
             // to prevent infinite recursion from symlink cycles.
-            if target_meta.is_file() && has_extension(&path, extension) {
+            if target_meta.is_file() && matches(&path) {
                 out.push(path);
             }
             continue;
@@ -173,7 +188,7 @@ fn collect_files_recursive(
 
         if file_type.is_dir() {
             collect_files_recursive(&path, extension, out)?;
-        } else if has_extension(&path, extension) {
+        } else if matches(&path) {
             out.push(path);
         }
     }


### PR DESCRIPTION
Split of the former monolithic PR #284. **Stacked on 2.1 (#285)** — review/merge that first; this PR's diff is only the codegen feature (base is the 2.1 branch, so GitHub shows just the delta).

## What
The first code generator: OpenAPI → Kotlin via the managed Fabrikt CLI JAR, built on `ManagedToolSpec` (from #285).

- **codegen module**: a `CodeGenerator` trait (`name`/`display_name`/`managed_tool`/`config_hash_parts`/`input_files`/`generate`) + the registry (`active_generators`, `generator_summaries`, `managed_tools`) and deterministic hashing (`compute_codegen_hashes`/`compute_generator_hash`) that folds the tool version, config, and every input file's content into the build cache key.
- **OpenApiGenerator (Fabrikt)**: a Maven/Jvm `ManagedToolSpec` (`com.cjbooms:fabrikt`); `generate()` runs it via `managed_tool().run(jre_home, ..)` and maps a failed run → `CodegenFailed` (the generator's opposite-of-detekt reading of `!success`). Fixed flags (`HTTP_MODELS`, `KOTLINX_SERIALIZATION`, `NO_VALIDATION` — native-first) are folded into the hash. Inputs = the primary `spec` + every file under each configured `extra_spec_dirs` dir (Fabrikt exposes no resolved-input API, so we hash the directories the user declares).
- **konvoy-util/fs**: `collect_files_recursive` generalized to an optional extension filter; new `collect_all_files` for extension-agnostic walks.
- **error**: codegen variants (`CodegenNotConfigured` / `InputNotFound` / `InputDirNotFound` / `ToolNotFound` / `Download` / `HashMismatch` / `Failed`).
- **tests/codegen_openapi.rs**: config hashing, input enumeration, ensure/locate.

Not yet wired into a CLI command or the build (no `konvoy generate` yet) — that orchestration + lockfile pins land in 3.

## Gates
build · clippy `-D warnings` · fmt · full 918-test suite · rustdoc — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)