### PR TITLE
build --locked: error instead of auto-installing the toolchain

### DIFF
--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -261,7 +261,14 @@ pub(crate) fn resolve_build_context(
     let target = resolve_target(&options.target)?;
     let profile = options.profile;
 
-    // 5. Resolve managed konanc toolchain.
+    // 5. Resolve managed konanc toolchain. `resolve_konanc` auto-installs a
+    //    missing toolchain (a network download), which --locked forbids — fail
+    //    with an actionable error instead.
+    if options.locked && !konvoy_konanc::toolchain::is_installed(&manifest.toolchain.kotlin)? {
+        return Err(EngineError::ToolchainLocked {
+            version: manifest.toolchain.kotlin,
+        });
+    }
     let resolved = resolve_konanc(&manifest.toolchain.kotlin)?;
     let konanc = resolved.info;
     let jre_home = resolved.jre_home;
@@ -1253,6 +1260,48 @@ mod tests {
         };
         let result = build(tmp.path(), &options);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_locked_errors_when_toolchain_missing() {
+        // Manifest and lockfile agree on a Kotlin version that is never
+        // installed, so the build passes the staleness check and reaches
+        // toolchain resolution.
+        let kotlin_version = "0.0.0-locked-test";
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src").join("main.kt"), "fun main() {}\n").unwrap();
+        fs::write(
+            root.join("konvoy.toml"),
+            format!("[package]\nname = \"demo\"\n\n[toolchain]\nkotlin = \"{kotlin_version}\"\n"),
+        )
+        .unwrap();
+        Lockfile::with_toolchain(kotlin_version)
+            .write_to(&root.join("konvoy.lock"))
+            .unwrap();
+
+        let result = build(
+            root,
+            &BuildOptions {
+                target: None,
+                profile: Profile::Debug,
+                verbose: false,
+                force: false,
+                locked: true,
+            },
+        );
+
+        assert!(result.is_err(), "expected Err, got: {result:?}");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--locked"),
+            "error should mention --locked: {err}"
+        );
+        assert!(
+            err.contains(kotlin_version),
+            "error should mention the toolchain version: {err}"
+        );
     }
 
     #[test]

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -93,6 +93,10 @@ pub enum EngineError {
     )]
     LockfileUpdateRequired,
 
+    /// The Kotlin/Native toolchain is missing and --locked prevents installing it.
+    #[error("Kotlin/Native toolchain {version} is not installed and --locked prevents downloads — run `konvoy toolchain install` first")]
+    ToolchainLocked { version: String },
+
     /// No test source files found.
     #[error("no test source files found in {dir} — create test files in src/test/ using kotlin.test annotations")]
     NoTestSources { dir: String },


### PR DESCRIPTION
## Summary

`konvoy build --locked` honored the no-downloads contract for Maven deps and the lockfile but **not** for the Kotlin/Native toolchain itself: `resolve_konanc` auto-installed it — downloading the konanc tarball from download.jetbrains.com plus the Adoptium JRE — whenever the requested version wasn't already present, regardless of `--locked`. This is the follow-up to #287, which fixed the same gap for `konvoy lint --locked` and called this one out as remaining.

## Changes

- Guard toolchain resolution in `resolve_build_context`: under `--locked`, a missing toolchain now returns an error instead of installing. The check lives in the engine crate (before the `resolve_konanc` call, the only call site in the workspace) so the error stays alongside the other `--locked` errors and the konvoy-konanc API is unchanged.
- New `EngineError::ToolchainLocked` variant with an actionable message: ``Kotlin/Native toolchain {version} is not installed and --locked prevents downloads — run `konvoy toolchain install` first``.
- `resolve_build_context` is the shared pipeline for `build()` and `build_tests()`, and `konvoy run` builds through it too — so the one guard covers the `--locked` flag of `build`, `test`, and `run`.

## Test

`build_locked_errors_when_toolchain_missing` runs end-to-end through `build()`: manifest and lockfile both pin a never-installed Kotlin version (`0.0.0-locked-test`), so the staleness check passes and the build reaches toolchain resolution. Before the fix, the test attempted a live network install under `--locked` ("Installing Kotlin/Native 0.0.0-locked-test... cannot download... http status: 404"); after, it fails fast with the new error and no network access.

Note: the error.rs hunk sits near (but not overlapping) #287's `DetektJreLocked` hunk — the two PRs merge cleanly in either order.

## Gates

- `cargo build --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test --workspace` ✅ (896 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)