### PR TITLE
konvoy-engine: generate codegen for path-deps (graph-wide tool pinning)

### DIFF
--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -11,6 +11,24 @@ pub struct Lockfile {
     pub dependencies: Vec<DependencyLock>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugins: Vec<PluginLock>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub codegen_tools: Vec<CodegenToolLock>,
+}
+
+/// A locked code-generation tool entry (e.g. the Fabrikt JAR) in the lockfile.
+///
+/// Identified by the generator-stable tool `name` + resolved `version`; the SHA
+/// pins the downloaded artifact for reproducibility and `--locked` verification.
+/// (The download source is derived from the generator, not stored here.)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CodegenToolLock {
+    /// Stable tool id (e.g. `"fabrikt"`).
+    pub name: String,
+    /// Resolved tool version.
+    pub version: String,
+    /// Hex-encoded SHA-256 hash of the downloaded artifact.
+    pub sha256: String,
 }
 
 /// A locked plugin artifact entry in the lockfile.
@@ -112,6 +130,7 @@ impl Lockfile {
             }),
             dependencies: Vec::new(),
             plugins: Vec::new(),
+            codegen_tools: Vec::new(),
         }
     }
 
@@ -131,6 +150,7 @@ impl Lockfile {
             }),
             dependencies: Vec::new(),
             plugins: Vec::new(),
+            codegen_tools: Vec::new(),
         }
     }
 
@@ -450,6 +470,77 @@ konanc_version = "2.1.0"
         let lockfile = Lockfile::with_toolchain("2.1.0");
         let content = toml::to_string_pretty(&lockfile).unwrap();
         assert!(!content.contains("dependencies"), "content was: {content}");
+    }
+
+    #[test]
+    fn round_trip_with_codegen_tools() {
+        let dir = make_test_dir();
+        let path = dir.path().join("konvoy.lock");
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile.codegen_tools.push(CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "abc123def456".to_owned(),
+        });
+        lockfile.write_to(&path).unwrap();
+        let reparsed = Lockfile::from_path(&path).unwrap();
+        assert_eq!(lockfile, reparsed);
+        assert_eq!(reparsed.codegen_tools.len(), 1);
+        let tool = reparsed.codegen_tools.first().unwrap();
+        assert_eq!(tool.name, "fabrikt");
+        assert_eq!(tool.version, "1.2.3");
+        assert_eq!(tool.sha256, "abc123def456");
+    }
+
+    #[test]
+    fn backward_compat_no_codegen_tools() {
+        let dir = make_test_dir();
+        let path = dir.path().join("konvoy.lock");
+        fs::write(
+            &path,
+            r#"
+[toolchain]
+konanc_version = "2.1.0"
+"#,
+        )
+        .unwrap();
+
+        let lockfile = Lockfile::from_path(&path).unwrap();
+        assert!(lockfile.codegen_tools.is_empty());
+    }
+
+    #[test]
+    fn empty_codegen_tools_omitted_in_toml() {
+        let lockfile = Lockfile::with_toolchain("2.1.0");
+        let content = toml::to_string_pretty(&lockfile).unwrap();
+        assert!(!content.contains("codegen_tools"), "content was: {content}");
+    }
+
+    #[test]
+    fn codegen_tool_lock_rejects_unknown_fields() {
+        // `deny_unknown_fields` guards against silently-ignored typos in a hand-
+        // edited lockfile (e.g. `shar256` instead of `sha256`).
+        let dir = make_test_dir();
+        let path = dir.path().join("konvoy.lock");
+        fs::write(
+            &path,
+            r#"
+[toolchain]
+konanc_version = "2.1.0"
+
+[[codegen_tools]]
+name = "fabrikt"
+version = "1.2.3"
+sha256 = "abc123"
+bogus = "nope"
+"#,
+        )
+        .unwrap();
+
+        assert!(
+            Lockfile::from_path(&path).is_err(),
+            "an unknown field in [[codegen_tools]] must be rejected"
+        );
     }
 
     /// Create a unique temporary directory that is auto-cleaned on drop.

--- a/crates/konvoy-engine/src/artifact.rs
+++ b/crates/konvoy-engine/src/artifact.rs
@@ -367,6 +367,7 @@ mod tests {
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         CacheKey::compute(&inputs).unwrap()
     }

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -138,13 +138,8 @@ pub(crate) struct ResolvedBuildContext {
     pub plugin_jars: Vec<PathBuf>,
     /// Lockfile entries for resolved plugins (used by `update_lockfile_if_needed`).
     pub plugin_locks: Vec<konvoy_config::lockfile::PluginLock>,
-    /// Active code generators for the root project's `[codegen]` config (empty
-    /// when no codegen is configured). Run on a cache miss to produce sources.
-    pub generators: Vec<Box<dyn crate::codegen::CodeGenerator>>,
-    /// Tagged (`name:hash`) codegen input hashes folded into the root project's
-    /// cache key (empty when no codegen is configured).
-    pub codegen_hashes: Vec<String>,
-    /// Resolved codegen-tool lockfile pins (persisted by `update_lockfile_if_needed`).
+    /// Resolved codegen-tool lockfile pins — the deduped union across the root and
+    /// all path-deps (persisted to the root lock by `update_lockfile_if_needed`).
     pub codegen_locks: Vec<CodegenToolLock>,
     /// Resolved path-dependency graph in topological order.
     pub dep_graph: ResolvedGraph,
@@ -320,20 +315,32 @@ pub(crate) fn resolve_build_context(
         (Vec::new(), Vec::new())
     };
 
-    // 6b. Resolve codegen tools, mirroring plugins (issue #133 class). Each
-    //     generator's managed tool is downloaded + SHA-pinned up front so the
-    //     predicted lockfile — and therefore the cache key — is stable from the
-    //     first build, and the per-generator input hashes that feed the cache key
-    //     are computed here too. Generation itself is deferred to a cache miss in
-    //     `build_single`. Codegen is scoped to the root project; path-dependency
-    //     `[codegen]` config is not processed.
+    // 6b. Resolve the dependency graph up front. Codegen-tool pinning spans the
+    //     WHOLE graph (root + path-deps), so every dependency's manifest must be
+    //     known before the lockfile is predicted. `resolve_dependencies` only reads
+    //     dep manifests + source hashes (no toolchain/plugin state), so running it
+    //     here — earlier than the build loop below — is safe.
+    let dep_graph = resolve_dependencies(project_root, &manifest)?;
+
+    // 6c. Resolve codegen tools, mirroring plugins (issue #133 class). Tools are
+    //     downloaded + SHA-pinned up front so the predicted lockfile — and thus the
+    //     cache key — is stable from the first build. The pin set is the deduped
+    //     UNION of every codegen tool across the root and all path-deps, recorded
+    //     in the root `konvoy.lock` (just as the root lock aggregates the graph's
+    //     Maven deps). Each project's input hashing and the generation itself are
+    //     deferred to a cache miss in `build_single`, per project.
     //
     // On a warm cache the tools are already present and pinned, so
     // `ensure_codegen_tools` only re-verifies their hashes — it does not download.
-    let generators = crate::codegen::active_generators(&manifest.codegen);
-    let codegen_locks =
-        crate::codegen::ensure_codegen_tools(&generators, &lockfile.codegen_tools, options.locked)?;
-    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
+    let mut graph_generators = crate::codegen::active_generators(&manifest.codegen);
+    for dep in &dep_graph.order {
+        graph_generators.extend(crate::codegen::active_generators(&dep.manifest.codegen));
+    }
+    let codegen_locks = crate::codegen::ensure_codegen_tools(
+        &graph_generators,
+        &lockfile.codegen_tools,
+        options.locked,
+    )?;
 
     // We predict the lockfile content that will eventually be written, so the
     // cache key is the same in the first and second builds. In `--locked` mode
@@ -348,8 +355,7 @@ pub(crate) fn resolve_build_context(
         options.locked,
     );
 
-    // 7. Resolve dependencies and build them in topological order.
-    let dep_graph = resolve_dependencies(project_root, &manifest)?;
+    // 7. Build path dependencies in topological order.
     let lockfile_content = lockfile_toml_content(&effective_lockfile)?;
 
     let levels = parallel_levels(&dep_graph);
@@ -373,9 +379,6 @@ pub(crate) fn resolve_build_context(
                     options,
                     library_inputs: &lib_inputs,
                     plugin_jars: &[],
-                    // Codegen is root-scoped; path-deps don't generate.
-                    codegen_hashes: &[],
-                    generators: &[],
                 };
                 let (output, outcome) = build_single(
                     &dep.project_root,
@@ -424,8 +427,6 @@ pub(crate) fn resolve_build_context(
         library_inputs,
         plugin_jars,
         plugin_locks,
-        generators,
-        codegen_hashes,
         codegen_locks,
         dep_graph,
         store,
@@ -462,8 +463,6 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
         options,
         library_inputs: &ctx.library_inputs,
         plugin_jars: &ctx.plugin_jars,
-        codegen_hashes: &ctx.codegen_hashes,
-        generators: &ctx.generators,
     };
     let (output_path, outcome) = build_single(
         project_root,
@@ -516,13 +515,6 @@ pub(crate) struct CompileContext<'a> {
     pub library_inputs: &'a [LibraryInput],
     /// Compiler plugin JAR paths to pass as `-Xplugin` args.
     pub plugin_jars: &'a [PathBuf],
-    /// Tagged (`name:hash`) codegen input hashes folded into the cache key (empty
-    /// when the project has no `[codegen]` config).
-    pub codegen_hashes: &'a [String],
-    /// Code generators to run on a cache miss, producing `.kt` sources to compile
-    /// (empty when the project has no `[codegen]` config). Their tools must already
-    /// be ensured (see `resolve_build_context`).
-    pub generators: &'a [Box<dyn crate::codegen::CodeGenerator>],
 }
 
 /// Build a single project (either root or a dependency).
@@ -547,6 +539,14 @@ pub(crate) fn build_single(
         .collect();
 
     let is_lib = manifest.package.kind == PackageKind::Lib;
+
+    // Codegen is resolved per project from its OWN manifest — the root and every
+    // path-dep are treated identically. The tags (spec contents + config + tool
+    // version) feed this project's cache key; the generators run on a miss (below).
+    // Their tools were already downloaded + pinned graph-wide in
+    // `resolve_build_context`, so a miss here only runs them, never downloads.
+    let generators = crate::codegen::active_generators(&manifest.codegen);
+    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
 
     // Compute cache key.
     let manifest_content = manifest.to_toml()?;
@@ -573,7 +573,7 @@ pub(crate) fn build_single(
             .collect::<Result<Vec<_>, _>>()?,
         // Codegen inputs (spec files + generator config + tool version) — a change
         // here rebuilds. Empty when the project has no `[codegen]` config.
-        codegen_hashes: cc.codegen_hashes.to_vec(),
+        codegen_hashes,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -599,14 +599,14 @@ pub(crate) fn build_single(
         return Ok((output_path, BuildOutcome::Cached));
     }
 
-    // Cache miss: run code generators (their tools were ensured up front in
-    // resolve_build_context) and add the emitted `.kt` to the source set. The
-    // generated output is NOT in the cache key directly — its inputs are, via
-    // `codegen_hashes` — so generation is deterministic w.r.t. the key.
-    if !cc.generators.is_empty() {
+    // Cache miss: run this project's code generators (their tools were ensured up
+    // front, graph-wide, in resolve_build_context) and add the emitted `.kt` to the
+    // source set. The generated output is NOT in the cache key directly — its
+    // inputs are, via `codegen_hashes` — so generation is deterministic w.r.t. the key.
+    if !generators.is_empty() {
         let generated = crate::codegen::run_codegen(
             project_root,
-            cc.generators,
+            &generators,
             cc.jre_home,
             cc.options.verbose,
         )?;
@@ -1734,8 +1734,6 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
-            codegen_hashes: &[],
-            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1824,8 +1822,6 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
-            codegen_hashes: &[],
-            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1940,8 +1936,6 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
-            codegen_hashes: &[],
-            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -2543,8 +2537,6 @@ mod tests {
             options: &options_no_force,
             library_inputs: &[],
             plugin_jars: &[],
-            codegen_hashes: &[],
-            generators: &[],
         };
         let (_, outcome) = build_single(
             &project,
@@ -2573,8 +2565,6 @@ mod tests {
             options: &options_force,
             library_inputs: &[],
             plugin_jars: &[],
-            codegen_hashes: &[],
-            generators: &[],
         };
         let result = build_single(&project, &manifest, &cc_force, profile, &lockfile_content);
 

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
-use konvoy_config::lockfile::{DepSource, DependencyLock, Lockfile, PluginLock};
+use konvoy_config::lockfile::{CodegenToolLock, DepSource, DependencyLock, Lockfile, PluginLock};
 use konvoy_config::manifest::{Manifest, PackageKind};
 use konvoy_config::Profile;
 use konvoy_konanc::detect::{resolve_konanc, KonancInfo};
@@ -138,6 +138,14 @@ pub(crate) struct ResolvedBuildContext {
     pub plugin_jars: Vec<PathBuf>,
     /// Lockfile entries for resolved plugins (used by `update_lockfile_if_needed`).
     pub plugin_locks: Vec<konvoy_config::lockfile::PluginLock>,
+    /// Active code generators for the root project's `[codegen]` config (empty
+    /// when no codegen is configured). Run on a cache miss to produce sources.
+    pub generators: Vec<Box<dyn crate::codegen::CodeGenerator>>,
+    /// Tagged (`name:hash`) codegen input hashes folded into the root project's
+    /// cache key (empty when no codegen is configured).
+    pub codegen_hashes: Vec<String>,
+    /// Resolved codegen-tool lockfile pins (persisted by `update_lockfile_if_needed`).
+    pub codegen_locks: Vec<CodegenToolLock>,
     /// Resolved path-dependency graph in topological order.
     pub dep_graph: ResolvedGraph,
     /// Content-addressed artifact store for this project.
@@ -160,25 +168,28 @@ pub(crate) struct LockfileWriteInputs {
 ///
 /// - In `--locked` mode the on-disk lockfile is authoritative and returned
 ///   unchanged (the user explicitly forbids any modification; it already
-///   contains the plugin entries, enforced by the staleness check).
+///   contains the plugin and codegen-tool entries — `ensure_codegen_tools`
+///   re-verifies the latter against their pins before this point).
 /// - Otherwise the toolchain section is stabilized to the detected konanc
 ///   version (predicting the post-build write), existing dependencies are
-///   preserved, and the predicted `[[plugins]]` entries (`plugin_locks`,
-///   resolved before the cache key is computed) are folded in.
+///   preserved, and the predicted `[[plugins]]` (`plugin_locks`) and
+///   `[[codegen_tools]]` (`codegen_locks`) entries — both resolved before the
+///   cache key is computed — are folded in.
 ///
-/// Folding the plugin entries in BOTH the version-matches branch and the
-/// stabilized branch is what fixes the spurious one-time recompile of projects
-/// with plugins: the first build's on-disk lockfile has no `[[plugins]]`
+/// Folding the plugin and codegen-tool entries in BOTH the version-matches branch
+/// and the stabilized branch is what fixes the spurious one-time recompile of
+/// projects with plugins/codegen: the first build's on-disk lockfile has no such
 /// entries yet, but the second build reads them back from disk. Without folding,
 /// the two builds produce different `lockfile_content` and therefore different
-/// cache keys. Plugins genuinely affect compilation, so they must stay in the
-/// cache key — folding the predicted entries in is what keeps it stable.
+/// cache keys. Both genuinely affect compilation, so they must stay in the cache
+/// key — folding the predicted entries in is what keeps it stable.
 fn predicted_effective_lockfile(
     lockfile: &Lockfile,
     konanc_version: &str,
     konanc_tarball_sha256: Option<&str>,
     jre_tarball_sha256: Option<&str>,
     plugin_locks: &[PluginLock],
+    codegen_locks: &[CodegenToolLock],
     locked: bool,
 ) -> Lockfile {
     // In --locked mode the lockfile must not change. It already contains the
@@ -211,6 +222,9 @@ fn predicted_effective_lockfile(
     // (`updated.plugins = plugin_locks`). This keeps the cache key identical
     // across the first and second builds of a project with plugins.
     effective.plugins = plugin_locks.to_vec();
+    // Same reasoning for the predicted [[codegen_tools]] pins: they are written
+    // only at the end of the build, so fold them in here for cache-key stability.
+    effective.codegen_tools = codegen_locks.to_vec();
     effective
 }
 
@@ -306,6 +320,21 @@ pub(crate) fn resolve_build_context(
         (Vec::new(), Vec::new())
     };
 
+    // 6b. Resolve codegen tools, mirroring plugins (issue #133 class). Each
+    //     generator's managed tool is downloaded + SHA-pinned up front so the
+    //     predicted lockfile — and therefore the cache key — is stable from the
+    //     first build, and the per-generator input hashes that feed the cache key
+    //     are computed here too. Generation itself is deferred to a cache miss in
+    //     `build_single`. Codegen is scoped to the root project; path-dependency
+    //     `[codegen]` config is not processed.
+    //
+    // On a warm cache the tools are already present and pinned, so
+    // `ensure_codegen_tools` only re-verifies their hashes — it does not download.
+    let generators = crate::codegen::active_generators(&manifest.codegen);
+    let codegen_locks =
+        crate::codegen::ensure_codegen_tools(&generators, &lockfile.codegen_tools, options.locked)?;
+    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
+
     // We predict the lockfile content that will eventually be written, so the
     // cache key is the same in the first and second builds. In `--locked` mode
     // the lockfile is used as-is because the user explicitly forbids changes.
@@ -315,6 +344,7 @@ pub(crate) fn resolve_build_context(
         konanc_tarball_sha256.as_deref(),
         jre_tarball_sha256.as_deref(),
         &plugin_locks,
+        &codegen_locks,
         options.locked,
     );
 
@@ -343,6 +373,9 @@ pub(crate) fn resolve_build_context(
                     options,
                     library_inputs: &lib_inputs,
                     plugin_jars: &[],
+                    // Codegen is root-scoped; path-deps don't generate.
+                    codegen_hashes: &[],
+                    generators: &[],
                 };
                 let (output, outcome) = build_single(
                     &dep.project_root,
@@ -391,6 +424,9 @@ pub(crate) fn resolve_build_context(
         library_inputs,
         plugin_jars,
         plugin_locks,
+        generators,
+        codegen_hashes,
+        codegen_locks,
         dep_graph,
         store,
     })
@@ -426,6 +462,8 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
         options,
         library_inputs: &ctx.library_inputs,
         plugin_jars: &ctx.plugin_jars,
+        codegen_hashes: &ctx.codegen_hashes,
+        generators: &ctx.generators,
     };
     let (output_path, outcome) = build_single(
         project_root,
@@ -437,7 +475,7 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
 
     let lockfile_path = project_root.join("konvoy.lock");
 
-    // 9. Update lockfile if toolchain, dependencies, or plugins changed.
+    // 9. Update lockfile if toolchain, dependencies, plugins, or codegen tools changed.
     update_lockfile_if_needed(
         &ctx.lockfile,
         &ctx.konanc,
@@ -445,6 +483,7 @@ pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult,
         ctx.lockfile_write_inputs.jre_tarball_sha256.as_deref(),
         &ctx.dep_graph,
         &ctx.plugin_locks,
+        &ctx.codegen_locks,
         project_root,
         &lockfile_path,
         options.force,
@@ -477,6 +516,13 @@ pub(crate) struct CompileContext<'a> {
     pub library_inputs: &'a [LibraryInput],
     /// Compiler plugin JAR paths to pass as `-Xplugin` args.
     pub plugin_jars: &'a [PathBuf],
+    /// Tagged (`name:hash`) codegen input hashes folded into the cache key (empty
+    /// when the project has no `[codegen]` config).
+    pub codegen_hashes: &'a [String],
+    /// Code generators to run on a cache miss, producing `.kt` sources to compile
+    /// (empty when the project has no `[codegen]` config). Their tools must already
+    /// be ensured (see `resolve_build_context`).
+    pub generators: &'a [Box<dyn crate::codegen::CodeGenerator>],
 }
 
 /// Build a single project (either root or a dependency).
@@ -489,19 +535,16 @@ pub(crate) fn build_single(
     profile: Profile,
     lockfile_content: &str,
 ) -> Result<(PathBuf, BuildOutcome), EngineError> {
-    // Collect source files, excluding test sources (src/test/).
+    // Collect source files, excluding test sources (src/test/). Emptiness is
+    // checked AFTER codegen (below), so a project whose Kotlin is entirely
+    // generated from a spec still builds.
     let src_dir = project_root.join("src");
     let test_dir = src_dir.join("test");
     let all_sources = konvoy_util::fs::collect_files(&src_dir, "kt")?;
-    let sources: Vec<PathBuf> = all_sources
+    let mut sources: Vec<PathBuf> = all_sources
         .into_iter()
         .filter(|p| !p.starts_with(&test_dir))
         .collect();
-    if sources.is_empty() {
-        return Err(EngineError::NoSources {
-            dir: src_dir.display().to_string(),
-        });
-    }
 
     let is_lib = manifest.package.kind == PackageKind::Lib;
 
@@ -528,6 +571,9 @@ pub(crate) fn build_single(
                 None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
             })
             .collect::<Result<Vec<_>, _>>()?,
+        // Codegen inputs (spec files + generator config + tool version) — a change
+        // here rebuilds. Empty when the project has no `[codegen]` config.
+        codegen_hashes: cc.codegen_hashes.to_vec(),
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -551,6 +597,26 @@ pub(crate) fn build_single(
         eprintln!("    Fresh {} (cached)", manifest.package.name);
         store.materialize(&cache_key, &output_name, &output_path)?;
         return Ok((output_path, BuildOutcome::Cached));
+    }
+
+    // Cache miss: run code generators (their tools were ensured up front in
+    // resolve_build_context) and add the emitted `.kt` to the source set. The
+    // generated output is NOT in the cache key directly — its inputs are, via
+    // `codegen_hashes` — so generation is deterministic w.r.t. the key.
+    if !cc.generators.is_empty() {
+        let generated = crate::codegen::run_codegen(
+            project_root,
+            cc.generators,
+            cc.jre_home,
+            cc.options.verbose,
+        )?;
+        sources.extend(generated);
+    }
+
+    if sources.is_empty() {
+        return Err(EngineError::NoSources {
+            dir: src_dir.display().to_string(),
+        });
     }
 
     // Compile.
@@ -1003,6 +1069,7 @@ fn update_lockfile_if_needed(
     jre_tarball_sha256: Option<&str>,
     dep_graph: &ResolvedGraph,
     plugin_locks: &[konvoy_config::lockfile::PluginLock],
+    codegen_locks: &[CodegenToolLock],
     project_root: &Path,
     lockfile_path: &Path,
     force: bool,
@@ -1065,9 +1132,15 @@ fn update_lockfile_if_needed(
     let has_new_hashes = konanc_tarball_sha256.is_some() || jre_tarball_sha256.is_some();
     let deps_changed = lockfile.dependencies != new_deps;
     let plugins_changed = lockfile.plugins.as_slice() != plugin_locks;
+    let codegen_changed = lockfile.codegen_tools.as_slice() != codegen_locks;
 
     // If nothing changed, nothing to do.
-    if !toolchain_changed && !has_new_hashes && !deps_changed && !plugins_changed {
+    if !toolchain_changed
+        && !has_new_hashes
+        && !deps_changed
+        && !plugins_changed
+        && !codegen_changed
+    {
         return Ok(());
     }
 
@@ -1127,6 +1200,7 @@ fn update_lockfile_if_needed(
     );
     updated.dependencies = new_deps;
     updated.plugins = plugin_locks.to_vec();
+    updated.codegen_tools = codegen_locks.to_vec();
     updated.write_to(lockfile_path)?;
 
     Ok(())
@@ -1403,6 +1477,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -1436,6 +1511,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -1465,6 +1541,7 @@ mod tests {
             Some("cafebabe"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -1493,6 +1570,7 @@ mod tests {
             Some("first-konanc-hash"),
             Some("first-jre-hash"),
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -1558,6 +1636,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -1628,6 +1707,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -1654,6 +1734,8 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
+            codegen_hashes: &[],
+            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1715,6 +1797,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -1741,6 +1824,8 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
+            codegen_hashes: &[],
+            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1797,6 +1882,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key_before = CacheKey::compute(&cache_inputs_before).unwrap();
 
@@ -1838,6 +1924,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key_after = CacheKey::compute(&cache_inputs_after).unwrap();
         assert_eq!(
@@ -1853,6 +1940,8 @@ mod tests {
             options: &options,
             library_inputs: &[],
             plugin_jars: &[],
+            codegen_hashes: &[],
+            generators: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1882,6 +1971,7 @@ mod tests {
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -1922,6 +2012,7 @@ mod tests {
             Some("newhash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -1960,6 +2051,7 @@ mod tests {
             Some("samehash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -1993,6 +2085,7 @@ mod tests {
             Some("newhash1"),
             Some("newhash2"),
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2035,6 +2128,7 @@ mod tests {
             Some("newhash2"),
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             true,
@@ -2072,6 +2166,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2107,6 +2202,7 @@ mod tests {
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2164,6 +2260,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2226,6 +2323,7 @@ mod tests {
             None,
             &graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2277,6 +2375,7 @@ mod tests {
             None,
             None,
             &graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -2357,6 +2456,7 @@ mod tests {
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -2409,6 +2509,7 @@ mod tests {
             os: std::env::consts::OS.to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let cache_key = CacheKey::compute(&cache_inputs).unwrap();
 
@@ -2442,6 +2543,8 @@ mod tests {
             options: &options_no_force,
             library_inputs: &[],
             plugin_jars: &[],
+            codegen_hashes: &[],
+            generators: &[],
         };
         let (_, outcome) = build_single(
             &project,
@@ -2470,6 +2573,8 @@ mod tests {
             options: &options_force,
             library_inputs: &[],
             plugin_jars: &[],
+            codegen_hashes: &[],
+            generators: &[],
         };
         let result = build_single(&project, &manifest, &cc_force, profile, &lockfile_content);
 
@@ -2575,6 +2680,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             false,
         );
 
@@ -2591,6 +2697,7 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &[],
             false,
         );
 
@@ -3002,6 +3109,7 @@ mod tests {
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -3058,6 +3166,7 @@ mod tests {
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -3072,6 +3181,185 @@ mod tests {
             reparsed.plugins.first().unwrap().maven,
             "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin"
         );
+    }
+
+    /// Codegen-tool pins must be folded into the pre-stabilized lockfile exactly
+    /// like plugins, so the cache key is identical on the first build (lockfile has
+    /// no `[[codegen_tools]]` yet) and the second (it does). Otherwise a project
+    /// with `[codegen]` recompiles once unnecessarily after its first build.
+    #[test]
+    fn pre_stabilized_lockfile_matches_post_update_lockfile_with_codegen_tools() {
+        let konanc_version = "2.1.0";
+        let codegen_locks = vec![CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "codegen-sha-deadbeef".to_owned(),
+        }];
+
+        // First build: no lockfile on disk (no toolchain, no codegen tools).
+        let first_on_disk = Lockfile::default();
+        let effective_first = predicted_effective_lockfile(
+            &first_on_disk,
+            konanc_version,
+            None,
+            None,
+            &[],
+            &codegen_locks,
+            false,
+        );
+
+        // After the first build the lockfile carries the managed toolchain plus
+        // the resolved codegen-tool pins.
+        let mut written = Lockfile::with_managed_toolchain(konanc_version, None, None);
+        written.codegen_tools = codegen_locks.clone();
+        let effective_second = predicted_effective_lockfile(
+            &written,
+            konanc_version,
+            None,
+            None,
+            &[],
+            &codegen_locks,
+            false,
+        );
+
+        let content_first = lockfile_toml_content(&effective_first).unwrap();
+        let content_second = lockfile_toml_content(&effective_second).unwrap();
+        assert_eq!(
+            content_first, content_second,
+            "cache-key lockfile content must match across first/second builds with codegen tools"
+        );
+        assert!(
+            content_first.contains("fabrikt"),
+            "predicted codegen-tool pins must be folded into the cache-key lockfile content"
+        );
+    }
+
+    #[test]
+    fn update_lockfile_writes_codegen_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("konvoy.lock");
+        let lockfile = Lockfile::default();
+        let konanc = KonancInfo {
+            path: PathBuf::from("/usr/bin/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "abc".to_owned(),
+        };
+        let codegen_locks = vec![CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "codegenhash1".to_owned(),
+        }];
+
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        update_lockfile_if_needed(
+            &lockfile,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &[],
+            &codegen_locks,
+            tmp.path(),
+            &lockfile_path,
+            false,
+            false,
+        )
+        .unwrap();
+
+        let reparsed = Lockfile::from_path(&lockfile_path).unwrap();
+        assert_eq!(reparsed.codegen_tools.len(), 1);
+        let tool = reparsed.codegen_tools.first().unwrap();
+        assert_eq!(tool.name, "fabrikt");
+        assert_eq!(tool.version, "1.2.3");
+        assert_eq!(tool.sha256, "codegenhash1");
+    }
+
+    /// A codegen pin that differs from the lockfile, under `--locked`, must fail
+    /// (the lockfile may not be rewritten in locked mode) — mirroring plugins.
+    #[test]
+    fn update_lockfile_locked_mode_codegen_change_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("konvoy.lock");
+        let mut lf = Lockfile::with_toolchain("2.1.0");
+        lf.codegen_tools.push(CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "oldhash".to_owned(),
+        });
+        lf.write_to(&lockfile_path).unwrap();
+
+        let konanc = KonancInfo {
+            path: PathBuf::from("/usr/bin/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "abc".to_owned(),
+        };
+        // Same tool + version, different sha → a change the locked build must reject.
+        let new_codegen_locks = vec![CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "newhash".to_owned(),
+        }];
+
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        let result = update_lockfile_if_needed(
+            &lf,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &[],
+            &new_codegen_locks,
+            tmp.path(),
+            &lockfile_path,
+            false,
+            true, // locked = true
+        );
+
+        match result {
+            Err(EngineError::LockfileUpdateRequired) => {}
+            other => panic!("expected LockfileUpdateRequired, got {other:?}"),
+        }
+    }
+
+    /// Matching codegen pins (and nothing else changed) → no rewrite, no error,
+    /// and the existing `[[codegen_tools]]` survive untouched.
+    #[test]
+    fn update_lockfile_noop_when_codegen_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("konvoy.lock");
+        let mut lf = Lockfile::with_toolchain("2.1.0");
+        lf.codegen_tools.push(CodegenToolLock {
+            name: "fabrikt".to_owned(),
+            version: "1.2.3".to_owned(),
+            sha256: "stable".to_owned(),
+        });
+        lf.write_to(&lockfile_path).unwrap();
+
+        let konanc = KonancInfo {
+            path: PathBuf::from("/usr/bin/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "abc".to_owned(),
+        };
+        let same = lf.codegen_tools.clone();
+
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        update_lockfile_if_needed(
+            &lf,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &[],
+            &same,
+            tmp.path(),
+            &lockfile_path,
+            false,
+            false,
+        )
+        .unwrap();
+
+        let reparsed = Lockfile::from_path(&lockfile_path).unwrap();
+        assert_eq!(reparsed.codegen_tools, same);
     }
 
     #[test]
@@ -3420,6 +3708,7 @@ linux_x64 = "1111"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -3478,6 +3767,7 @@ linux_x64 = "1111"
             None,
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,
@@ -3568,6 +3858,7 @@ linux_x64 = "1111"
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -3622,6 +3913,7 @@ linux_x64 = "1111"
             None,
             &graph,
             &plugin_locks,
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -4018,6 +4310,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
 
         let key_no_plugins = CacheKey::compute(&make_inputs(content_no_plugins)).unwrap();
@@ -4069,6 +4362,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
 
         let key_v1 = CacheKey::compute(&make_inputs(content_v1)).unwrap();
@@ -4113,6 +4407,7 @@ url = "https://example.com/plugin.jar"
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -4211,6 +4506,7 @@ url = "https://example.com/plugin.jar"
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         };
         let key = CacheKey::compute(&inputs).unwrap();
         assert_eq!(
@@ -4341,6 +4637,7 @@ url = "https://example.com/plugin.jar"
             None,
             &empty_graph,
             &plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -4426,6 +4723,7 @@ kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-comp
             None,
             &empty_graph,
             &new_plugin_locks,
+            &[],
             dir.path(),
             &lockfile_path,
             false,
@@ -4835,6 +5133,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false,
@@ -4864,6 +5163,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             None,
             &empty_graph,
             &[],
+            &[],
             tmp.path(),
             &lockfile_path,
             false, // not force
@@ -4892,6 +5192,7 @@ compose = { maven = "org.jetbrains.compose.compiler:compiler", version = "1.5.0"
             Some("different-hash"),
             None,
             &empty_graph,
+            &[],
             &[],
             tmp.path(),
             &lockfile_path,

--- a/crates/konvoy-engine/src/cache.rs
+++ b/crates/konvoy-engine/src/cache.rs
@@ -33,6 +33,10 @@ pub struct CacheInputs {
     pub arch: String,
     /// SHA-256 hashes of dependency `.klib` files (empty for projects with no deps).
     pub dependency_hashes: Vec<String>,
+    /// Tagged (`name:hash`) per-generator codegen hashes — folds each generator's
+    /// config + input files into the key so a spec/config change rebuilds. Empty for
+    /// projects with no `[codegen]` config (leaving the key unchanged for them).
+    pub codegen_hashes: Vec<String>,
 }
 
 /// A content-addressed cache key wrapping a SHA-256 hex string.
@@ -65,6 +69,13 @@ impl CacheKey {
         ];
         // Include dependency hashes so cache key changes when deps are rebuilt.
         for h in &inputs.dependency_hashes {
+            parts.push(h);
+        }
+        // Include codegen hashes so a spec/generator-config change rebuilds. These
+        // are `name:hash` (distinct in shape from the bare-SHA dependency hashes),
+        // and the list is empty when no codegen is configured — so projects without
+        // codegen keep their existing cache key.
+        for h in &inputs.codegen_hashes {
             parts.push(h);
         }
 
@@ -111,6 +122,7 @@ mod tests {
             os: "linux".to_owned(),
             arch: "x86_64".to_owned(),
             dependency_hashes: Vec::new(),
+            codegen_hashes: Vec::new(),
         }
     }
 
@@ -177,6 +189,29 @@ mod tests {
         let key2 = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
 
         assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn codegen_hashes_change_key() {
+        // Codegen inputs must participate in the key: adding codegen hashes, and
+        // changing them, both change the key. (Backward compatibility holds by
+        // construction: an empty list folds in nothing, so a non-codegen project's
+        // key stays byte-identical to the pre-codegen format.)
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sources(tmp.path());
+
+        let key_none = CacheKey::compute(&make_inputs(tmp.path())).unwrap();
+
+        let mut inputs_a = make_inputs(tmp.path());
+        inputs_a.codegen_hashes = vec!["openapi:aaaa".to_owned()];
+        let key_a = CacheKey::compute(&inputs_a).unwrap();
+
+        let mut inputs_b = make_inputs(tmp.path());
+        inputs_b.codegen_hashes = vec!["openapi:bbbb".to_owned()];
+        let key_b = CacheKey::compute(&inputs_b).unwrap();
+
+        assert_ne!(key_none, key_a, "adding codegen hashes must change the key");
+        assert_ne!(key_a, key_b, "a different codegen hash must change the key");
     }
 
     #[test]
@@ -435,6 +470,7 @@ mod tests {
                             os,
                             arch,
                             dependency_hashes: Vec::new(),
+                            codegen_hashes: Vec::new(),
                         }
                     },
                 )
@@ -467,6 +503,7 @@ mod tests {
                     os: inputs1.os.clone(),
                     arch: inputs1.arch.clone(),
                     dependency_hashes: Vec::new(),
+                    codegen_hashes: Vec::new(),
                 };
 
                 let key1 = CacheKey::compute(&inputs1).unwrap();

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -7,6 +7,7 @@
 //! are assembled into a `&[Box<dyn CodeGenerator>]` by a registry that lives with
 //! the implementations, so adding a generator never touches this file.
 
+use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
 use konvoy_config::lockfile::CodegenToolLock;
@@ -167,15 +168,37 @@ pub fn generator_output_dir(project_root: &Path, name: &str) -> PathBuf {
     project_root.join(".konvoy").join("gen").join(name)
 }
 
-/// Download + SHA-verify every generator's managed tool, returning the resolved
-/// lockfile pins (one per generator, in order).
+/// The managed tools of `generators`, deduplicated by `(id, version)` and in
+/// stable sorted order.
+///
+/// A build graph (root + path-dependencies) may have several generators backed by
+/// the same tool+version — it is content-addressed under `~/.konvoy/tools`, so it
+/// need only be downloaded, verified, and pinned once. Sorting keeps the resulting
+/// lockfile pins deterministic regardless of the order generators were discovered.
+fn unique_codegen_tools(generators: &[Box<dyn CodeGenerator>]) -> Vec<ManagedToolSpec> {
+    let mut unique: BTreeMap<(String, String), ManagedToolSpec> = BTreeMap::new();
+    for generator in generators {
+        let tool = generator.managed_tool();
+        unique
+            .entry((tool.id().to_owned(), tool.version().to_owned()))
+            .or_insert(tool);
+    }
+    unique.into_values().collect()
+}
+
+/// Download + SHA-verify the codegen tools required by `generators`, returning the
+/// resolved lockfile pins — one per **distinct** `(name, version)`, sorted.
+///
+/// `generators` is the whole build graph's set (root + every path-dependency), so
+/// a tool shared across projects is fetched and pinned once (deduped by
+/// `(name, version)`); the returned union is what the build persists into the root
+/// `konvoy.lock`.
 ///
 /// Mirrors the detekt/plugin pattern: the expected SHA is read from `pinned` (by
 /// tool name + version); under `locked` a missing pin is a `LockfileUpdateRequired`
 /// and a not-yet-downloaded tool is a `CodegenToolNotFound`; otherwise the tool is
-/// fetched (or a cached copy re-verified) and its computed SHA returned for the
-/// caller to persist into `konvoy.lock`. This is generator-agnostic — it only uses
-/// the [`ManagedToolSpec`] each generator exposes.
+/// fetched (or a cached copy re-verified) and its computed SHA returned. This is
+/// generator-agnostic — it only uses the [`ManagedToolSpec`] each generator exposes.
 ///
 /// # Errors
 /// Returns an error if a tool can't be downloaded, a pinned hash doesn't match, or
@@ -185,9 +208,9 @@ pub fn ensure_codegen_tools(
     pinned: &[CodegenToolLock],
     locked: bool,
 ) -> Result<Vec<CodegenToolLock>, EngineError> {
-    let mut resolved = Vec::with_capacity(generators.len());
-    for generator in generators {
-        let tool = generator.managed_tool();
+    let tools = unique_codegen_tools(generators);
+    let mut resolved = Vec::with_capacity(tools.len());
+    for tool in tools {
         let (name, version) = (tool.id().to_owned(), tool.version().to_owned());
 
         let expected = pinned
@@ -809,6 +832,22 @@ mod tests {
             }
             other => panic!("expected CodegenToolNotFound, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn unique_codegen_tools_dedupes_by_name_version_and_sorts() {
+        // Across a build graph the same tool can back several generators (e.g. the
+        // root and a path-dep both use openapi/fabrikt); it must be pinned once.
+        // Order is stable (sorted) regardless of discovery order. The fake's tool
+        // id == its generator name and its version is fixed, so equal names collide.
+        let gens = vec![
+            fake("b", &[], &[]),
+            fake("a", &[], &[]),
+            fake("a", &["different-config"], &[]),
+        ];
+        let tools = unique_codegen_tools(&gens);
+        let ids: Vec<&str> = tools.iter().map(|t| t.id()).collect();
+        assert_eq!(ids, vec!["a", "b"], "deduped by (id, version), sorted");
     }
 
     // ---- run_codegen (generation + source collection) -----------------------

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -9,6 +9,7 @@
 
 use std::path::{Component, Path, PathBuf};
 
+use konvoy_config::lockfile::CodegenToolLock;
 use konvoy_config::manifest::Codegen;
 
 use crate::error::EngineError;
@@ -164,6 +165,97 @@ pub fn compute_codegen_hashes(
 #[must_use]
 pub fn generator_output_dir(project_root: &Path, name: &str) -> PathBuf {
     project_root.join(".konvoy").join("gen").join(name)
+}
+
+/// Download + SHA-verify every generator's managed tool, returning the resolved
+/// lockfile pins (one per generator, in order).
+///
+/// Mirrors the detekt/plugin pattern: the expected SHA is read from `pinned` (by
+/// tool name + version); under `locked` a missing pin is a `LockfileUpdateRequired`
+/// and a not-yet-downloaded tool is a `CodegenToolNotFound`; otherwise the tool is
+/// fetched (or a cached copy re-verified) and its computed SHA returned for the
+/// caller to persist into `konvoy.lock`. This is generator-agnostic — it only uses
+/// the [`ManagedToolSpec`] each generator exposes.
+///
+/// # Errors
+/// Returns an error if a tool can't be downloaded, a pinned hash doesn't match, or
+/// `locked` is set but the tool isn't pinned/downloaded.
+pub fn ensure_codegen_tools(
+    generators: &[Box<dyn CodeGenerator>],
+    pinned: &[CodegenToolLock],
+    locked: bool,
+) -> Result<Vec<CodegenToolLock>, EngineError> {
+    let mut resolved = Vec::with_capacity(generators.len());
+    for generator in generators {
+        let tool = generator.managed_tool();
+        let (name, version) = (tool.id().to_owned(), tool.version().to_owned());
+
+        let expected = pinned
+            .iter()
+            .find(|p| p.name == name && p.version == version)
+            .map(|p| p.sha256.as_str());
+
+        if locked {
+            if expected.is_none() {
+                return Err(EngineError::LockfileUpdateRequired);
+            }
+            if !tool.is_installed().map_err(EngineError::from)? {
+                return Err(EngineError::CodegenToolNotFound { name, version });
+            }
+        }
+
+        let (_, sha256) = tool.ensure(expected).map_err(|e| {
+            crate::error::map_artifact_download_err(
+                &name,
+                e,
+                |name, message| EngineError::CodegenDownload {
+                    name,
+                    version: version.clone(),
+                    message,
+                },
+                |name, expected_hash, actual_hash| EngineError::CodegenHashMismatch {
+                    name,
+                    version: version.clone(),
+                    expected: expected_hash,
+                    actual: actual_hash,
+                },
+            )
+        })?;
+
+        resolved.push(CodegenToolLock {
+            name,
+            version,
+            sha256,
+        });
+    }
+    Ok(resolved)
+}
+
+/// Run every generator (on a cache miss), writing sources into its
+/// `.konvoy/gen/<name>/` dir, and return the generated `.kt` files to add to the
+/// compile source set.
+///
+/// The tools must already be downloaded (call [`ensure_codegen_tools`] first).
+/// `jre_home` is forwarded to each generator's tool — required for JVM generators,
+/// ignored by native ones.
+///
+/// # Errors
+/// Returns an error if a generator fails or its output cannot be read.
+pub fn run_codegen(
+    project_root: &Path,
+    generators: &[Box<dyn CodeGenerator>],
+    jre_home: Option<&Path>,
+    verbose: bool,
+) -> Result<Vec<PathBuf>, EngineError> {
+    let mut generated = Vec::new();
+    for generator in generators {
+        let output_dir = generator_output_dir(project_root, generator.name());
+        generator.generate(project_root, &output_dir, jre_home, verbose)?;
+        // Collect the emitted `.kt` (generators may nest them, e.g. Fabrikt writes
+        // under `<output_dir>/src/main/kotlin/`), to feed into compilation.
+        generated.extend(konvoy_util::fs::collect_files(&output_dir, "kt")?);
+    }
+    Ok(generated)
 }
 
 fn compute_generator_hash(
@@ -676,5 +768,183 @@ mod tests {
         );
         assert_eq!(summaries[1].name, "other");
         assert_eq!(managed_tools(&gens).len(), 2);
+    }
+
+    // ---- ensure_codegen_tools (download/pin orchestration) ------------------
+
+    #[test]
+    fn ensure_codegen_tools_empty_is_noop() {
+        // No generators → no pins, in either lock mode, and never touches the net.
+        assert!(ensure_codegen_tools(&[], &[], false).unwrap().is_empty());
+        assert!(ensure_codegen_tools(&[], &[], true).unwrap().is_empty());
+    }
+
+    #[test]
+    fn ensure_codegen_tools_locked_without_pin_requires_update() {
+        // --locked with a generator whose tool isn't pinned must fail loudly
+        // BEFORE any download, so an offline `--locked` build is deterministic.
+        let gens = vec![fake("demo", &["v=1"], &[])];
+        match ensure_codegen_tools(&gens, &[], true) {
+            Err(EngineError::LockfileUpdateRequired) => {}
+            other => panic!("expected LockfileUpdateRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_codegen_tools_locked_with_pin_but_not_installed_errors() {
+        // --locked + a matching pin, but the tool was never downloaded → a
+        // CodegenToolNotFound (downloads are forbidden under --locked). The id
+        // `uninstalled-tool`/`1.0.0` is never present under ~/.konvoy/tools, so
+        // `is_installed()` is deterministically false without env juggling.
+        let gens = vec![fake("uninstalled-tool", &["v=1"], &[])];
+        let pins = vec![CodegenToolLock {
+            name: "uninstalled-tool".to_owned(),
+            version: "1.0.0".to_owned(),
+            sha256: "a".repeat(64),
+        }];
+        match ensure_codegen_tools(&gens, &pins, true) {
+            Err(EngineError::CodegenToolNotFound { name, version }) => {
+                assert_eq!(name, "uninstalled-tool");
+                assert_eq!(version, "1.0.0");
+            }
+            other => panic!("expected CodegenToolNotFound, got {other:?}"),
+        }
+    }
+
+    // ---- run_codegen (generation + source collection) -----------------------
+
+    /// A generator that writes real `.kt` (and a non-`.kt`) into its output dir,
+    /// to exercise `run_codegen`'s recursive `.kt` collection. Nests one file like
+    /// Fabrikt's `src/main/kotlin/` layout.
+    struct WritingGenerator {
+        name: String,
+    }
+    impl CodeGenerator for WritingGenerator {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn display_name(&self) -> &str {
+            &self.name
+        }
+        fn managed_tool(&self) -> ManagedToolSpec {
+            ManagedToolSpec::direct_url(
+                &self.name,
+                &self.name,
+                "1.0.0",
+                "https://example.invalid/x.jar".to_owned(),
+                "x.jar".to_owned(),
+            )
+        }
+        fn config_hash_parts(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn input_files(&self, _project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+            Ok(Vec::new())
+        }
+        fn generate(
+            &self,
+            _project_root: &Path,
+            output_dir: &Path,
+            _jre_home: Option<&Path>,
+            _verbose: bool,
+        ) -> Result<(), EngineError> {
+            let nested = output_dir.join("src").join("main").join("kotlin");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(output_dir.join("Api.kt"), "package x").unwrap();
+            std::fs::write(nested.join("Model.kt"), "package x.m").unwrap();
+            std::fs::write(output_dir.join("README.md"), "not kotlin").unwrap();
+            Ok(())
+        }
+    }
+
+    /// A generator whose `generate` always fails — proves run_codegen propagates.
+    struct FailingGenerator;
+    impl CodeGenerator for FailingGenerator {
+        fn name(&self) -> &str {
+            "boom"
+        }
+        fn display_name(&self) -> &str {
+            "boom"
+        }
+        fn managed_tool(&self) -> ManagedToolSpec {
+            ManagedToolSpec::direct_url(
+                "boom",
+                "boom",
+                "1.0.0",
+                "https://example.invalid/x.jar".to_owned(),
+                "x.jar".to_owned(),
+            )
+        }
+        fn config_hash_parts(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn input_files(&self, _project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
+            Ok(Vec::new())
+        }
+        fn generate(
+            &self,
+            _project_root: &Path,
+            _output_dir: &Path,
+            _jre_home: Option<&Path>,
+            _verbose: bool,
+        ) -> Result<(), EngineError> {
+            Err(EngineError::CodegenFailed {
+                name: "boom".to_owned(),
+                message: "kaboom".to_owned(),
+            })
+        }
+    }
+
+    #[test]
+    fn run_codegen_collects_generated_kt_excluding_non_kt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![Box::new(WritingGenerator {
+            name: "openapi".to_owned(),
+        })];
+        let generated = run_codegen(tmp.path(), &gens, None, false).unwrap();
+
+        // Exactly the two `.kt` files (sorted; `README.md` excluded), under
+        // `.konvoy/gen/openapi/` including the nested one.
+        let out = generator_output_dir(tmp.path(), "openapi");
+        assert_eq!(
+            generated,
+            vec![
+                out.join("Api.kt"),
+                out.join("src").join("main").join("kotlin").join("Model.kt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn run_codegen_runs_every_generator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![
+            Box::new(WritingGenerator {
+                name: "openapi".to_owned(),
+            }),
+            Box::new(WritingGenerator {
+                name: "grpc".to_owned(),
+            }),
+        ];
+        let generated = run_codegen(tmp.path(), &gens, None, false).unwrap();
+
+        // Two `.kt` per generator, each under its own `.konvoy/gen/<name>/` dir.
+        assert_eq!(generated.len(), 4);
+        assert!(generated
+            .iter()
+            .any(|p| p.starts_with(generator_output_dir(tmp.path(), "openapi"))));
+        assert!(generated
+            .iter()
+            .any(|p| p.starts_with(generator_output_dir(tmp.path(), "grpc"))));
+    }
+
+    #[test]
+    fn run_codegen_propagates_generator_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gens: Vec<Box<dyn CodeGenerator>> = vec![Box::new(FailingGenerator)];
+        match run_codegen(tmp.path(), &gens, None, false) {
+            Err(EngineError::CodegenFailed { name, .. }) => assert_eq!(name, "boom"),
+            other => panic!("expected CodegenFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -1,10 +1,12 @@
 //! OpenAPI source generation using Fabrikt.
 
 use std::ffi::OsString;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use konvoy_config::manifest::OpenApiCodegen;
 use konvoy_util::maven::MavenCoordinate;
+use konvoy_util::path::{has_hidden_component_under, relative_to};
+use konvoy_util::text::first_non_blank_line;
 
 use crate::codegen::{CodeGenerator, ManagedToolSpec};
 use crate::error::EngineError;
@@ -161,10 +163,10 @@ impl CodeGenerator for OpenApiGenerator {
     fn input_files(&self, project_root: &Path) -> Result<Vec<PathBuf>, EngineError> {
         // Just collect the inputs — the framework sorts + de-duplicates before
         // hashing, so this need not. Paths are normalized to project-relative form
-        // (via `project_relative`) so the same file referenced two ways (e.g. the
-        // spec written `./specs/api.yaml` and again as a `specs` dir entry) collapses
-        // to one when the framework de-duplicates, and so the cache key is portable.
-        let mut files = vec![project_relative(project_root, Path::new(&self.config.spec))];
+        // (via `relative_to`) so the same file referenced two ways (e.g. the spec
+        // written `./specs/api.yaml` and again as a `specs` dir entry) collapses to
+        // one when the framework de-duplicates, and so the cache key is portable.
+        let mut files = vec![relative_to(project_root, Path::new(&self.config.spec))];
 
         for dir in &self.config.extra_spec_dirs {
             let dir_abs = project_root.join(dir);
@@ -181,10 +183,10 @@ impl CodeGenerator for OpenApiGenerator {
                 // contains it (e.g. extra_spec_dirs = ["."]). These are never spec
                 // input, and folding them in would make the cache key depend on
                 // platform/editor state, breaking deterministic, stable hashing.
-                if has_hidden_component(&dir_abs, &file) {
+                if has_hidden_component_under(&dir_abs, &file) {
                     continue;
                 }
-                files.push(project_relative(project_root, &file));
+                files.push(relative_to(project_root, &file));
             }
         }
 
@@ -241,7 +243,7 @@ impl CodeGenerator for OpenApiGenerator {
             } else {
                 &output.stderr
             };
-            let hint = first_non_empty_line(hint_source)
+            let hint = first_non_blank_line(hint_source)
                 .map(|line| format!(" first message: {line}"))
                 .unwrap_or_default();
             // Only suggest --verbose when it wasn't already on (if it was, capture()
@@ -259,36 +261,6 @@ impl CodeGenerator for OpenApiGenerator {
 
         Ok(())
     }
-}
-
-/// First non-blank line of `output`, trimmed — used to surface a concise hint
-/// from a failed Fabrikt run without dumping its whole log.
-fn first_non_empty_line(output: &str) -> Option<&str> {
-    output.lines().map(str::trim).find(|line| !line.is_empty())
-}
-
-/// Whether `file` (a walk result under `base`) has any path component, below
-/// `base`, that is hidden (starts with `.`). Used to exclude OS/editor/VCS noise
-/// (`.DS_Store`, `.git/`, swap files) and the `.konvoy` output dir from the
-/// codegen input set, keeping the cache key deterministic and platform-stable.
-fn has_hidden_component(base: &Path, file: &Path) -> bool {
-    file.strip_prefix(base)
-        .unwrap_or(file)
-        .components()
-        .any(|c| matches!(c, Component::Normal(name) if name.to_string_lossy().starts_with('.')))
-}
-
-/// Normalize a path to a clean project-relative form for stable, dedup-able
-/// hashing. Absolute inputs (dir-walk results under `project_root`) and relative
-/// inputs (the configured `spec`, possibly written with a leading `./`) both
-/// collapse to the same `specs/api.yaml`-style path. Joining onto `project_root`
-/// then stripping it also drops interior `.` components via `Path::components`.
-fn project_relative(project_root: &Path, path: &Path) -> PathBuf {
-    let joined = project_root.join(path);
-    joined
-        .strip_prefix(project_root)
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -408,17 +380,6 @@ mod tests {
                 "validation_library=NO_VALIDATION".to_owned(),
             ]
         );
-    }
-
-    #[test]
-    fn first_non_empty_line_skips_blanks_and_trims() {
-        assert_eq!(
-            first_non_empty_line("\n   \n  hello world \nmore"),
-            Some("hello world")
-        );
-        assert_eq!(first_non_empty_line("first\nsecond"), Some("first"));
-        assert_eq!(first_non_empty_line("   \n\t\n  "), None);
-        assert_eq!(first_non_empty_line(""), None);
     }
 
     #[test]

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -140,6 +140,10 @@ pub enum EngineError {
     #[error("codegen spec directory for `{name}` not found at {path} — create the directory or fix `extra_spec_dirs` in [codegen.{name}]")]
     CodegenInputDirNotFound { name: String, path: String },
 
+    /// A codegen tool is not downloaded and `--locked` prevents downloading it.
+    #[error("codegen tool `{name}` {version} is not downloaded and --locked prevents downloads — run `konvoy build` (or `konvoy generate`) without --locked first")]
+    CodegenToolNotFound { name: String, version: String },
+
     /// A codegen tool download failed.
     #[error("cannot download codegen tool `{name}` {version}: {message}")]
     CodegenDownload {

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -66,6 +66,13 @@ pub fn build_tests(
         .collect();
     sources.extend(test_sources);
 
+    // Codegen for the root project, derived from its own manifest (identical to
+    // `build_single`): the tags feed the cache key, the generators run on a miss.
+    // Tools were ensured graph-wide in `resolve_build_context`. Path-deps generate
+    // when they are built as dependencies; here we only handle the root's sources.
+    let generators = crate::codegen::active_generators(&ctx.manifest.codegen);
+    let codegen_hashes = crate::codegen::compute_codegen_hashes(project_root, &generators)?;
+
     // Compute cache key. The test-binary build must produce a distinct cache
     // key from a regular build of the same source tree, so we tag the lockfile
     // content with a "test" marker (the lockfile_content is already a free-form
@@ -92,7 +99,7 @@ pub fn build_tests(
             .collect::<Result<Vec<_>, _>>()?,
         // Codegen inputs (shared with the regular build) — a spec/config change
         // rebuilds the test binary too. Empty when no `[codegen]` is configured.
-        codegen_hashes: ctx.codegen_hashes.clone(),
+        codegen_hashes,
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -116,12 +123,13 @@ pub fn build_tests(
         });
     }
 
-    // Cache miss: run code generators (tools were ensured in resolve_build_context)
-    // and add the emitted `.kt` to the source set so generated code is tested too.
-    if !ctx.generators.is_empty() {
+    // Cache miss: run the root's code generators (tools were ensured in
+    // resolve_build_context) and add the emitted `.kt` to the source set so
+    // generated code is compiled into the test binary too.
+    if !generators.is_empty() {
         let generated = crate::codegen::run_codegen(
             project_root,
-            &ctx.generators,
+            &generators,
             ctx.jre_home.as_deref(),
             options.verbose,
         )?;

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -90,6 +90,9 @@ pub fn build_tests(
                 None => konvoy_util::hash::sha256_file(&lib.path).map_err(EngineError::from),
             })
             .collect::<Result<Vec<_>, _>>()?,
+        // Codegen inputs (shared with the regular build) — a spec/config change
+        // rebuilds the test binary too. Empty when no `[codegen]` is configured.
+        codegen_hashes: ctx.codegen_hashes.clone(),
     };
     let cache_key = CacheKey::compute(&cache_inputs)?;
 
@@ -111,6 +114,18 @@ pub fn build_tests(
             output_path,
             compile_duration: start.elapsed(),
         });
+    }
+
+    // Cache miss: run code generators (tools were ensured in resolve_build_context)
+    // and add the emitted `.kt` to the source set so generated code is tested too.
+    if !ctx.generators.is_empty() {
+        let generated = crate::codegen::run_codegen(
+            project_root,
+            &ctx.generators,
+            ctx.jre_home.as_deref(),
+            options.verbose,
+        )?;
+        sources.extend(generated);
     }
 
     // Compile with test runner generation.

--- a/crates/konvoy-util/src/lib.rs
+++ b/crates/konvoy-util/src/lib.rs
@@ -10,8 +10,10 @@ pub mod maven;
 pub mod metadata;
 pub mod module_metadata;
 pub mod naming;
+pub mod path;
 pub mod pom;
 pub mod progress;
+pub mod text;
 
 #[cfg(test)]
 pub(crate) mod test_util;

--- a/crates/konvoy-util/src/path.rs
+++ b/crates/konvoy-util/src/path.rs
@@ -1,0 +1,110 @@
+//! Pure path-manipulation helpers (no filesystem I/O), shared across crates.
+//!
+//! These operate purely on the lexical structure of paths and never touch the
+//! filesystem, so their results stay deterministic and portable across machines.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Express `path` relative to `base`, in clean normalized form.
+///
+/// Both an absolute `path` under `base` and a `path` already relative to `base`
+/// (possibly written with a leading `./`) collapse to the same
+/// `specs/api.yaml`-style result: `path` is joined onto `base` and then the
+/// `base` prefix is stripped, which also drops interior `.` components via
+/// [`Path::components`]. A `path` that is absolute but *not* under `base` has no
+/// common prefix to strip and is returned unchanged (a caller that requires
+/// containment is expected to detect that, not have it silently rebased).
+#[must_use]
+pub fn relative_to(base: &Path, path: &Path) -> PathBuf {
+    let joined = base.join(path);
+    joined
+        .strip_prefix(base)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Whether `path` has any component, *below* `base`, whose name is hidden (starts
+/// with `.`).
+///
+/// `base` is stripped first, so a hidden segment in `base` itself does not count —
+/// only components below it. Useful for excluding OS/editor/VCS noise
+/// (`.DS_Store`, `.git/`, swap files) and dotted output dirs (e.g. `.konvoy`) when
+/// walking a directory. Purely lexical — no filesystem access.
+#[must_use]
+pub fn has_hidden_component_under(base: &Path, path: &Path) -> bool {
+    path.strip_prefix(base)
+        .unwrap_or(path)
+        .components()
+        .any(|c| matches!(c, Component::Normal(name) if name.to_string_lossy().starts_with('.')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_to_strips_base_from_absolute_paths_under_it() {
+        assert_eq!(
+            relative_to(Path::new("/proj"), Path::new("/proj/specs/api.yaml")),
+            PathBuf::from("specs/api.yaml")
+        );
+    }
+
+    #[test]
+    fn relative_to_normalizes_relative_spellings_to_one_form() {
+        let base = Path::new("/proj");
+        // A leading `./`, the bare relative path, and the absolute-under-base form
+        // all collapse to the same result — so callers can de-duplicate them.
+        assert_eq!(
+            relative_to(base, Path::new("./specs/api.yaml")),
+            PathBuf::from("specs/api.yaml")
+        );
+        assert_eq!(
+            relative_to(base, Path::new("specs/api.yaml")),
+            relative_to(base, Path::new("/proj/specs/api.yaml"))
+        );
+    }
+
+    #[test]
+    fn relative_to_returns_absolute_outside_base_unchanged() {
+        assert_eq!(
+            relative_to(Path::new("/proj"), Path::new("/etc/passwd")),
+            PathBuf::from("/etc/passwd")
+        );
+    }
+
+    #[test]
+    fn has_hidden_component_under_detects_dotfiles_below_base() {
+        let base = Path::new("/proj/specs");
+        assert!(has_hidden_component_under(
+            base,
+            Path::new("/proj/specs/.DS_Store")
+        ));
+        assert!(has_hidden_component_under(
+            base,
+            Path::new("/proj/specs/.git/HEAD")
+        ));
+        assert!(has_hidden_component_under(
+            base,
+            Path::new("/proj/specs/nested/.cache/x.yaml")
+        ));
+    }
+
+    #[test]
+    fn has_hidden_component_under_ignores_visible_paths_and_hidden_base() {
+        let base = Path::new("/proj/specs");
+        assert!(!has_hidden_component_under(
+            base,
+            Path::new("/proj/specs/api.yaml")
+        ));
+        assert!(!has_hidden_component_under(
+            base,
+            Path::new("/proj/specs/nested/pet.yaml")
+        ));
+        // A dotted segment in `base` itself must NOT count — only components below it.
+        assert!(!has_hidden_component_under(
+            Path::new("/proj/.hidden"),
+            Path::new("/proj/.hidden/api.yaml")
+        ));
+    }
+}

--- a/crates/konvoy-util/src/text.rs
+++ b/crates/konvoy-util/src/text.rs
@@ -1,0 +1,32 @@
+//! Small text helpers shared across crates.
+
+/// The first non-blank line of `text`, trimmed — or `None` if every line is blank
+/// (or `text` is empty).
+///
+/// Handy for surfacing a concise one-line hint from a tool's captured output
+/// without dumping the whole log: leading blank lines are skipped and the chosen
+/// line's surrounding whitespace is trimmed.
+#[must_use]
+pub fn first_non_blank_line(text: &str) -> Option<&str> {
+    text.lines().map(str::trim).find(|line| !line.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_leading_blanks_and_trims_the_chosen_line() {
+        assert_eq!(
+            first_non_blank_line("\n   \n  hello world \nmore"),
+            Some("hello world")
+        );
+        assert_eq!(first_non_blank_line("first\nsecond"), Some("first"));
+    }
+
+    #[test]
+    fn none_when_all_blank_or_empty() {
+        assert_eq!(first_non_blank_line("   \n\t\n  "), None);
+        assert_eq!(first_non_blank_line(""), None);
+    }
+}


### PR DESCRIPTION
**Stacked on #292** (base = `codegen/03-build-integration`). Review/merge #292 first; this PR's diff is just the path-dependency support (one commit). I'll retarget it to `main` once #292 lands.

Extends codegen from **root-only** to the whole build graph — the way the root lock already aggregates the graph's Maven deps. This is the "B1" approach we settled on (aggregate pins in the root lock, deduped union; apply per-project).

## What changes

- **`build_single` is now uniform.** Every project — root *and* each path-dep — derives its generators from *its own* manifest, computes its own `codegen_hashes` for its cache key, and runs them on a cache miss. Removes the root-only special-casing (the codegen fields on `CompileContext` / `ResolvedBuildContext` go away).
- **Tools are pinned graph-wide in the root lock.** `resolve_build_context` resolves the dependency graph up front, then ensures the **deduped union** of every codegen tool across root + all path-deps. Tools are content-addressed by `(name, version)`, so a tool shared across projects is downloaded, verified, and pinned **once**. The union is folded into the pre-stabilized lockfile (cache key stable from the first build, [#133](https://github.com/arncore/konvoy/issues/133) class) and written to the root `konvoy.lock`. No dependency checkouts are mutated.
- **`ensure_codegen_tools`** now takes the graph-wide generator set and returns the sorted, deduped pin union (new private `unique_codegen_tools` helper, sorted via `BTreeMap` for determinism). `--locked` enforcement unchanged.

## Why this is correct

- A path-dep declaring `[codegen]` previously got empty generators and **wouldn't compile** (missing generated types). Now it generates as part of being built.
- A dep keys off the root `lockfile_content` (which now holds the union), so it over-invalidates if any project's tool version changes — safe, and consistent with how deps already rebuild on root-toolchain/plugin changes.
- Multiple tool *versions* across the graph are recorded as distinct pins, **not** surfaced as a conflict — generator tools aren't linked into any artifact (unlike Maven libraries).

## Tests

`unique_codegen_tools` dedup + sort. `--locked` / `run_codegen` coverage carries over from #292. End-to-end dep generation + union pinning needs a real build (tool download + konanc) → smoke-test territory in the next PR.

## Gates

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS=-D warnings cargo doc` — all pass.

## Related

- The analogous **plugin** gap (path-deps get no `-Xplugin`) is tracked separately in #293 — same fix shape, deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)