### PR TITLE
konvoy-engine: codegen generation in the build pipeline (root + path-deps)

### DIFF
--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -11,6 +11,20 @@ pub struct Lockfile {
     pub dependencies: Vec<DependencyLock>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugins: Vec<PluginLock>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub codegen_tools: Vec<CodegenToolLock>,
+}
+
+/// A locked code-generation tool entry (e.g. the Fabrikt JAR) in the lockfile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodegenToolLock {
+    /// Stable tool id (e.g. `"fabrikt"`).
+    pub name: String,
+    /// Resolved tool version.
+    pub version: String,
+    /// Hex-encoded SHA-256 hash of the artifact file.
+    pub sha256: String,
 }
 
 /// A locked plugin artifact entry in the lockfile.
@@ -112,6 +126,7 @@ impl Lockfile {
             }),
             dependencies: Vec::new(),
             plugins: Vec::new(),
+            codegen_tools: Vec::new(),
         }
     }
 
@@ -131,6 +146,7 @@ impl Lockfile {
             }),
             dependencies: Vec::new(),
             plugins: Vec::new(),
+            codegen_tools: Vec::new(),
         }
     }
 

--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -367,6 +367,7 @@ mod tests {
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         CacheKey::compute(&inputs).unwrap()
     }

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -150,6 +150,9 @@ pub(crate) struct ResolvedBuildContext {
     /// Resolved plugin lockfile pins — the deduped union across the root and
     /// all path-deps (persisted to the root lock by `update_lockfile_if_needed`).
     pub plugin_locks: Vec<konvoy_config::lockfile::PluginLock>,
+    /// Resolved codegen-tool lockfile pins — the deduped union across the root and
+    /// all path-deps (persisted to the root lock by `update_lockfile_if_needed`).
+    pub codegen_locks: Vec<konvoy_config::lockfile::CodegenToolLock>,
     /// Resolved path-dependency graph in topological order.
     pub dep_graph: ResolvedGraph,
     /// Content-addressed artifact store for this project.
@@ -194,6 +197,7 @@ fn predicted_effective_lockfile(
     konanc_tarball_sha256: Option<&str>,
     jre_tarball_sha256: Option<&str>,
     plugin_locks: &[PluginLock],
+    codegen_locks: &[konvoy_config::lockfile::CodegenToolLock],
     dep_graph: &ResolvedGraph,
     project_root: &Path,
     resolver: crate::common::ArtifactResolver<'_>,
@@ -233,6 +237,9 @@ fn predicted_effective_lockfile(
         // project with path-deps recompiles its whole graph once after the
         // first build (issue #133 class).
         effective.dependencies = predicted_dependency_locks(lockfile, dep_graph, project_root);
+        // Same reasoning for the predicted [[codegen_tools]] pins (the deduped
+        // graph-wide union), matching `updated.codegen_tools = codegen_locks`.
+        effective.codegen_tools = codegen_locks.to_vec();
         effective
     })
 }
@@ -436,6 +443,18 @@ pub(crate) fn resolve_build_context(
         crate::plugin::ensure_plugin_artifacts(&graph_plugin_artifacts, &lockfile, resolver)?;
     let plugin_locks = crate::plugin::build_plugin_locks(&plugin_results);
 
+    // The codegen-tool union, by the same graph-wide reasoning as plugins (#293):
+    // a path-dep's `[codegen]` tool is downloaded + SHA-pinned just like the root's
+    // — the dep's own compile step uses the generated sources — and recorded as the
+    // deduped union in the root `konvoy.lock`. Generation itself, and each project's
+    // input hashing, are deferred to a cache miss in `build_single`.
+    let mut graph_generators = crate::codegen::active_generators(&manifest.codegen);
+    for dep in &dep_graph.order {
+        graph_generators.extend(crate::codegen::active_generators(&dep.manifest.codegen));
+    }
+    let codegen_locks =
+        crate::codegen::ensure_codegen_tools(&graph_generators, &lockfile.codegen_tools, resolver)?;
+
     // The ROOT project's own -Xplugin set, for the test build (`build_tests`
     // compiles the root's test sources). Regular compilation derives each
     // project's set from its own manifest inside `build_single`.
@@ -450,6 +469,7 @@ pub(crate) fn resolve_build_context(
         konanc_tarball_sha256.as_deref(),
         jre_tarball_sha256.as_deref(),
         &plugin_locks,
+        &codegen_locks,
         &dep_graph,
         project_root,
         resolver,
@@ -624,6 +644,7 @@ pub(crate) fn resolve_build_context(
         library_inputs,
         plugin_jars,
         plugin_locks,
+        codegen_locks,
         dep_graph,
         store,
     })
@@ -681,6 +702,7 @@ pub fn build(
         ctx.lockfile_write_inputs.jre_tarball_sha256.as_deref(),
         &ctx.dep_graph,
         &ctx.plugin_locks,
+        &ctx.codegen_locks,
         project_root,
         &lockfile_path,
         options.force,
@@ -726,19 +748,21 @@ pub(crate) fn build_single(
     profile: Profile,
     lockfile_content: &str,
 ) -> Result<(PathBuf, BuildOutcome), EngineError> {
-    // Collect source files, excluding test sources (src/test/).
+    // Collect source files, excluding test sources (src/test/). `src/` may be
+    // absent for a project whose Kotlin is entirely generated; treat that as "no
+    // hand-written sources" rather than an I/O error. Emptiness is checked AFTER
+    // codegen (below), with a clear `NoSources` when nothing was produced.
     let src_dir = project_root.join("src");
     let test_dir = src_dir.join("test");
-    let all_sources = konvoy_util::fs::collect_files(&src_dir, "kt")?;
-    let sources: Vec<PathBuf> = all_sources
+    let all_sources = if src_dir.is_dir() {
+        konvoy_util::fs::collect_files(&src_dir, "kt")?
+    } else {
+        Vec::new()
+    };
+    let mut sources: Vec<PathBuf> = all_sources
         .into_iter()
         .filter(|p| !p.starts_with(&test_dir))
         .collect();
-    if sources.is_empty() {
-        return Err(EngineError::NoSources {
-            dir: src_dir.display().to_string(),
-        });
-    }
 
     let is_lib = manifest.package.kind == PackageKind::Lib;
 
@@ -750,6 +774,14 @@ pub(crate) fn build_single(
     // covers plugins through `manifest_content` (the `[plugins]` config) and
     // `lockfile_content` (the graph-wide pin union, version + sha256).
     let plugin_jars = crate::plugin::plugin_jar_paths(manifest)?;
+
+    // This project's code generators, from its OWN manifest — identical treatment
+    // for the root and every path-dep. The tags (spec contents + config + tool
+    // version) feed this project's cache key; the generators run on a miss (below).
+    // Their tools were ensured graph-wide in `resolve_build_context`, so a miss
+    // here only runs them, never downloads.
+    let generators = crate::codegen::active_generators(&manifest.codegen);
+    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
 
     // Compute cache key.
     let manifest_content = manifest.to_toml()?;
@@ -774,6 +806,9 @@ pub(crate) fn build_single(
                 None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
             })
             .collect::<Result<Vec<_>, _>>()?,
+        // Codegen inputs (spec files + generator config + tool version) — a change
+        // here rebuilds. Empty when the project has no `[codegen]` config.
+        codegen_hashes,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -797,6 +832,26 @@ pub(crate) fn build_single(
         eprintln!("    Fresh {} (cached)", manifest.package.name);
         store.materialize(&cache_key, &output_name, &output_path)?;
         return Ok((output_path, BuildOutcome::Cached));
+    }
+
+    // Cache miss: run this project's code generators (tools ensured graph-wide in
+    // resolve_build_context) and add the emitted `.kt` to the source set. The
+    // generated output is NOT in the cache key directly — its inputs are, via
+    // `codegen_hashes` — so generation is deterministic w.r.t. the key.
+    if !generators.is_empty() {
+        let generated = crate::codegen::run_codegen(
+            project_root,
+            &generators,
+            cc.jre_home,
+            cc.options.verbose,
+        )?;
+        sources.extend(generated);
+    }
+
+    if sources.is_empty() {
+        return Err(EngineError::NoSources {
+            dir: src_dir.display().to_string(),
+        });
     }
 
     // Compile.
@@ -1389,6 +1444,21 @@ pub(crate) fn check_lockfile_staleness(
         }
     }
 
+    // Each configured codegen generator's tool must have a *pinned* lockfile entry
+    // (same identity + non-empty-`sha256` rule as plugins), so a --locked build
+    // fails fast before any download. Path-dep codegen drift is caught by the
+    // graph-wide ensure, mirroring how path-dep plugins are handled.
+    for generator in crate::codegen::active_generators(&manifest.codegen) {
+        let tool = generator.managed_tool();
+        let pinned = lockfile
+            .codegen_tools
+            .iter()
+            .any(|c| c.name == tool.id() && c.version == tool.version() && !c.sha256.is_empty());
+        if !pinned {
+            return Err(EngineError::LockfileUpdateRequired);
+        }
+    }
+
     // If the manifest has Maven dependencies (maven + version set), the lockfile
     // must pin each (by coordinate + version).
     manifest_maven_deps_resolved(manifest, lockfile)?;
@@ -1441,6 +1511,7 @@ fn update_lockfile_if_needed(
     jre_tarball_sha256: Option<&str>,
     dep_graph: &ResolvedGraph,
     plugin_locks: &[konvoy_config::lockfile::PluginLock],
+    codegen_locks: &[konvoy_config::lockfile::CodegenToolLock],
     project_root: &Path,
     lockfile_path: &Path,
     force: bool,
@@ -1479,9 +1550,15 @@ fn update_lockfile_if_needed(
     let has_new_hashes = konanc_tarball_sha256.is_some() || jre_tarball_sha256.is_some();
     let deps_changed = lockfile.dependencies != new_deps;
     let plugins_changed = lockfile.plugins.as_slice() != plugin_locks;
+    let codegen_changed = lockfile.codegen_tools.as_slice() != codegen_locks;
 
     // If nothing changed, nothing to do.
-    if !toolchain_changed && !has_new_hashes && !deps_changed && !plugins_changed {
+    if !toolchain_changed
+        && !has_new_hashes
+        && !deps_changed
+        && !plugins_changed
+        && !codegen_changed
+    {
         return Ok(());
     }
 
@@ -1531,6 +1608,7 @@ fn update_lockfile_if_needed(
     );
     updated.dependencies = new_deps;
     updated.plugins = plugin_locks.to_vec();
+    updated.codegen_tools = codegen_locks.to_vec();
     carry_forward_detekt(&mut updated, lockfile);
 
     resolver.persist_resolved_artifacts(lockfile, &updated, lockfile_path)
@@ -2016,6 +2094,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2049,6 +2128,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2078,6 +2158,7 @@ mod tests {
             Some("cafebabe"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2106,6 +2187,7 @@ mod tests {
             Some("first-konanc-hash"),
             Some("first-jre-hash"),
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2164,6 +2246,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2233,6 +2316,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -2318,6 +2402,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -2398,6 +2483,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key_before = CacheKey::compute(&cache_inputs_before).unwrap();
 
@@ -2439,6 +2525,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key_after = CacheKey::compute(&cache_inputs_after).unwrap();
         assert_eq!(
@@ -2483,6 +2570,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2522,6 +2610,7 @@ mod tests {
             Some("newhash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2560,6 +2649,7 @@ mod tests {
             Some("samehash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2593,6 +2683,7 @@ mod tests {
             Some("newhash1"),
             Some("newhash2"),
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2635,6 +2726,7 @@ mod tests {
             Some("newhash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             true,
@@ -2672,6 +2764,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2707,6 +2800,7 @@ mod tests {
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2764,6 +2858,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2826,6 +2921,7 @@ mod tests {
             None,
             &graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2882,6 +2978,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2961,6 +3058,7 @@ mod tests {
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -3052,6 +3150,7 @@ mod tests {
             Some("pinned2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -3093,6 +3192,7 @@ mod tests {
             Some("freshhash1"),
             Some("freshhash2"),
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -3136,6 +3236,7 @@ mod tests {
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -3253,6 +3354,7 @@ mod tests {
             None,
             &graph,
             &[],
+            &[],
             &app,
             &lockfile_path,
             false,
@@ -3307,6 +3409,7 @@ mod tests {
             None,
             &a_graph,
             &[],
+            &[],
             &a_app,
             &a_lock,
             false,
@@ -3336,6 +3439,7 @@ mod tests {
             None,
             None,
             &b_graph,
+            &[],
             &[],
             &b_app,
             &b_lock,
@@ -3377,6 +3481,7 @@ mod tests {
             "2.1.0",
             Some("new1"),
             Some("new2"),
+            &[],
             &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
@@ -3435,6 +3540,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -3597,6 +3703,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
             crate::common::test_resolver(false, false),
@@ -3615,6 +3722,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
             crate::common::test_resolver(false, false),
@@ -3679,6 +3787,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
             crate::common::test_resolver(false, false),
@@ -3695,6 +3804,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
             crate::common::test_resolver(false, false),
@@ -3751,6 +3861,7 @@ mod tests {
             None,
             None,
             &[],
+            &[],
             &graph,
             root_dir.path(),
             crate::common::test_resolver(false, false),
@@ -3772,6 +3883,7 @@ mod tests {
             None,
             &graph,
             &[],
+            &[],
             root_dir.path(),
             &lockfile_path,
             false,
@@ -3786,6 +3898,7 @@ mod tests {
             konanc_version,
             None,
             None,
+            &[],
             &[],
             &graph,
             root_dir.path(),
@@ -3843,6 +3956,7 @@ mod tests {
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -3866,6 +3980,7 @@ mod tests {
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -3949,6 +4064,7 @@ mod tests {
             konanc_version,
             None,
             None,
+            &[],
             &[],
             &crate::resolve::ResolvedGraph { order: Vec::new() },
             Path::new("/tmp"),
@@ -4353,6 +4469,7 @@ mod tests {
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -4370,6 +4487,149 @@ mod tests {
         );
         assert_eq!(plugin.version, "2.1.0");
         assert_eq!(plugin.sha256, "pluginhash1");
+    }
+
+    fn codegen_manifest() -> konvoy_config::manifest::Manifest {
+        konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"myapp\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n\n[codegen.openapi]\nversion = \"20.0.0\"\nspec = \"specs/api.yaml\"\nbase_package = \"com.example.api\"\n",
+            "konvoy.toml",
+        )
+        .unwrap()
+    }
+
+    fn fabrikt_lock(sha256: &str, version: &str) -> konvoy_config::lockfile::CodegenToolLock {
+        konvoy_config::lockfile::CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: version.to_owned(),
+            sha256: sha256.to_owned(),
+        }
+    }
+
+    #[test]
+    fn check_lockfile_staleness_missing_codegen_tool_errors() {
+        // [codegen.openapi] configured but no [[codegen_tools]] pin → drift.
+        let lockfile = Lockfile::with_toolchain("2.1.0");
+        assert!(
+            matches!(
+                check_lockfile_staleness(&codegen_manifest(), &lockfile),
+                Err(EngineError::LockfileUpdateRequired)
+            ),
+            "a configured codegen tool with no pin must be drift"
+        );
+    }
+
+    #[test]
+    fn check_lockfile_staleness_matching_codegen_tool_succeeds() {
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile
+            .codegen_tools
+            .push(fabrikt_lock("abc123", "20.0.0"));
+        assert!(
+            check_lockfile_staleness(&codegen_manifest(), &lockfile).is_ok(),
+            "matching [[codegen_tools]] pin should pass"
+        );
+    }
+
+    #[test]
+    fn check_lockfile_staleness_wrong_codegen_version_errors() {
+        // Lockfile pins fabrikt at a different version than the manifest → drift.
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile
+            .codegen_tools
+            .push(fabrikt_lock("abc123", "19.0.0"));
+        assert!(
+            matches!(
+                check_lockfile_staleness(&codegen_manifest(), &lockfile),
+                Err(EngineError::LockfileUpdateRequired)
+            ),
+            "a codegen tool pinned at the wrong version must be drift"
+        );
+    }
+
+    #[test]
+    fn check_lockfile_staleness_empty_codegen_sha_is_drift() {
+        // Present by name+version but empty sha256 → not a pin (matches the gate).
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile.codegen_tools.push(fabrikt_lock("", "20.0.0"));
+        assert!(
+            matches!(
+                check_lockfile_staleness(&codegen_manifest(), &lockfile),
+                Err(EngineError::LockfileUpdateRequired)
+            ),
+            "an empty-sha codegen pin must count as drift"
+        );
+    }
+
+    #[test]
+    fn update_lockfile_writes_codegen_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("konvoy.lock");
+        let lockfile = Lockfile::default();
+        let konanc = KonancInfo {
+            path: PathBuf::from("/usr/bin/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "abc".to_owned(),
+        };
+        let codegen_locks = vec![fabrikt_lock("codegenhash1", "20.0.0")];
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        update_lockfile_if_needed(
+            &lockfile,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &[],
+            &codegen_locks,
+            tmp.path(),
+            &lockfile_path,
+            false,
+            crate::common::test_resolver(false, false),
+        )
+        .unwrap();
+
+        let reparsed = Lockfile::from_path(&lockfile_path).unwrap();
+        assert_eq!(reparsed.codegen_tools.len(), 1);
+        let tool = reparsed.codegen_tools.first().unwrap();
+        assert_eq!(tool.name, "fabrikt");
+        assert_eq!(tool.version, "20.0.0");
+        assert_eq!(tool.sha256, "codegenhash1");
+    }
+
+    #[test]
+    fn update_lockfile_detects_codegen_changes() {
+        // Toolchain matches, no dep/plugin changes — ONLY the codegen sha differs.
+        // Exercises the codegen_changed arm of the nothing-changed guard.
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("konvoy.lock");
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile
+            .codegen_tools
+            .push(fabrikt_lock("oldhash", "20.0.0"));
+        let konanc = KonancInfo {
+            path: PathBuf::from("/usr/bin/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "abc".to_owned(),
+        };
+        let new_codegen_locks = vec![fabrikt_lock("newhash", "20.0.0")];
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        update_lockfile_if_needed(
+            &lockfile,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &[],
+            &new_codegen_locks,
+            tmp.path(),
+            &lockfile_path,
+            false,
+            crate::common::test_resolver(false, false),
+        )
+        .unwrap();
+
+        let reparsed = Lockfile::from_path(&lockfile_path).unwrap();
+        assert_eq!(reparsed.codegen_tools.len(), 1);
+        assert_eq!(reparsed.codegen_tools.first().unwrap().sha256, "newhash");
     }
 
     #[test]
@@ -4409,6 +4669,7 @@ mod tests {
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -5325,6 +5586,7 @@ linux_x64 = "1111"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -5383,6 +5645,7 @@ linux_x64 = "1111"
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -5473,6 +5736,7 @@ linux_x64 = "1111"
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -5527,6 +5791,7 @@ linux_x64 = "1111"
             None,
             &graph,
             &plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -5923,6 +6188,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
 
         let key_no_plugins = CacheKey::compute(&make_inputs(content_no_plugins)).unwrap();
@@ -5974,6 +6240,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
 
         let key_v1 = CacheKey::compute(&make_inputs(content_v1)).unwrap();
@@ -6018,6 +6285,7 @@ url = "https://example.com/plugin.jar"
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -6116,6 +6384,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key = CacheKey::compute(&inputs).unwrap();
         assert_eq!(
@@ -6246,6 +6515,7 @@ url = "https://example.com/plugin.jar"
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -6331,6 +6601,7 @@ kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-comp
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -6749,6 +7020,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -6778,6 +7050,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false, // not force
@@ -6806,6 +7079,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             Some("different-hash"),
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,

--- a/crates/konvoy-engine/src/cache.rs
+++ b/crates/konvoy-engine/src/cache.rs
@@ -33,6 +33,10 @@ pub struct CacheInputs {
     pub arch: String,
     /// SHA-256 hashes of dependency `.klib` files (empty for projects with no deps).
     pub dependency_hashes: Vec<String>,
+    /// Tagged (`name:hash`) per-generator codegen hashes — folds each generator's
+    /// config + input files into the key so a spec/config change rebuilds. Empty for
+    /// projects with no `[codegen]` config (leaving the key unchanged for them).
+    pub codegen_hashes: Vec<String>,
 }
 
 /// A content-addressed cache key wrapping a SHA-256 hex string.
@@ -65,6 +69,13 @@ impl CacheKey {
         ];
         // Include dependency hashes so cache key changes when deps are rebuilt.
         for h in &inputs.dependency_hashes {
+            parts.push(h);
+        }
+        // Include codegen hashes so a spec/generator-config change rebuilds. These
+        // are `name:hash` (distinct in shape from the bare-SHA dependency hashes),
+        // and the list is empty when no codegen is configured — so projects without
+        // codegen keep their existing cache key.
+        for h in &inputs.codegen_hashes {
             parts.push(h);
         }
 
@@ -111,6 +122,7 @@ mod tests {
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         }
     }
 
@@ -177,6 +189,29 @@ mod tests {
         let key2 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
 
         assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn codegen_hashes_change_key() {
+        // Codegen inputs must participate in the key: adding codegen hashes, and
+        // changing them, both change the key. (Backward compatibility holds by
+        // construction: an empty list folds in nothing, so a non-codegen project's
+        // key stays byte-identical to the pre-codegen format.)
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key_none = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs_a = make_inputs(tmp.path());
+        inputs_a.codegen_hashes = vec!["openapi:aaaa".to_owned()];
+        let key_a = CacheKey::compute(&inputs_a).unwrap();
+
+        let mut inputs_b = make_inputs(tmp.path());
+        inputs_b.codegen_hashes = vec!["openapi:bbbb".to_owned()];
+        let key_b = CacheKey::compute(&inputs_b).unwrap();
+
+        assert_ne!(key_none, key_a, "adding codegen hashes must change the key");
+        assert_ne!(key_a, key_b, "a different codegen hash must change the key");
     }
 
     #[test]
@@ -435,6 +470,7 @@ mod tests {
                             os,
                             arch,
                             dependency_hashes: Vec::new(),
+                            codegen_hashes: Vec::new(),
                         }
                     },
                 )
@@ -467,6 +503,7 @@ mod tests {
                     os: inputs1.os.clone(),
                     arch: inputs1.arch.clone(),
                     dependency_hashes: Vec::new(),
+                    codegen_hashes: Vec::new(),
                 };
 
                 let key1 = CacheKey::compute(&inputs1).unwrap();

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -7,8 +7,10 @@
 //! are assembled into a `&[Box<dyn CodeGenerator>]` by a registry that lives with
 //! the implementations, so adding a generator never touches this file.
 
+use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
+use konvoy_config::lockfile::CodegenToolLock;
 use konvoy_config::manifest::Codegen;
 
 use crate::error::EngineError;
@@ -164,6 +166,127 @@ pub fn compute_codegen_hashes(
 #[must_use]
 pub fn generator_output_dir(project_root: &Path, name: &str) -> PathBuf {
     project_root.join(".konvoy").join("gen").join(name)
+}
+
+/// Map a download/verify [`UtilError`](konvoy_util::error::UtilError) to the
+/// codegen-tool engine error, mirroring the detekt and plugin paths via the shared
+/// [`map_artifact_download_err`](crate::error::map_artifact_download_err).
+pub(crate) fn map_download_err(
+    name: &str,
+    version: &str,
+    e: konvoy_util::error::UtilError,
+) -> EngineError {
+    crate::error::map_artifact_download_err(
+        name,
+        e,
+        |name, message| EngineError::CodegenDownload {
+            name,
+            version: version.to_owned(),
+            message,
+        },
+        |name, expected, actual| EngineError::CodegenHashMismatch {
+            name,
+            version: version.to_owned(),
+            expected,
+            actual,
+        },
+    )
+}
+
+/// The managed tools of `generators`, deduplicated by `(id, version)` and in
+/// stable sorted order.
+///
+/// A build graph (root + path-dependencies) may have several generators backed by
+/// the same tool+version — it is content-addressed under `~/.konvoy/tools`, so it
+/// need only be downloaded, verified, and pinned once. Sorting keeps the resulting
+/// lockfile pins deterministic regardless of the order generators were discovered.
+fn unique_codegen_tools(generators: &[Box<dyn CodeGenerator>]) -> Vec<ManagedToolSpec> {
+    let mut unique: BTreeMap<(String, String), ManagedToolSpec> = BTreeMap::new();
+    for generator in generators {
+        let tool = generator.managed_tool();
+        unique
+            .entry((tool.id().to_owned(), tool.version().to_owned()))
+            .or_insert(tool);
+    }
+    unique.into_values().collect()
+}
+
+/// Download + SHA-verify the codegen tools required by `generators`, returning the
+/// resolved lockfile pins — one per **distinct** `(name, version)`, sorted.
+///
+/// `generators` is the whole build graph's set (root + every path-dependency), so
+/// a tool shared across projects is fetched and pinned once (deduped by
+/// `(name, version)`); the returned union is what the build persists into the root
+/// `konvoy.lock`.
+///
+/// The expected SHA is read from `pinned` (by tool name + version); the shared
+/// [`ArtifactResolver`](crate::common::ArtifactResolver) applies the `--locked` /
+/// `--offline` policy (a missing pin under `--locked` is `LockfileUpdateRequired`;
+/// an absent tool under `--offline` is `CodegenToolOffline`) and fetches or
+/// re-verifies the artifact through the shared network client. This is
+/// generator-agnostic — it only uses the [`ManagedToolSpec`] each generator exposes.
+///
+/// # Errors
+/// Returns an error if a tool can't be downloaded, a pinned hash doesn't match, or
+/// the command's `--locked` / `--offline` policy forbids resolving it.
+pub fn ensure_codegen_tools(
+    generators: &[Box<dyn CodeGenerator>],
+    pinned: &[CodegenToolLock],
+    resolver: crate::common::ArtifactResolver<'_>,
+) -> Result<Vec<CodegenToolLock>, EngineError> {
+    let tools = unique_codegen_tools(generators);
+    let mut resolved = Vec::with_capacity(tools.len());
+    for tool in tools {
+        let (name, version) = (tool.id().to_owned(), tool.version().to_owned());
+
+        let expected = pinned
+            .iter()
+            .find(|p| p.name == name && p.version == version)
+            .map(|p| p.sha256.as_str())
+            // An empty `sha256` is not a pin (matches the detekt/toolchain
+            // convention): under `--locked` this surfaces as clean lockfile drift
+            // rather than a download that then fails verifying against an empty hash.
+            .filter(|s| !s.is_empty());
+
+        let (_, sha256) = resolver.resolve_codegen_tool(&tool, expected)?;
+
+        resolved.push(CodegenToolLock {
+            name,
+            version,
+            sha256,
+        });
+    }
+    Ok(resolved)
+}
+
+/// Run every generator (on a cache miss), writing sources into its
+/// `.konvoy/gen/<name>/` dir, and return the generated `.kt` files to add to the
+/// compile source set.
+///
+/// The tools must already be downloaded (call [`ensure_codegen_tools`] first).
+/// `jre_home` is forwarded to each generator's tool — required for JVM generators,
+/// ignored by native ones.
+///
+/// # Errors
+/// Returns an error if a generator fails or its output cannot be read.
+pub fn run_codegen(
+    project_root: &Path,
+    generators: &[Box<dyn CodeGenerator>],
+    jre_home: Option<&Path>,
+    verbose: bool,
+) -> Result<Vec<PathBuf>, EngineError> {
+    let mut generated = Vec::new();
+    for generator in generators {
+        let output_dir = generator_output_dir(project_root, generator.name());
+        generator.generate(project_root, &output_dir, jre_home, verbose)?;
+        // Collect the emitted `.kt` (generators may nest them, e.g. Fabrikt writes
+        // under `<output_dir>/src/main/kotlin/`), to feed into compilation. Tolerate
+        // a generator that legitimately produced no output dir (emitted nothing).
+        if output_dir.is_dir() {
+            generated.extend(konvoy_util::fs::collect_files(&output_dir, "kt")?);
+        }
+    }
+    Ok(generated)
 }
 
 fn compute_generator_hash(
@@ -676,5 +799,224 @@ mod tests {
         );
         assert_eq!(summaries[1].name, "other");
         assert_eq!(managed_tools(&gens).len(), 2);
+    }
+
+    // ---- ensure_codegen_tools (download/pin orchestration) ------------------
+
+    #[test]
+    fn ensure_codegen_tools_empty_is_noop() {
+        // No generators → no pins, under any policy, and never touches the net.
+        assert!(
+            ensure_codegen_tools(&[], &[], crate::common::test_resolver(false, false))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            ensure_codegen_tools(&[], &[], crate::common::test_resolver(true, true))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn ensure_codegen_tools_locked_without_pin_requires_update() {
+        // --locked with a generator whose tool isn't pinned must fail loudly with
+        // lockfile drift, BEFORE any download. test_resolver(offline, locked).
+        let gens = vec![fake("demo", &["v=1"], &[])];
+        match ensure_codegen_tools(&gens, &[], crate::common::test_resolver(false, true)) {
+            Err(EngineError::LockfileUpdateRequired) => {}
+            other => panic!("expected LockfileUpdateRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_codegen_tools_locked_with_empty_sha_pin_is_drift() {
+        // An empty `sha256` is not a pin: under --locked it must surface as drift
+        // (LockfileUpdateRequired), not pass the gate and download-then-mismatch.
+        let gens = vec![fake("demo", &["v=1"], &[])];
+        let pins = vec![CodegenToolLock {
+            name: "demo".to_owned(),
+            version: "1.0.0".to_owned(),
+            sha256: String::new(),
+        }];
+        match ensure_codegen_tools(&gens, &pins, crate::common::test_resolver(false, true)) {
+            Err(EngineError::LockfileUpdateRequired) => {}
+            other => panic!("expected LockfileUpdateRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_codegen_tools_offline_with_pin_but_not_installed_errors() {
+        // --offline + a matching pin, but the tool was never downloaded → a
+        // CodegenToolOffline (downloads are forbidden under --offline; under
+        // --locked alone it would download). The id `uninstalled-tool`/`1.0.0` is
+        // never present under ~/.konvoy/tools, so `is_installed()` is
+        // deterministically false without env juggling.
+        let gens = vec![fake("uninstalled-tool", &["v=1"], &[])];
+        let pins = vec![CodegenToolLock {
+            name: "uninstalled-tool".to_owned(),
+            version: "1.0.0".to_owned(),
+            sha256: "a".repeat(64),
+        }];
+        match ensure_codegen_tools(&gens, &pins, crate::common::test_resolver(true, false)) {
+            Err(EngineError::CodegenToolOffline { name, version }) => {
+                assert_eq!(name, "uninstalled-tool");
+                assert_eq!(version, "1.0.0");
+            }
+            other => panic!("expected CodegenToolOffline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unique_codegen_tools_dedupes_by_name_version_and_sorts() {
+        // Across a build graph the same tool can back several generators (e.g. the
+        // root and a path-dep both use openapi/fabrikt); it must be pinned once.
+        // Order is stable (sorted) regardless of discovery order. The fake's tool
+        // id == its generator name and its version is fixed, so equal names collide.
+        let gens = vec![
+            fake("b", &[], &[]),
+            fake("a", &[], &[]),
+            fake("a", &["different-config"], &[]),
+        ];
+        let tools = unique_codegen_tools(&gens);
+        let ids: Vec<&str> = tools.iter().map(|t| t.id()).collect();
+        assert_eq!(ids, vec!["a", "b"], "deduped by (id, version), sorted");
+    }
+
+    // ---- run_codegen (generation + source collection) -----------------------
+
+    /// A generator that writes real `.kt` (and a non-`.kt`) into its output dir,
+    /// to exercise `run_codegen`'s recursive `.kt` collection. Nests one file like
+    /// Fabrikt's `src/main/kotlin/` layout.
+    struct WritingGenerator {
+        name: String,
+    }
+    impl CodeGenerator for WritingGenerator {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn display_name(&self) -> &str {
+            &self.name
+        }
+        fn managed_tool(&self) -> ManagedToolSpec {
+            ManagedToolSpec::direct_url(
+                &self.name,
+                &self.name,
+                "1.0.0",
+                "https://example.invalid/x.jar".to_owned(),
+                "x.jar".to_owned(),
+            )
+        }
+        fn config_hash_parts(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn input_files(&self, _project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+            Ok(Vec::new())
+        }
+        fn generate(
+            &self,
+            _project_root: &Path,
+            output_dir: &Path,
+            _jre_home: Option<&Path>,
+            _verbose: bool,
+        ) -> Result<(), EngineError> {
+            let nested = output_dir.join("src").join("main").join("kotlin");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(output_dir.join("Api.kt"), "package x").unwrap();
+            std::fs::write(nested.join("Model.kt"), "package x.m").unwrap();
+            std::fs::write(output_dir.join("README.md"), "not kotlin").unwrap();
+            Ok(())
+        }
+    }
+
+    /// A generator whose `generate` always fails — proves run_codegen propagates.
+    struct FailingGenerator;
+    impl CodeGenerator for FailingGenerator {
+        fn name(&self) -> &str {
+            "boom"
+        }
+        fn display_name(&self) -> &str {
+            "boom"
+        }
+        fn managed_tool(&self) -> ManagedToolSpec {
+            ManagedToolSpec::direct_url(
+                "boom",
+                "boom",
+                "1.0.0",
+                "https://example.invalid/x.jar".to_owned(),
+                "x.jar".to_owned(),
+            )
+        }
+        fn config_hash_parts(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn input_files(&self, _project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+            Ok(Vec::new())
+        }
+        fn generate(
+            &self,
+            _project_root: &Path,
+            _output_dir: &Path,
+            _jre_home: Option<&Path>,
+            _verbose: bool,
+        ) -> Result<(), EngineError> {
+            Err(EngineError::CodegenFailed {
+                name: "boom".to_owned(),
+                message: "kaboom".to_owned(),
+            })
+        }
+    }
+
+    #[test]
+    fn run_codegen_collects_generated_kt_excluding_non_kt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![Box::new(WritingGenerator {
+            name: "openapi".to_owned(),
+        })];
+        let generated = run_codegen(tmp.path(), &gens, None, false).unwrap();
+
+        // Exactly the two `.kt` files (sorted; `README.md` excluded), under
+        // `.konvoy/gen/openapi/` including the nested one.
+        let out = generator_output_dir(tmp.path(), "openapi");
+        assert_eq!(
+            generated,
+            vec![
+                out.join("Api.kt"),
+                out.join("src").join("main").join("kotlin").join("Model.kt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn run_codegen_runs_every_generator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![
+            Box::new(WritingGenerator {
+                name: "openapi".to_owned(),
+            }),
+            Box::new(WritingGenerator {
+                name: "grpc".to_owned(),
+            }),
+        ];
+        let generated = run_codegen(tmp.path(), &gens, None, false).unwrap();
+
+        // Two `.kt` per generator, each under its own `.konvoy/gen/<name>/` dir.
+        assert_eq!(generated.len(), 4);
+        assert!(generated
+            .iter()
+            .any(|p| p.starts_with(generator_output_dir(tmp.path(), "openapi"))));
+        assert!(generated
+            .iter()
+            .any(|p| p.starts_with(generator_output_dir(tmp.path(), "grpc"))));
+    }
+
+    #[test]
+    fn run_codegen_propagates_generator_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![Box::new(FailingGenerator)];
+        match run_codegen(tmp.path(), &gens, None, false) {
+            Err(EngineError::CodegenFailed { name, .. }) => assert_eq!(name, "boom"),
+            other => panic!("expected CodegenFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -125,6 +125,31 @@ impl<'a> ArtifactResolver<'a> {
         Ok(jre_home)
     }
 
+    /// Resolve a code-generation tool (e.g. the Fabrikt JAR), returning its path
+    /// and freshly-verified SHA-256.
+    ///
+    /// Mirrors [`resolve_detekt_jar`](Self::resolve_detekt_jar): gate on the
+    /// `--locked` pin and `--offline` presence, then fetch-or-re-verify the
+    /// artifact through the shared network client.
+    pub(crate) fn resolve_codegen_tool(
+        self,
+        tool: &crate::managed_tool::ManagedToolSpec,
+        expected_sha256: Option<&str>,
+    ) -> Result<(std::path::PathBuf, String), EngineError> {
+        let is_present = tool.is_installed().map_err(EngineError::from)?;
+        self.resolve_artifact(
+            || Ok(expected_sha256.is_some()),
+            is_present,
+            || EngineError::CodegenToolOffline {
+                name: tool.id().to_owned(),
+                version: tool.version().to_owned(),
+            },
+        )?;
+        let version = tool.version().to_owned();
+        self.ensure_managed_tool(tool, expected_sha256)
+            .map_err(|e| crate::codegen::map_download_err(tool.id(), &version, e))
+    }
+
     /// Resolve a compiler plugin artifact and return its verified artifact data.
     pub(crate) fn resolve_plugin_artifact(
         self,

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -165,6 +165,10 @@ pub enum EngineError {
     #[error("cannot run codegen `{name}`: {message}")]
     CodegenFailed { name: String, message: String },
 
+    /// A pinned codegen tool is absent locally and --offline prevents fetching it.
+    #[error("codegen tool `{name}` {version} is not downloaded and --offline prevents downloads — run `konvoy build` (or `konvoy generate`) once without --offline, or drop --offline")]
+    CodegenToolOffline { name: String, version: String },
+
     /// The project name supplied to `konvoy init` is invalid.
     #[error("invalid project name \"{name}\": {reason}")]
     InvalidProjectName { name: String, reason: String },

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -149,7 +149,7 @@ fn unique_plugin_artifacts(artifacts: Vec<ResolvedPluginArtifact>) -> Vec<Resolv
 /// This is the graph-wide ensure's input: each manifest's plugins are resolved
 /// against its own `[toolchain]` (for the `{kotlin}` placeholder — path-deps are
 /// required to match the root's Kotlin version), then deduplicated and sorted by
-/// [`unique_plugin_artifacts`]. The resulting pins are recorded in the **root**
+/// `unique_plugin_artifacts`. The resulting pins are recorded in the **root**
 /// `konvoy.lock`, exactly as the root lock already aggregates the graph's Maven
 /// dependencies; no dependency checkout is written to.
 ///

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -67,6 +67,12 @@ pub fn build_tests(
         .collect();
     sources.extend(test_sources);
 
+    // Codegen for the root project, derived from its own manifest (identical to
+    // `build_single`): the tags feed the cache key, the generators run on a miss.
+    // Tools were ensured graph-wide in `resolve_build_context`.
+    let generators = crate::codegen::active_generators(&ctx.manifest.codegen);
+    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
+
     // Compute cache key. The test-binary build must produce a distinct cache
     // key from a regular build of the same source tree, so we tag the lockfile
     // content with a "test" marker (the lockfile_content is already a free-form
@@ -91,6 +97,9 @@ pub fn build_tests(
                 None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
             })
             .collect::<Result<Vec<_>, _>>()?,
+        // Codegen inputs (shared with the regular build) — a spec/config change
+        // rebuilds the test binary too. Empty when no `[codegen]` is configured.
+        codegen_hashes,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -112,6 +121,19 @@ pub fn build_tests(
             output_path,
             compile_duration: start.elapsed(),
         });
+    }
+
+    // Cache miss: run the root's code generators (tools were ensured graph-wide in
+    // resolve_build_context) and add the emitted `.kt` so generated code is compiled
+    // into the test binary too.
+    if !generators.is_empty() {
+        let generated = crate::codegen::run_codegen(
+            project_root,
+            &generators,
+            ctx.jre_home.as_deref(),
+            options.verbose,
+        )?;
+        sources.extend(generated);
     }
 
     // Compile with test runner generation.

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1142,6 +1142,75 @@ KOTLIN
     assert_contains "$out4" "lockfile"
 }
 
+# Expected: the root AND a path-dep BOTH declare [codegen.openapi] with the SAME
+# Fabrikt version. The graph-wide union is content-addressed by (name, version),
+# so the shared tool is pinned exactly ONCE in the root lock — not duplicated, not
+# a conflict. (Different base_packages avoid a generated-class collision; both
+# projects generate + compile their own models.)
+test_codegen_graph_union_dedup() {
+    konvoy init --name cgdedup-lib --lib >/dev/null 2>&1
+    konvoy init --name cgdedup-app >/dev/null 2>&1
+    _write_openapi_spec cgdedup-lib/specs/api.yaml
+    _write_openapi_spec cgdedup-app/specs/api.yaml
+    cat >> cgdedup-lib/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
+
+[dependencies]
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+kotlinx-serialization-json = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.lib"
+TOML
+    cat >> cgdedup-app/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
+
+[dependencies]
+cgdedup-lib = { path = "../cgdedup-lib" }
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+kotlinx-serialization-json = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.app"
+TOML
+    cd cgdedup-app
+
+    local out
+    out=$(konvoy build 2>&1)
+    assert_contains "$out" "Compiling cgdedup-lib"
+    assert_contains "$out" "Compiling cgdedup-app"
+
+    # Exactly one [[codegen_tools]] entry despite codegen declared by BOTH projects.
+    local count
+    count=$(grep -c '^\[\[codegen_tools\]\]' konvoy.lock)
+    if [ "$count" != "1" ]; then
+        echo "    expected exactly 1 deduped codegen pin, got $count" >&2
+        cat konvoy.lock >&2
+        return 1
+    fi
+    assert_file_contains konvoy.lock "fabrikt"
+
+    # Second build fully cached (the deduped pin folded into the key).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked satisfied by the single deduped pin (declared by both projects).
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+    assert_not_contains "$out3" "Compiling"
+}
+
 # Unexpected: [codegen.openapi] declared, lockfile pins the toolchain but NOT the
 # codegen tool → --locked drift, before any download.
 test_codegen_locked_no_pin_fails() {
@@ -3065,6 +3134,7 @@ run_test test_issue_239_serialization_plugin_applied
 run_test test_codegen_build_lifecycle
 run_test test_codegen_fully_generated_lib_builds
 run_test test_codegen_path_dep_build_lifecycle
+run_test test_codegen_graph_union_dedup
 run_test test_codegen_locked_no_pin_fails
 run_test test_codegen_offline_tool_absent_fails
 run_test test_codegen_missing_spec_fails

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -925,6 +925,363 @@ KOTLIN
 }
 
 # ---------------------------------------------------------------------------
+# Tests: codegen (OpenAPI / Fabrikt)
+# ---------------------------------------------------------------------------
+# Fabrikt emits `@Serializable` models, so a project that COMPILES generated code
+# needs the kotlin-serialization plugin + its runtime (the same recipe the plugin
+# tests use). Fabrikt 20.0.0 is the pinned version across these tests; the shared
+# ~/.konvoy cache means it (and the serialization artifacts) download once.
+
+# Write a minimal OpenAPI spec (one @Serializable model) to $1.
+_write_openapi_spec() {
+    mkdir -p "$(dirname "$1")"
+    cat > "$1" << 'YAML'
+openapi: 3.0.3
+info:
+  title: Pet API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+YAML
+}
+
+# Append the serialization plugin + runtime + [codegen.openapi] to manifest $1.
+_append_codegen_config() {
+    cat >> "$1" << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
+
+[dependencies]
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+kotlinx-serialization-json = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+}
+
+# Assert dir $1 exists and holds at least one generated `.kt`.
+_assert_generated_kt() {
+    assert_dir_exists "$1"
+    if [ -z "$(find "$1" -name '*.kt' 2>/dev/null)" ]; then
+        echo "    expected generated .kt under $1" >&2
+        return 1
+    fi
+}
+
+# Expected: root [codegen.openapi] generates sources, compiles them, pins the
+# Fabrikt JAR in the lockfile; the second build is cached (#133); a spec change
+# rebuilds; --locked is a cache hit; the binary runs.
+test_codegen_build_lifecycle() {
+    konvoy init --name cg-app >/dev/null 2>&1
+    _append_codegen_config cg-app/konvoy.toml
+    _write_openapi_spec cg-app/specs/api.yaml
+    cat > cg-app/src/main.kt << 'KOTLIN'
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+
+@Serializable
+data class Cfg(val name: String)
+
+fun main() {
+    println("cfg=" + Json.encodeToString(Cfg("ok")))
+}
+KOTLIN
+    cd cg-app
+
+    local out1
+    out1=$(konvoy build 2>&1)
+    assert_contains "$out1" "Compiling"
+    _assert_generated_kt .konvoy/gen/openapi
+    assert_file_exists .konvoy/build/linux_x64/debug/cg-app
+
+    # The Fabrikt JAR is pinned in the lockfile.
+    assert_file_contains konvoy.lock "[[codegen_tools]]"
+    assert_file_contains konvoy.lock "fabrikt"
+    assert_file_contains konvoy.lock "20.0.0"
+    assert_file_contains konvoy.lock "sha256"
+
+    # Second build is a cache hit — the codegen pins + input hashes are folded
+    # into the first build's cache key (issue #133 class).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked is also a cache hit (the tool is pinned).
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+
+    # Changing the spec changes the codegen input hash → rebuild, not a cache hit.
+    # (A comment bumps the file content without changing the generated output.)
+    printf '# rev2\n' >> specs/api.yaml
+    local out4
+    out4=$(konvoy build 2>&1)
+    assert_contains "$out4" "Compiling"
+    assert_not_contains "$out4" "(cached)"
+
+    # The binary runs (generated model compiled in alongside hand-written code).
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "cfg="
+}
+
+# Expected: a library whose Kotlin is ENTIRELY generated (no hand-written src/)
+# still builds — build_single tolerates a missing src/ and compiles the generated
+# sources into the klib.
+test_codegen_fully_generated_lib_builds() {
+    konvoy init --name cg-genlib --lib >/dev/null 2>&1
+    rm -rf cg-genlib/src
+    _append_codegen_config cg-genlib/konvoy.toml
+    _write_openapi_spec cg-genlib/specs/api.yaml
+    cd cg-genlib
+
+    local out
+    out=$(konvoy build 2>&1)
+    assert_contains "$out" "Compiling"
+    _assert_generated_kt .konvoy/gen/openapi
+    assert_file_exists .konvoy/build/linux_x64/debug/cg-genlib.klib
+    assert_file_contains konvoy.lock "[[codegen_tools]]"
+    assert_file_contains konvoy.lock "fabrikt"
+}
+
+# Expected: a path-dependency with [codegen] generates @Serializable models and
+# compiles them with its OWN serialization plugin (#293/#299); the app links the
+# dep and runs. The dep's Fabrikt tool is pinned in the ROOT lockfile (graph-wide
+# union), even though the root declares no codegen, and the dep checkout is never
+# written to. --locked succeeds with the pin and fails (drift) without it.
+test_codegen_path_dep_build_lifecycle() {
+    konvoy init --name cg-dep --lib >/dev/null 2>&1
+    konvoy init --name cg-root >/dev/null 2>&1
+    _append_codegen_config cg-dep/konvoy.toml
+    _write_openapi_spec cg-dep/specs/api.yaml
+    # A hand-written entry point gives the app a stable symbol to call; the
+    # generated models are compiled into the dep's klib alongside it.
+    cat > cg-dep/src/lib.kt << 'KOTLIN'
+package cgdep
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+
+@Serializable
+data class Marker(val ok: Boolean)
+
+fun marker(): String = Json.encodeToString(Marker(true))
+KOTLIN
+    cat >> cg-root/konvoy.toml << 'TOML'
+
+[dependencies]
+cg-dep = { path = "../cg-dep" }
+TOML
+    cat > cg-root/src/main.kt << 'KOTLIN'
+import cgdep.marker
+
+fun main() {
+    println("root:" + marker())
+}
+KOTLIN
+    cd cg-root
+
+    local out1
+    out1=$(konvoy build 2>&1)
+    assert_contains "$out1" "Compiling cg-dep"
+    assert_contains "$out1" "Compiling cg-root"
+    assert_file_exists .konvoy/build/linux_x64/debug/cg-root
+
+    # The dep generated into ITS OWN .konvoy/gen, the dep's Fabrikt tool is pinned
+    # in the ROOT lockfile (graph-wide union), and the dep checkout is untouched.
+    _assert_generated_kt ../cg-dep/.konvoy/gen/openapi
+    assert_file_contains konvoy.lock "[[codegen_tools]]"
+    assert_file_contains konvoy.lock "fabrikt"
+    if [ -f ../cg-dep/konvoy.lock ]; then
+        echo "    root build must not write a lockfile into the dep checkout" >&2
+        return 1
+    fi
+
+    # Second build fully cached across the stack (#133 — codegen pins folded in).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # The binary runs through the dep (its generated + hand-written code linked).
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "root:"
+
+    # --locked succeeds with the dep's codegen pin present...
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+
+    # ...and fails when the dep's codegen pin is removed: path-dep codegen drift is
+    # caught by the graph-wide ensure (the root staleness check is root-only, and
+    # the root declares no codegen). [[codegen_tools]] is the last lock section.
+    sed -i '/\[\[codegen_tools\]\]/,$d' konvoy.lock
+    local out4
+    if out4=$(konvoy build --locked 2>&1); then
+        echo "    expected --locked to fail with the dep codegen pin missing" >&2
+        return 1
+    fi
+    assert_contains "$out4" "lockfile"
+}
+
+# Unexpected: [codegen.openapi] declared, lockfile pins the toolchain but NOT the
+# codegen tool → --locked drift, before any download.
+test_codegen_locked_no_pin_fails() {
+    konvoy init --name cg-locked >/dev/null 2>&1
+    cat >> cg-locked/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-locked
+    printf '[toolchain]\nkonanc_version = "2.2.0"\n' > konvoy.lock
+    local output
+    if output=$(konvoy build --locked 2>&1); then
+        echo "    expected --locked to fail without a codegen pin" >&2
+        return 1
+    fi
+    assert_contains "$output" "lockfile"
+}
+
+# Unexpected: --offline + an uncached Fabrikt JAR is a hard error naming the tool.
+# A unique version guarantees it is never in the shared cache (so this is not racy
+# against the other codegen tests, which all use 20.0.0).
+test_codegen_offline_tool_absent_fails() {
+    konvoy init --name cg-offline >/dev/null 2>&1
+    cat >> cg-offline/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "99.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-offline
+    local output
+    if output=$(konvoy build --offline 2>&1); then
+        echo "    expected --offline build to fail with an absent codegen tool" >&2
+        return 1
+    fi
+    assert_contains "$output" 'codegen tool `fabrikt`'
+    assert_contains "$output" "--offline prevents downloads"
+}
+
+# Unexpected: the spec file is declared but absent → CodegenInputNotFound at build
+# (after the tool is ensured, before compilation).
+test_codegen_missing_spec_fails() {
+    konvoy init --name cg-nospec >/dev/null 2>&1
+    cat >> cg-nospec/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-nospec
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected build to fail with a missing spec file" >&2
+        return 1
+    fi
+    assert_contains "$output" "codegen input for"
+    assert_contains "$output" "not found"
+}
+
+# Unexpected (manifest validation, fails at parse before any build work): an
+# absolute spec path is rejected.
+test_codegen_absolute_spec_rejected() {
+    konvoy init --name cg-abs >/dev/null 2>&1
+    cat >> cg-abs/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "/etc/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-abs
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected build to fail with an absolute spec path" >&2
+        return 1
+    fi
+    assert_contains "$output" "relative path inside the project"
+}
+
+# Unexpected: a non-OpenAPI spec extension is rejected.
+test_codegen_bad_spec_extension_rejected() {
+    konvoy init --name cg-ext >/dev/null 2>&1
+    cat >> cg-ext/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.txt"
+base_package = "com.example.gen"
+TOML
+    cd cg-ext
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected build to fail with a non-OpenAPI spec extension" >&2
+        return 1
+    fi
+    assert_contains "$output" ".yaml, .yml, or .json"
+}
+
+# Unexpected: a Fabrikt version older than the supported minimum is rejected.
+test_codegen_old_fabrikt_version_rejected() {
+    konvoy init --name cg-oldver >/dev/null 2>&1
+    cat >> cg-oldver/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "17.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-oldver
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected build to fail with an unsupported Fabrikt version" >&2
+        return 1
+    fi
+    assert_contains "$output" "18.0.0 or newer"
+}
+
+# Unexpected: an unknown codegen tool ([codegen.grpc]) is rejected.
+test_codegen_unknown_tool_rejected() {
+    konvoy init --name cg-unknown >/dev/null 2>&1
+    cat >> cg-unknown/konvoy.toml << 'TOML'
+
+[codegen.grpc]
+version = "1.0.0"
+TOML
+    cd cg-unknown
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected build to fail with an unknown codegen tool" >&2
+        return 1
+    fi
+    assert_contains "$output" "grpc"
+}
+
+# ---------------------------------------------------------------------------
 # Tests: Maven dependencies
 # ---------------------------------------------------------------------------
 
@@ -2703,6 +3060,18 @@ run_test test_plugin_kotlin_placeholder_resolves
 # Issue #239: serialization plugin downloaded but not applied (fixed by two-step
 # program compilation, #243 — the embeddable-JAR mapping was reverted in #245).
 run_test test_issue_239_serialization_plugin_applied
+
+# codegen (OpenAPI / Fabrikt)
+run_test test_codegen_build_lifecycle
+run_test test_codegen_fully_generated_lib_builds
+run_test test_codegen_path_dep_build_lifecycle
+run_test test_codegen_locked_no_pin_fails
+run_test test_codegen_offline_tool_absent_fails
+run_test test_codegen_missing_spec_fails
+run_test test_codegen_absolute_spec_rejected
+run_test test_codegen_bad_spec_extension_rejected
+run_test test_codegen_old_fabrikt_version_rejected
+run_test test_codegen_unknown_tool_rejected
 
 # Maven dependencies
 run_test test_update_help


### PR DESCRIPTION
Wires `[codegen]` (OpenAPI via the Fabrikt JAR) into `konvoy build` / `konvoy build --tests`, on the `ArtifactResolver` / `NetworkClient` model introduced by #297/#298. Generator-agnostic throughout — the build only ever sees `&[Box<dyn CodeGenerator>]`.

Rebuilt on current `main`: this **supersedes the original #292 (root-only) + #294 (path-deps) split** and lands them as **one** change on the new architecture (the old base was refactored enough that a rebase was a re-implementation). Stacks on the merged codegen framework (#289/#290/#291).

## What it does

- **Policy via the shared resolver.** Codegen tools resolve through `ArtifactResolver::resolve_codegen_tool`, so the `--locked` / `--offline` policy and the network client apply *uniformly* with plugins and detekt — no codegen-specific gate:
  - missing pin under `--locked` → `LockfileUpdateRequired`
  - absent tool under `--offline` → `CodegenToolOffline`
  - otherwise fetch-or-re-verify against the pinned SHA through the `NetworkClient` (offline is enforced at the wire).
- **Graph-wide pinning.** `ensure_codegen_tools` resolves the **deduped union** of every codegen tool across the root + all path-deps (content-addressed by `(name, version)`, so a shared tool is fetched/pinned once) and records it in the root `konvoy.lock` `[[codegen_tools]]`, folded into the pre-stabilized lockfile so the cache key is stable from the first build (issue #133 class). No dependency checkouts are mutated.
- **Uniform per-project generation (path-deps work).** `build_single` and `build_tests` derive each project's generators from its **own** manifest, fold the input hashes (`codegen_hashes`: spec contents + config + tool version) into *that project's* cache key, and run the generators on a cache miss — root and path-deps treated identically. The empty-source check moves after codegen so a fully-generated project still builds.
- **`check_lockfile_staleness`** requires a `[[codegen_tools]]` pin per configured generator under `--locked` (fast-fail before any download), mirroring the plugin check.

## Schema

`konvoy-config` gains `Lockfile.codegen_tools: Vec<CodegenToolLock>` (`deny_unknown_fields`; empty omitted from TOML).

## Tests

- Orchestration (`ensure_codegen_tools` / `unique_codegen_tools` / `run_codegen`): empty no-op; `--locked` without pin → `LockfileUpdateRequired`; `--offline` pinned-but-absent → `CodegenToolOffline`; tool dedup + sort across a graph; recursive `.kt` collection excluding non-`.kt`; multi-generator; failure propagation.
- Cache key: `codegen_hashes` participate.
- Lockfile: `check_lockfile_staleness` codegen drift/match; `update_lockfile_if_needed` writes `[[codegen_tools]]`.

## Gates

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS=-D warnings cargo doc` — all pass.

## Notes

- The path/text util refactor that rode along in the original #292 is **dropped** here (unrelated cleanup; can be its own PR).
- The path-dep **plugins** gap (#293) is still separate and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)