### PR TITLE
lint --locked: error instead of auto-installing the toolchain JRE

### DIFF
--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -176,9 +176,15 @@ fn persist_detekt_hash(
 
 /// Resolve the JRE `java` binary from the managed Kotlin toolchain.
 ///
-/// Auto-installs the toolchain if it is not yet present.
-fn resolve_java_bin(kotlin_version: &str) -> Result<(PathBuf, PathBuf), EngineError> {
+/// Auto-installs the toolchain if it is not yet present, unless `locked`
+/// is set — `--locked` forbids downloads, so a missing toolchain is an error.
+fn resolve_java_bin(kotlin_version: &str, locked: bool) -> Result<(PathBuf, PathBuf), EngineError> {
     if !konvoy_konanc::toolchain::is_installed(kotlin_version)? {
+        if locked {
+            return Err(EngineError::DetektJreLocked {
+                version: kotlin_version.to_owned(),
+            });
+        }
         eprintln!("    Installing Kotlin/Native {kotlin_version} (for JRE)...");
         konvoy_konanc::toolchain::install(kotlin_version)?;
     }
@@ -327,7 +333,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     }
 
     // Resolve JRE.
-    let (java_bin, jre_home) = resolve_java_bin(&manifest.toolchain.kotlin)?;
+    let (java_bin, jre_home) = resolve_java_bin(&manifest.toolchain.kotlin, options.locked)?;
 
     // Check for sources.
     let src_dir = root.join("src");
@@ -658,6 +664,65 @@ src/main.kt:3:5: Magic number. [MagicNumber]
         let (path, hash) = result.unwrap();
         assert_eq!(hash, real_hash);
         assert!(path.display().to_string().contains(version));
+    }
+
+    #[test]
+    fn lint_locked_errors_when_toolchain_missing() {
+        // Pre-install a fake detekt JAR with its hash pinned in the lockfile,
+        // so the JAR-side --locked checks pass and lint reaches JRE resolution.
+        let detekt_version = "99.0.2-test";
+        let jar = super::detekt_jar_path(detekt_version).unwrap();
+        std::fs::create_dir_all(jar.parent().unwrap()).unwrap();
+        let content = b"fake jar for locked jre test";
+        std::fs::write(&jar, content).unwrap();
+        let jar_hash = konvoy_util::hash::sha256_bytes(content);
+
+        // Project manifest pins a Kotlin version that is never installed.
+        let kotlin_version = "0.0.0-locked-test";
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("konvoy.toml"),
+            format!(
+                "[package]\nname = \"demo\"\n\n[toolchain]\nkotlin = \"{kotlin_version}\"\ndetekt = \"{detekt_version}\"\n"
+            ),
+        )
+        .unwrap();
+        let lockfile = konvoy_config::lockfile::Lockfile {
+            toolchain: Some(konvoy_config::lockfile::ToolchainLock {
+                konanc_version: kotlin_version.to_owned(),
+                konanc_tarball_sha256: None,
+                jre_tarball_sha256: None,
+                detekt_version: Some(detekt_version.to_owned()),
+                detekt_jar_sha256: Some(jar_hash),
+            }),
+            ..Default::default()
+        };
+        lockfile.write_to(&root.join("konvoy.lock")).unwrap();
+
+        let result = super::lint(
+            root,
+            &super::LintOptions {
+                verbose: false,
+                config: None,
+                locked: true,
+            },
+        );
+
+        // Clean up the fake JAR before asserting.
+        let _ = std::fs::remove_file(&jar);
+        let _ = std::fs::remove_dir(jar.parent().unwrap());
+
+        assert!(result.is_err(), "expected Err, got: {result:?}");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--locked"),
+            "error should mention --locked: {err}"
+        );
+        assert!(
+            err.contains(kotlin_version),
+            "error should mention the toolchain version: {err}"
+        );
     }
 
     #[test]

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -109,6 +109,10 @@ pub enum EngineError {
     #[error("jre not available for running detekt — run `konvoy toolchain install` first")]
     DetektNoJre,
 
+    /// The toolchain providing detekt's JRE is missing and --locked prevents installing it.
+    #[error("Kotlin/Native toolchain {version} is not installed (detekt needs its JRE) and --locked prevents downloads — run `konvoy toolchain install` first")]
+    DetektJreLocked { version: String },
+
     /// Detekt jar hash mismatch.
     #[error("detekt {version} jar hash mismatch — expected {expected}, got {actual}; this may indicate a tampered or corrupted download — delete ~/.konvoy/tools/detekt/{version}/ and re-run `konvoy lint` to re-download, or verify the hash at the detekt release page")]
     DetektHashMismatch {


### PR DESCRIPTION
## Summary

`konvoy lint --locked` honored the no-downloads contract for the detekt JAR (errors if the JAR isn't already downloaded) but **not** for the JRE: `resolve_java_bin` auto-installed the Kotlin/Native toolchain — downloading the konanc tarball and the Adoptium JRE — whenever the toolchain wasn't already present. So `konvoy lint --locked` on a machine without the toolchain performed network downloads, violating the `--locked` contract.

## Changes

- Thread `LintOptions::locked` into `resolve_java_bin`. Under `--locked`, a missing toolchain now returns an error instead of installing, mirroring the existing detekt-JAR check.
- New `EngineError::DetektJreLocked` variant with an actionable message: `Kotlin/Native toolchain {version} is not installed (detekt needs its JRE) and --locked prevents downloads — run `konvoy toolchain install` first`. (Kept separate from `DetektNoJre`, which means "toolchain installed but `java` missing inside it".)

## Test

`lint_locked_errors_when_toolchain_missing` runs end-to-end through `lint()`: a fake detekt JAR is pre-installed with its hash pinned in the lockfile (so the JAR-side `--locked` checks pass) and the manifest pins a never-installed Kotlin version. Before the fix, the test attempted a live network install under `--locked` ("Installing Kotlin/Native 0.0.0-locked-test (for JRE)... cannot download... http status: 404"); after, it fails fast with the new error and no network access.

Note: `konvoy build --locked` has the same gap via `resolve_konanc` — left out of scope here, to be fixed separately.

## Gates

- `cargo build --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test --workspace` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)