### PR TITLE
codegen (2.2c): OpenAPI source generation via Fabrikt (first CodeGenerator impl)

### DIFF
--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -9,7 +9,11 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use konvoy_config::manifest::Codegen;
+
 use crate::error::EngineError;
+
+pub mod openapi;
 
 // The managed-tool abstraction is shared with the detekt linter, so it lives at
 // the engine root (`crate::managed_tool`); re-exported here for codegen callers.
@@ -77,6 +81,21 @@ pub trait CodeGenerator {
         jre_home: Option<&Path>,
         verbose: bool,
     ) -> Result<(), EngineError>;
+}
+
+/// Build the active generators for a manifest's `[codegen]` config, in stable
+/// order.
+///
+/// This is the registry — the single place that maps config to concrete generator
+/// types. The framework above stays generator-agnostic; a new generator is added
+/// here (and as a `CodeGenerator` impl), never by changing the hashing core.
+#[must_use]
+pub fn active_generators(codegen: &Codegen) -> Vec<Box<dyn CodeGenerator>> {
+    let mut generators: Vec<Box<dyn CodeGenerator>> = Vec::new();
+    if let Some(openapi) = &codegen.openapi {
+        generators.push(Box::new(openapi::OpenApiGenerator::new(openapi.clone())));
+    }
+    generators
 }
 
 /// Return display summaries for the given generators.

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -1,0 +1,510 @@
+//! OpenAPI source generation using Fabrikt.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+use konvoy_config::manifest::OpenApiCodegen;
+use konvoy_util::maven::MavenCoordinate;
+
+use crate::codegen::{CodeGenerator, ManagedToolSpec};
+use crate::error::EngineError;
+
+const GENERATOR_NAME: &str = "openapi";
+const TOOL_NAME: &str = "fabrikt";
+/// Human-readable tool name, used consistently in the download bar, the
+/// generation message, and failure diagnostics.
+const TOOL_DISPLAY: &str = "Fabrikt";
+
+/// Fixed Fabrikt generation flags. These affect generated output, so they are
+/// also folded into the config hash (see `config_hash_parts`) — if any of them
+/// ever changes, the codegen hash and build cache key change with it.
+const FABRIKT_TARGETS: &str = "HTTP_MODELS";
+const FABRIKT_SERIALIZATION_LIBRARY: &str = "KOTLINX_SERIALIZATION";
+/// Fabrikt defaults to `JAVAX_VALIDATION`, which emits `javax.validation.*`
+/// annotations on required/constrained fields. Those are JVM-only and do not
+/// exist on Kotlin/Native, so generated models would not compile. Konvoy is
+/// native-first, so validation annotations are disabled.
+const FABRIKT_VALIDATION_LIBRARY: &str = "NO_VALIDATION";
+
+/// OpenAPI generator backed by the Fabrikt CLI JAR.
+#[derive(Debug, Clone)]
+pub struct OpenApiGenerator {
+    config: OpenApiCodegen,
+}
+
+impl OpenApiGenerator {
+    /// Create a generator from parsed manifest config.
+    #[must_use]
+    pub fn new(config: OpenApiCodegen) -> Self {
+        Self { config }
+    }
+}
+
+fn fabrikt_tool(version: &str) -> ManagedToolSpec {
+    ManagedToolSpec::maven_jar(
+        TOOL_NAME,
+        TOOL_DISPLAY,
+        MavenCoordinate::new("com.cjbooms", TOOL_NAME, version),
+    )
+}
+
+/// Return the managed Fabrikt JAR path for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn fabrikt_jar_path(version: &str) -> Result<PathBuf, EngineError> {
+    fabrikt_tool(version)
+        .artifact_path()
+        .map_err(EngineError::from)
+}
+
+/// Return the Maven Central URL for a Fabrikt JAR.
+#[must_use]
+pub fn fabrikt_download_url(version: &str) -> String {
+    fabrikt_tool(version).download_url()
+}
+
+/// Return whether Fabrikt is installed for `version`.
+///
+/// # Errors
+/// Returns an error if the Konvoy home directory cannot be resolved.
+pub fn is_installed(version: &str) -> Result<bool, EngineError> {
+    fabrikt_tool(version)
+        .is_installed()
+        .map_err(EngineError::from)
+}
+
+/// Download or verify the managed Fabrikt JAR.
+///
+/// # Errors
+/// Returns an error if the version is unsafe, the artifact cannot be
+/// downloaded, or the expected SHA-256 does not match.
+pub fn ensure_fabrikt(
+    version: &str,
+    expected_sha256: Option<&str>,
+) -> Result<(PathBuf, String), EngineError> {
+    // Pre-validate for an actionable, Fabrikt-specific message; the shared tool
+    // also validates, but its raw error would map to a generic one. Use the same
+    // `validate_identifier` the spec uses (it rejects `..`), so a traversal-laden
+    // version yields this clear message rather than falling through to the generic
+    // download mapping.
+    konvoy_util::artifact::validate_identifier(version).map_err(|_| EngineError::CodegenDownload {
+        name: TOOL_NAME.to_owned(),
+        version: version.to_owned(),
+        message: format!(
+            "invalid fabrikt version \"{version}\" — only alphanumeric characters, dots, hyphens, and underscores are allowed, and it cannot be `..`"
+        ),
+    })?;
+    fabrikt_tool(version)
+        .ensure(expected_sha256)
+        .map_err(|e| map_fabrikt_download_err(version, e))
+}
+
+/// Map a download/verify `UtilError` to the Fabrikt-specific engine error
+/// (mirrors the detekt and plugin paths via the shared mapper).
+fn map_fabrikt_download_err(version: &str, e: konvoy_util::error::UtilError) -> EngineError {
+    crate::error::map_artifact_download_err(
+        TOOL_NAME,
+        e,
+        |name, message| EngineError::CodegenDownload {
+            name,
+            version: version.to_owned(),
+            message,
+        },
+        |name, expected, actual| EngineError::CodegenHashMismatch {
+            name,
+            version: version.to_owned(),
+            expected,
+            actual,
+        },
+    )
+}
+
+impl CodeGenerator for OpenApiGenerator {
+    fn name(&self) -> &str {
+        GENERATOR_NAME
+    }
+
+    fn display_name(&self) -> &str {
+        "OpenAPI"
+    }
+
+    fn managed_tool(&self) -> ManagedToolSpec {
+        fabrikt_tool(&self.config.version)
+    }
+
+    fn config_hash_parts(&self) -> Vec<String> {
+        // Only non-file config that affects generated output. `spec` and
+        // `extra_spec_dirs` are deliberately NOT folded in here: `input_files`
+        // already contributes their (normalized, sorted, deduped) paths *and*
+        // contents to the same generator hash. Repeating the raw config strings
+        // would only over-invalidate the cache on cosmetic edits (a leading `./`,
+        // an interior `.`) or a reorder of `extra_spec_dirs` — neither of which
+        // changes the resolved input set or the generated sources.
+        vec![
+            format!("tool_version={}", self.config.version),
+            format!("base_package={}", self.config.base_package),
+            format!("targets={FABRIKT_TARGETS}"),
+            format!("serialization_library={FABRIKT_SERIALIZATION_LIBRARY}"),
+            format!("validation_library={FABRIKT_VALIDATION_LIBRARY}"),
+        ]
+    }
+
+    /// Project-relative files whose contents feed the codegen cache key.
+    ///
+    /// Always includes the primary `spec`. When `extra_spec_dirs` is configured, also
+    /// includes every file under those directories so a change to any `$ref`'d
+    /// sibling (which Fabrikt resolves internally but never reports) regenerates
+    /// sources. Fabrikt exposes no resolved-input list — via CLI, library, or its
+    /// Gradle plugins — so we deliberately over-approximate by directory rather
+    /// than re-parse the spec in Rust.
+    fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+        // Just collect the inputs — the framework sorts + de-duplicates before
+        // hashing, so this need not. Paths are normalized to project-relative form
+        // (via `project_relative`) so the same file referenced two ways (e.g. the
+        // spec written `./specs/api.yaml` and again as a `specs` dir entry) collapses
+        // to one when the framework de-duplicates, and so the cache key is portable.
+        let mut files = vec![project_relative(project_root, Path::new(&self.config.spec))];
+
+        for dir in &self.config.extra_spec_dirs {
+            let dir_abs = project_root.join(dir);
+            if !dir_abs.is_dir() {
+                return Err(EngineError::CodegenInputDirNotFound {
+                    name: GENERATOR_NAME.to_owned(),
+                    path: dir_abs.display().to_string(),
+                });
+            }
+            for file in konvoy_util::fs::collect_all_files(&dir_abs)? {
+                // Skip hidden entries (a path component below the dir that starts
+                // with `.`): OS/editor/VCS noise like `.DS_Store`, `.git/`, and
+                // editor swap files, plus the `.konvoy` output dir when a spec dir
+                // contains it (e.g. extra_spec_dirs = ["."]). These are never spec
+                // input, and folding them in would make the cache key depend on
+                // platform/editor state, breaking deterministic, stable hashing.
+                if has_hidden_component(&dir_abs, &file) {
+                    continue;
+                }
+                files.push(project_relative(project_root, &file));
+            }
+        }
+
+        Ok(files)
+    }
+
+    fn generate(
+        &self,
+        project_root: &Path,
+        output_dir: &Path,
+        jre_home: Option<&Path>,
+        verbose: bool,
+    ) -> Result<(), EngineError> {
+        let spec_path = project_root.join(&self.config.spec);
+        eprintln!(
+            "    Generating OpenAPI sources with {TOOL_DISPLAY} {}...",
+            self.config.version
+        );
+
+        let args = [
+            OsString::from("--api-file"),
+            spec_path.into_os_string(),
+            OsString::from("--base-package"),
+            OsString::from(&self.config.base_package),
+            OsString::from("--output-directory"),
+            output_dir.as_os_str().to_owned(),
+            OsString::from("--targets"),
+            OsString::from(FABRIKT_TARGETS),
+            OsString::from("--serialization-library"),
+            OsString::from(FABRIKT_SERIALIZATION_LIBRARY),
+            OsString::from("--validation-library"),
+            OsString::from(FABRIKT_VALIDATION_LIBRARY),
+        ];
+
+        // Clear the output dir first: Fabrikt only writes/overwrites files for the
+        // schemas in the current spec — it never prunes — so a model removed or
+        // renamed in the spec would otherwise leave a stale `.kt` behind that still
+        // gets compiled into the build. Recreating it makes each run produce exactly
+        // the current source set.
+        konvoy_util::fs::remove_dir_all_if_exists(output_dir).map_err(EngineError::from)?;
+        konvoy_util::fs::ensure_dir(output_dir).map_err(EngineError::from)?;
+
+        let output = self.managed_tool().run(jre_home, &args, verbose)?;
+
+        // A code generator treats a non-zero exit as a hard failure (unlike the
+        // linter, which reads it as "issues found").
+        if !output.success {
+            // JVM CLIs typically print the real error to stderr (and banners to
+            // stdout), so prefer stderr for the one-line hint and fall back to
+            // stdout. Never concatenate the streams — that can fuse an unrelated
+            // stdout line onto the first stderr line.
+            let hint_source = if output.stderr.trim().is_empty() {
+                &output.stdout
+            } else {
+                &output.stderr
+            };
+            let hint = first_non_empty_line(hint_source)
+                .map(|line| format!(" first message: {line}"))
+                .unwrap_or_default();
+            // Only suggest --verbose when it wasn't already on (if it was, capture()
+            // already echoed the full output, so the suggestion would be misleading).
+            let verbose_hint = if verbose {
+                ""
+            } else {
+                " Run with --verbose to see full output."
+            };
+            return Err(EngineError::CodegenFailed {
+                name: GENERATOR_NAME.to_owned(),
+                message: format!("{TOOL_DISPLAY} failed.{hint}{verbose_hint}"),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// First non-blank line of `output`, trimmed — used to surface a concise hint
+/// from a failed Fabrikt run without dumping its whole log.
+fn first_non_empty_line(output: &str) -> Option<&str> {
+    output.lines().map(str::trim).find(|line| !line.is_empty())
+}
+
+/// Whether `file` (a walk result under `base`) has any path component, below
+/// `base`, that is hidden (starts with `.`). Used to exclude OS/editor/VCS noise
+/// (`.DS_Store`, `.git/`, swap files) and the `.konvoy` output dir from the
+/// codegen input set, keeping the cache key deterministic and platform-stable.
+fn has_hidden_component(base: &Path, file: &Path) -> bool {
+    file.strip_prefix(base)
+        .unwrap_or(file)
+        .components()
+        .any(|c| matches!(c, Component::Normal(name) if name.to_string_lossy().starts_with('.')))
+}
+
+/// Normalize a path to a clean project-relative form for stable, dedup-able
+/// hashing. Absolute inputs (dir-walk results under `project_root`) and relative
+/// inputs (the configured `spec`, possibly written with a leading `./`) both
+/// collapse to the same `specs/api.yaml`-style path. Joining onto `project_root`
+/// then stripping it also drops interior `.` components via `Path::components`.
+fn project_relative(project_root: &Path, path: &Path) -> PathBuf {
+    let joined = project_root.join(path);
+    joined
+        .strip_prefix(project_root)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn generator(spec: &str, extra_spec_dirs: &[&str]) -> OpenApiGenerator {
+        OpenApiGenerator::new(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: spec.to_owned(),
+            base_package: "com.example.api".to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|s| (*s).to_owned()).collect(),
+        })
+    }
+
+    /// The canonical set of inputs this generator contributes: `input_files` then
+    /// sort + de-duplicate, exactly as the framework does before hashing.
+    /// `input_files` itself returns inputs unsorted and possibly with duplicates by
+    /// design — determinism is the framework's job, not the generator's — so these
+    /// tests assert *content*, not the implementation's return order.
+    fn canonical_inputs(spec: &str, extra_spec_dirs: &[&str], root: &Path) -> Vec<PathBuf> {
+        let mut files = generator(spec, extra_spec_dirs).input_files(root).unwrap();
+        files.sort();
+        files.dedup();
+        files
+    }
+
+    #[test]
+    fn input_files_without_extra_spec_dirs_is_just_the_spec() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = generator("specs/api.yaml", &[])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("specs/api.yaml")]);
+    }
+
+    #[test]
+    fn input_files_tracks_every_file_under_spec_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(specs.join("nested")).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+        std::fs::write(specs.join("pet.yaml"), "Pet").unwrap();
+        std::fs::write(specs.join("nested").join("owner.yaml"), "Owner").unwrap();
+        // A non-spec file in the directory is also tracked (over-approximation).
+        std::fs::write(specs.join("README.md"), "notes").unwrap();
+
+        // Project-relative, every file tracked, primary spec not double-counted.
+        assert_eq!(
+            canonical_inputs("specs/api.yaml", &["specs"], tmp.path()),
+            vec![
+                PathBuf::from("specs/README.md"),
+                PathBuf::from("specs/api.yaml"),
+                PathBuf::from("specs/nested/owner.yaml"),
+                PathBuf::from("specs/pet.yaml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dot_slash_spec_collapses_against_listed_dir() {
+        // A spec written with a leading `./` normalizes to the same relative path as
+        // the dir-collected entry, so the framework's de-dup folds it to one input.
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(&specs).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+
+        assert_eq!(
+            canonical_inputs("./specs/api.yaml", &["specs"], tmp.path()),
+            vec![PathBuf::from("specs/api.yaml")]
+        );
+    }
+
+    #[test]
+    fn input_files_missing_spec_dir_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = generator("specs/api.yaml", &["does-not-exist"])
+            .input_files(tmp.path())
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::CodegenInputDirNotFound { .. }),
+            "expected CodegenInputDirNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn config_hash_parts_is_stable_across_spec_and_dir_cosmetics() {
+        // spec / extra_spec_dirs are tracked by input_files (normalized + sorted +
+        // content), NOT config_hash_parts — so a leading `./` on the spec or a
+        // reorder of extra_spec_dirs must not change config_hash_parts (those edits
+        // don't change the resolved input set or the generated sources).
+        let a = generator("./specs/api.yaml", &["a", "b"]).config_hash_parts();
+        let b = generator("specs/api.yaml", &["b", "a"]).config_hash_parts();
+        assert_eq!(a, b);
+        assert!(
+            a.iter()
+                .all(|p| !p.starts_with("spec=") && !p.starts_with("extra_spec_dir")),
+            "config_hash_parts must not fold in raw spec/extra_spec_dir paths: {a:?}"
+        );
+    }
+
+    #[test]
+    fn config_hash_parts_pins_output_affecting_config() {
+        // Pins every output-affecting field as load-bearing: the tool version,
+        // base_package, and the three fixed Fabrikt flags. Removing or changing any
+        // (e.g. re-enabling JAVAX_VALIDATION, which breaks native compilation) would
+        // otherwise leave the cache key unchanged and silently reuse stale sources.
+        assert_eq!(
+            generator("specs/api.yaml", &[]).config_hash_parts(),
+            vec![
+                "tool_version=20.0.0".to_owned(),
+                "base_package=com.example.api".to_owned(),
+                "targets=HTTP_MODELS".to_owned(),
+                "serialization_library=KOTLINX_SERIALIZATION".to_owned(),
+                "validation_library=NO_VALIDATION".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn first_non_empty_line_skips_blanks_and_trims() {
+        assert_eq!(
+            first_non_empty_line("\n   \n  hello world \nmore"),
+            Some("hello world")
+        );
+        assert_eq!(first_non_empty_line("first\nsecond"), Some("first"));
+        assert_eq!(first_non_empty_line("   \n\t\n  "), None);
+        assert_eq!(first_non_empty_line(""), None);
+    }
+
+    #[test]
+    fn generate_clears_output_dir_before_running() {
+        // generate() must clear stale output before invoking Fabrikt. Verify it even
+        // when the run itself can't proceed: with no JRE the Fabrikt run errors, but
+        // the pre-existing stale file must already be gone and the dir recreated.
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        std::fs::write(out.join("Stale.kt"), "// from a previous run").unwrap();
+
+        let result = generator("api.yaml", &[]).generate(tmp.path(), &out, None, false);
+        assert!(result.is_err(), "a JVM run with no JRE should error");
+        assert!(
+            !out.join("Stale.kt").exists(),
+            "stale output must be removed before the generator runs"
+        );
+        assert!(out.is_dir(), "output dir should be recreated");
+    }
+
+    #[test]
+    fn extra_spec_dirs_order_does_not_change_the_input_set() {
+        // Reordering extra_spec_dirs yields the same canonical input set, so the
+        // codegen hash is unchanged. (input_files preserves dir order; the framework
+        // sorts — this asserts the content is identical regardless.)
+        let tmp = tempfile::tempdir().unwrap();
+        for d in ["a", "b"] {
+            std::fs::create_dir_all(tmp.path().join(d)).unwrap();
+            std::fs::write(tmp.path().join(d).join("s.yaml"), d).unwrap();
+        }
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+
+        assert_eq!(
+            canonical_inputs("api.yaml", &["a", "b"], tmp.path()),
+            canonical_inputs("api.yaml", &["b", "a"], tmp.path()),
+        );
+    }
+
+    #[test]
+    fn input_files_skips_hidden_files_and_dirs() {
+        // OS/editor/VCS noise under a spec dir must not enter the cache key, or the
+        // hash would flip on a `.DS_Store` write and differ across platforms.
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        std::fs::create_dir_all(specs.join(".git")).unwrap();
+        std::fs::write(specs.join("api.yaml"), "openapi").unwrap();
+        std::fs::write(specs.join(".DS_Store"), "junk").unwrap();
+        std::fs::write(specs.join(".git").join("config"), "vcs").unwrap();
+
+        // Only the real spec survives — the hidden entries are excluded (otherwise
+        // they'd appear here alongside specs/api.yaml).
+        assert_eq!(
+            canonical_inputs("specs/api.yaml", &["specs"], tmp.path()),
+            vec![PathBuf::from("specs/api.yaml")]
+        );
+    }
+
+    #[test]
+    fn input_files_with_dot_dir_excludes_konvoy_output_dir() {
+        // extra_spec_dirs = ["."] walks the whole project; the generator's own
+        // output under `.konvoy` (a hidden dir) must be excluded, or the input hash
+        // would depend on its own output (self-referential cache key).
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+        let gen_out = tmp.path().join(".konvoy").join("gen").join("openapi");
+        std::fs::create_dir_all(&gen_out).unwrap();
+        std::fs::write(gen_out.join("Models.kt"), "generated").unwrap();
+
+        assert_eq!(
+            canonical_inputs("api.yaml", &["."], tmp.path()),
+            vec![PathBuf::from("api.yaml")]
+        );
+    }
+
+    #[test]
+    fn input_files_empty_extra_spec_dir_contributes_nothing() {
+        // A configured-but-empty spec dir is valid (no error) and adds no inputs,
+        // so it can't perturb the hash until a file actually appears in it.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("api.yaml"), "openapi").unwrap();
+        std::fs::create_dir_all(tmp.path().join("extra")).unwrap();
+
+        let files = generator("api.yaml", &["extra"])
+            .input_files(tmp.path())
+            .unwrap();
+        assert_eq!(files, vec![PathBuf::from("api.yaml")]);
+    }
+}

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -136,6 +136,31 @@ pub enum EngineError {
     #[error("codegen input for `{name}` not found at {path} — create the file, or fix the inputs configured in [codegen.{name}]")]
     CodegenInputNotFound { name: String, path: String },
 
+    /// A configured codegen spec directory is missing.
+    #[error("codegen spec directory for `{name}` not found at {path} — create the directory or fix `extra_spec_dirs` in [codegen.{name}]")]
+    CodegenInputDirNotFound { name: String, path: String },
+
+    /// A codegen tool download failed.
+    #[error("cannot download codegen tool `{name}` {version}: {message}")]
+    CodegenDownload {
+        name: String,
+        version: String,
+        message: String,
+    },
+
+    /// A codegen tool artifact hash does not match the lockfile.
+    #[error("codegen tool `{name}` {version} hash mismatch — expected {expected}, got {actual}; delete ~/.konvoy/tools/{name}/{version}/ and re-run `konvoy generate`, or verify the artifact upstream")]
+    CodegenHashMismatch {
+        name: String,
+        version: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// Code generation process failed.
+    #[error("cannot run codegen `{name}`: {message}")]
+    CodegenFailed { name: String, message: String },
+
     /// The project name supplied to `konvoy init` is invalid.
     #[error("invalid project name \"{name}\": {reason}")]
     InvalidProjectName { name: String, reason: String },

--- a/crates/konvoy-engine/tests/codegen_openapi.rs
+++ b/crates/konvoy-engine/tests/codegen_openapi.rs
@@ -1,0 +1,458 @@
+use std::fs;
+
+use konvoy_config::manifest::{Codegen, OpenApiCodegen};
+use konvoy_engine::codegen::ManagedToolSpec;
+use konvoy_util::maven::MavenCoordinate;
+
+/// Removes a managed-tool version directory on drop, so tests that write fake
+/// JARs under the real `~/.konvoy/tools/` don't leave junk behind — even when an
+/// assertion panics mid-test.
+struct CleanupDir(std::path::PathBuf);
+impl Drop for CleanupDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn managed_tool_spec_formats_maven_jar_url_and_path() {
+    let spec = ManagedToolSpec::maven_jar(
+        "grpc",
+        "gRPC Kotlin generator",
+        MavenCoordinate::new("io.grpc", "protoc-gen-grpc-kotlin", "1.4.1"),
+    );
+
+    assert_eq!(
+        spec.download_url(),
+        "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.4.1/protoc-gen-grpc-kotlin-1.4.1.jar"
+    );
+    let path = spec.artifact_path().unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/grpc/1.4.1"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("protoc-gen-grpc-kotlin-1.4.1.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_includes_generator_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+
+    let first = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.first".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+    let second = Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: "20.0.0".to_owned(),
+            spec: "openapi.yaml".to_owned(),
+            base_package: "com.example.second".to_owned(),
+            extra_spec_dirs: Vec::new(),
+        }),
+    };
+
+    let first_hashes = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&first),
+    )
+    .unwrap();
+    let second_hashes = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&second),
+    )
+    .unwrap();
+
+    assert_ne!(first_hashes, second_hashes);
+}
+
+fn openapi_codegen(version: &str, spec: &str, base_package: &str) -> Codegen {
+    openapi_codegen_with_dirs(version, spec, base_package, &[])
+}
+
+fn openapi_codegen_with_dirs(
+    version: &str,
+    spec: &str,
+    base_package: &str,
+    extra_spec_dirs: &[&str],
+) -> Codegen {
+    Codegen {
+        openapi: Some(OpenApiCodegen {
+            version: version.to_owned(),
+            spec: spec.to_owned(),
+            base_package: base_package.to_owned(),
+            extra_spec_dirs: extra_spec_dirs.iter().map(|d| (*d).to_owned()).collect(),
+        }),
+    }
+}
+
+#[test]
+fn openapi_codegen_hash_stable_across_cosmetic_config() {
+    // End-to-end: a leading `./` on the spec and a reorder of extra_spec_dirs must
+    // NOT change the assembled build cache key — the resolved inputs and generated
+    // sources are identical. (The unit tests cover config_hash_parts + input_files
+    // separately; this pins the combined `compute_codegen_hashes` output.)
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("a")).unwrap();
+    fs::create_dir_all(dir.path().join("b")).unwrap();
+    fs::write(dir.path().join("openapi.yaml"), "openapi: 3.1.0\n").unwrap();
+    fs::write(dir.path().join("a/x.yaml"), "x").unwrap();
+    fs::write(dir.path().join("b/y.yaml"), "y").unwrap();
+
+    let plain = openapi_codegen_with_dirs("20.0.0", "openapi.yaml", "com.example.api", &["a", "b"]);
+    let cosmetic =
+        openapi_codegen_with_dirs("20.0.0", "./openapi.yaml", "com.example.api", &["b", "a"]);
+    let h1 = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&plain),
+    )
+    .unwrap();
+    let h2 = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&cosmetic),
+    )
+    .unwrap();
+    assert_eq!(
+        h1, h2,
+        "cosmetic-only config differences must not change the codegen hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_changes_when_spec_content_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = dir.path().join("openapi.yaml");
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: A\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let before = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    // Same path, different bytes — the cache key MUST change.
+    fs::write(
+        &spec,
+        "openapi: 3.1.0\ninfo:\n  title: B\n  version: 2.0.0\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing the spec content must change the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_tracks_files_under_extra_spec_dirs() {
+    // Fabrikt resolves `$ref`'d sibling files internally but never reports them,
+    // so Konvoy tracks them by directory: listing the sub-spec's directory in
+    // `extra_spec_dirs` makes a change to ANY file under it invalidate the hash.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: integer\n",
+    )
+    .unwrap();
+
+    let codegen =
+        openapi_codegen_with_dirs("20.0.0", "openapi.yaml", "com.example.api", &["components"]);
+    let before = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    // Changing ONLY the referenced sub-spec must change the hash.
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    assert_ne!(
+        before, after,
+        "editing a file under a spec_dir must change the codegen hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_ignores_siblings_without_extra_spec_dirs() {
+    // The flip side of the accepted tradeoff: without `extra_spec_dirs`, only the
+    // primary spec is tracked. A change to a sibling `$ref`'d file is NOT picked
+    // up — users must opt in by listing the directory. This documents (and locks)
+    // that Konvoy does not parse the spec to discover `$ref` targets.
+    let dir = tempfile::tempdir().unwrap();
+    let components = dir.path().join("components");
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\ncomponents:\n  schemas:\n    Pet:\n      $ref: './components/pet.yaml#/Pet'\n",
+    )
+    .unwrap();
+    fs::write(components.join("pet.yaml"), "Pet:\n  type: object\n").unwrap();
+
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let before = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    fs::write(
+        components.join("pet.yaml"),
+        "Pet:\n  type: object\n  properties:\n    id:\n      type: string\n",
+    )
+    .unwrap();
+    let after = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    assert_eq!(
+        before, after,
+        "without extra_spec_dirs, a sibling file change must not affect the hash"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_dir_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen_with_dirs(
+        "20.0.0",
+        "openapi.yaml",
+        "com.example.api",
+        &["does-not-exist"],
+    );
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(konvoy_engine::EngineError::CodegenInputDirNotFound { .. })
+        ),
+        "expected CodegenInputDirNotFound, got {result:?}"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_is_stable_across_runs_and_project_roots() {
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+    let spec_bytes = "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n";
+
+    let dir1 = tempfile::tempdir().unwrap();
+    fs::write(dir1.path().join("openapi.yaml"), spec_bytes).unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    fs::write(dir2.path().join("openapi.yaml"), spec_bytes).unwrap();
+
+    let h1a = konvoy_engine::codegen::compute_codegen_hashes(
+        dir1.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+    let h1b = konvoy_engine::codegen::compute_codegen_hashes(
+        dir1.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+    let h2 = konvoy_engine::codegen::compute_codegen_hashes(
+        dir2.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    assert_eq!(h1a, h1b, "identical inputs must produce identical hashes");
+    assert_eq!(
+        h1a, h2,
+        "the hash must be independent of the absolute project location"
+    );
+}
+
+#[test]
+fn openapi_codegen_hash_errors_when_spec_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let codegen = openapi_codegen("20.0.0", "missing.yaml", "com.example.api");
+
+    let result = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    );
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("missing.yaml"),
+        "error should name the missing spec, was: {message}"
+    );
+}
+
+#[test]
+fn codegen_hash_pairs_match_tagged_hashes() {
+    // compute_codegen_hashes (cache-key form) must be exactly the tagged
+    // rendering of compute_codegen_hash_pairs, so threading the pairs into the
+    // build does not change the cache key bytes.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Demo\n  version: 1.0.0\n",
+    )
+    .unwrap();
+    let codegen = openapi_codegen("20.0.0", "openapi.yaml", "com.example.api");
+
+    let pairs = konvoy_engine::codegen::compute_codegen_hash_pairs(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+    let tagged = konvoy_engine::codegen::compute_codegen_hashes(
+        dir.path(),
+        &konvoy_engine::codegen::active_generators(&codegen),
+    )
+    .unwrap();
+
+    let from_pairs: Vec<String> = pairs.iter().map(|(n, h)| format!("{n}:{h}")).collect();
+    assert_eq!(tagged, from_pairs);
+    assert!(pairs.iter().any(|(name, _)| name == "openapi"));
+}
+
+#[test]
+fn fabrikt_download_url_format() {
+    let url = konvoy_engine::codegen::openapi::fabrikt_download_url("20.0.0");
+    assert_eq!(
+        url,
+        "https://repo1.maven.org/maven2/com/cjbooms/fabrikt/20.0.0/fabrikt-20.0.0.jar"
+    );
+}
+
+#[test]
+fn fabrikt_jar_path_format() {
+    let path = konvoy_engine::codegen::openapi::fabrikt_jar_path("20.0.0").unwrap();
+    let rendered = path.display().to_string();
+    assert!(
+        rendered.contains(".konvoy/tools/fabrikt/20.0.0"),
+        "path was: {rendered}"
+    );
+    assert!(
+        rendered.contains("fabrikt-20.0.0.jar"),
+        "path was: {rendered}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_rejects_invalid_version() {
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("../bad", None);
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("invalid fabrikt version"),
+        "error was: {message}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_rejects_dotdot_version() {
+    // Charset-valid but contains `..` (e.g. a `1..2` typo): the weaker
+    // validate_version would have let this through, so this is the regression guard
+    // for the validate_identifier fix. `../bad` above does NOT exercise it (the `/`
+    // is rejected by either check).
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("1..2", None);
+    let message = result
+        .expect_err("a `..` version must be rejected")
+        .to_string();
+    assert!(
+        message.contains("invalid fabrikt version"),
+        "expected the curated fabrikt message, got: {message}"
+    );
+}
+
+#[test]
+fn ensure_fabrikt_hash_mismatch_on_existing_jar() {
+    let version = format!("99.0.0-test-mismatch-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"not the expected jar").unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        &version,
+        Some("0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+
+    assert!(result.is_err());
+    let message = result.unwrap_err().to_string();
+    assert!(message.contains("hash mismatch"), "error was: {message}");
+    let _ = fs::remove_file(&jar);
+}
+
+#[test]
+fn ensure_fabrikt_accepts_matching_hash_on_existing_jar() {
+    let version = format!("99.0.0-test-match-{}", std::process::id());
+    let jar = konvoy_engine::codegen::openapi::fabrikt_jar_path(&version).unwrap();
+    if let Some(parent) = jar.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let _cleanup = CleanupDir(
+        jar.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_default(),
+    );
+    fs::write(&jar, b"already cached").unwrap();
+    let real_hash = konvoy_util::hash::sha256_file(&jar).unwrap();
+
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(&version, Some(&real_hash));
+
+    assert!(result.is_ok(), "matching hash should pass: {result:?}");
+    let (path, hash) = result.unwrap();
+    assert_eq!(path, jar);
+    assert_eq!(hash, real_hash);
+    let _ = fs::remove_file(&path);
+}


### PR DESCRIPTION
2.2c of the codegen split — the first concrete generator. Stacked on 2.2a (framework) + 2.2b (util); its diff is only the OpenAPI implementation.

## What
OpenAPI → Kotlin via the managed Fabrikt CLI JAR, implementing `CodeGenerator`:
- `config_hash_parts` (output-affecting config only: version, base_package, fixed Fabrikt flags), `input_files` (primary `spec` + non-hidden files under each `extra_spec_dirs` dir), `generate()` (runs Fabrikt via `managed_tool().run()`, maps failure → `CodegenFailed`).
- `ensure_fabrikt` — Maven download/verify (`com.cjbooms:fabrikt`), `..`-rejecting pre-check.
- **Registry wiring**: `active_generators(&Codegen)` in `mod.rs` maps `[codegen.openapi]` → this generator — the one place that names a concrete generator, keeping the framework decoupled.
- errors: `CodegenInputDirNotFound` / `CodegenDownload` / `CodegenHashMismatch` / `CodegenFailed`.

## Tests
15 integration + 9 unit: hashing determinism + cosmetic-stability, input enumeration (extra dirs, hidden-file & dot-dir-output exclusion, dedup, empty dir, order-insensitivity), ensure download paths (hash mismatch/accept, invalid + `..` version rejection).

Not yet wired into a CLI command or the build (no `konvoy generate` yet) — orchestration + lockfile pins land in 3.

## Gates
build · clippy `-D warnings` · fmt · full suite · rustdoc — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)