### PR TITLE
NetworkClient: single construct owns all outbound HTTP; --offline enforced at the wire (#295)

### DIFF
--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -130,6 +130,12 @@ enum ToolchainAction {
 fn main() {
     let cli = Cli::parse();
 
+    // The single outbound-HTTP funnel for the whole process: constructed once
+    // here at the program entry point and threaded into every command that may
+    // fetch. Always online for now; the --offline flag (#295) will feed this
+    // constructor when it lands.
+    let net = konvoy_util::net::NetworkClient::new(false);
+
     let result = match cli.command {
         Command::Init { name, lib } => cmd_init(name, lib),
         Command::Build {
@@ -138,7 +144,14 @@ fn main() {
             verbose,
             force,
             locked,
-        } => cmd_build(target, profile_from_flag(release), verbose, force, locked),
+        } => cmd_build(
+            target,
+            profile_from_flag(release),
+            verbose,
+            force,
+            locked,
+            &net,
+        ),
         Command::Run {
             target,
             release,
@@ -153,6 +166,7 @@ fn main() {
             force,
             locked,
             &args,
+            &net,
         ),
         Command::Test {
             target,
@@ -168,16 +182,17 @@ fn main() {
             force,
             locked,
             &filter,
+            &net,
         ),
         Command::Lint {
             verbose,
             config,
             locked,
-        } => cmd_lint(verbose, config, locked),
-        Command::Update => cmd_update(),
+        } => cmd_lint(verbose, config, locked, &net),
+        Command::Update => cmd_update(&net),
         Command::Clean { all } => cmd_clean(all),
         Command::Doctor => cmd_doctor(),
-        Command::Toolchain { action } => cmd_toolchain(action),
+        Command::Toolchain { action } => cmd_toolchain(action, &net),
     };
 
     if let Err(msg) = result {
@@ -270,11 +285,12 @@ fn cmd_build(
     verbose: bool,
     force: bool,
     locked: bool,
+    net: &konvoy_util::net::NetworkClient,
 ) -> CliResult {
     let root = project_root()?;
     let options = build_options(target, profile, verbose, force, locked);
 
-    let result = konvoy_engine::build(&root, &options)?;
+    let result = konvoy_engine::build(&root, &options, net)?;
 
     match result.outcome {
         konvoy_engine::BuildOutcome::Cached => {
@@ -301,6 +317,7 @@ fn cmd_run(
     force: bool,
     locked: bool,
     args: &[String],
+    net: &konvoy_util::net::NetworkClient,
 ) -> CliResult {
     let root = project_root()?;
 
@@ -315,7 +332,7 @@ fn cmd_run(
 
     let options = build_options(target, profile, verbose, force, locked);
 
-    let result = konvoy_engine::build(&root, &options)?;
+    let result = konvoy_engine::build(&root, &options, net)?;
 
     eprintln!(
         "    Finished `{profile}` target in {:.2}s",
@@ -343,11 +360,12 @@ fn cmd_test(
     force: bool,
     locked: bool,
     filter: &Option<String>,
+    net: &konvoy_util::net::NetworkClient,
 ) -> CliResult {
     let root = project_root()?;
     let options = build_options(target, profile, verbose, force, locked);
 
-    let result = konvoy_engine::build_tests(&root, &options)?;
+    let result = konvoy_engine::build_tests(&root, &options, net)?;
 
     eprintln!(
         "    Finished `{profile}` test target in {:.2}s",
@@ -372,7 +390,12 @@ fn cmd_test(
     Ok(())
 }
 
-fn cmd_lint(verbose: bool, config: Option<PathBuf>, locked: bool) -> CliResult {
+fn cmd_lint(
+    verbose: bool,
+    config: Option<PathBuf>,
+    locked: bool,
+    net: &konvoy_util::net::NetworkClient,
+) -> CliResult {
     let root = project_root()?;
     let options = konvoy_engine::LintOptions {
         verbose,
@@ -380,7 +403,7 @@ fn cmd_lint(verbose: bool, config: Option<PathBuf>, locked: bool) -> CliResult {
         locked,
     };
 
-    let result = konvoy_engine::lint(&root, &options)?;
+    let result = konvoy_engine::lint(&root, &options, net)?;
 
     if result.success {
         eprintln!("    No lint issues found");
@@ -400,10 +423,10 @@ fn cmd_lint(verbose: bool, config: Option<PathBuf>, locked: bool) -> CliResult {
     Err(format!("lint found {} issue(s)", result.finding_count).into())
 }
 
-fn cmd_update() -> CliResult {
+fn cmd_update(net: &konvoy_util::net::NetworkClient) -> CliResult {
     let root = project_root()?;
     // `konvoy update` is inherently online — resolving fetches POMs/klibs.
-    let result = konvoy_engine::update(&root, &konvoy_util::net::NetworkClient::new(false))?;
+    let result = konvoy_engine::update(&root, net)?;
     eprintln!(
         "  Updated {} dependencies in konvoy.lock",
         result.updated_count
@@ -604,7 +627,7 @@ fn cmd_doctor() -> CliResult {
     }
 }
 
-fn cmd_toolchain(action: ToolchainAction) -> CliResult {
+fn cmd_toolchain(action: ToolchainAction, net: &konvoy_util::net::NetworkClient) -> CliResult {
     match action {
         ToolchainAction::Install { version } => {
             let version = if let Some(v) = version {
@@ -627,10 +650,7 @@ fn cmd_toolchain(action: ToolchainAction) -> CliResult {
             }
 
             eprintln!("    Installing Kotlin/Native {version}...");
-            let result = konvoy_konanc::toolchain::install(
-                &version,
-                &konvoy_util::net::NetworkClient::new(false),
-            )?;
+            let result = konvoy_konanc::toolchain::install(&version, net)?;
             eprintln!(
                 "    Installed Kotlin/Native {version} at {}",
                 result.konanc_path.display()

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -402,7 +402,8 @@ fn cmd_lint(verbose: bool, config: Option<PathBuf>, locked: bool) -> CliResult {
 
 fn cmd_update() -> CliResult {
     let root = project_root()?;
-    let result = konvoy_engine::update(&root)?;
+    // `konvoy update` is inherently online — resolving fetches POMs/klibs.
+    let result = konvoy_engine::update(&root, &konvoy_util::net::NetworkClient::new(false))?;
     eprintln!(
         "  Updated {} dependencies in konvoy.lock",
         result.updated_count
@@ -626,7 +627,10 @@ fn cmd_toolchain(action: ToolchainAction) -> CliResult {
             }
 
             eprintln!("    Installing Kotlin/Native {version}...");
-            let result = konvoy_konanc::toolchain::install(&version)?;
+            let result = konvoy_konanc::toolchain::install(
+                &version,
+                &konvoy_util::net::NetworkClient::new(false),
+            )?;
             eprintln!(
                 "    Installed Kotlin/Native {version} at {}",
                 result.konanc_path.display()

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -239,12 +239,17 @@ pub(crate) fn resolve_build_context(
     let lockfile_path = project_root.join("konvoy.lock");
     let lockfile = Lockfile::from_path(&lockfile_path)?;
 
+    // One client per build, threaded to everything that may fetch — the single
+    // funnel for outbound HTTP (see konvoy_util::net). Always online for now;
+    // the --offline flag (#295) will feed this constructor when it lands.
+    let net = konvoy_util::net::NetworkClient::new(false);
+
     // 3. Auto-resolve Maven deps if needed (unless --locked).
     //    When the manifest declares Maven deps that aren't in the lockfile,
     //    run `konvoy update` automatically so users don't have to.
     let lockfile = if !options.locked && has_unresolved_maven_deps(&manifest, &lockfile) {
         eprintln!("  Maven dependencies not resolved \u{2014} running update automatically...");
-        crate::update::update(project_root)?;
+        crate::update::update(project_root, &net)?;
         // Re-read the lockfile after update wrote it.
         Lockfile::from_path(&lockfile_path)?
     } else {
@@ -269,7 +274,7 @@ pub(crate) fn resolve_build_context(
             version: manifest.toolchain.kotlin,
         });
     }
-    let resolved = resolve_konanc(&manifest.toolchain.kotlin)?;
+    let resolved = resolve_konanc(&manifest.toolchain.kotlin, &net)?;
     let konanc = resolved.info;
     let jre_home = resolved.jre_home;
     let konanc_tarball_sha256 = resolved.konanc_tarball_sha256;
@@ -297,8 +302,12 @@ pub(crate) fn resolve_build_context(
     // `ensure_plugin_artifacts` only re-verifies hashes — it does not download.
     let (plugin_jars, plugin_locks) = if !manifest.plugins.is_empty() {
         let resolved_artifacts = crate::plugin::resolve_plugin_artifacts(&manifest)?;
-        let results =
-            crate::plugin::ensure_plugin_artifacts(&resolved_artifacts, &lockfile, options.locked)?;
+        let results = crate::plugin::ensure_plugin_artifacts(
+            &resolved_artifacts,
+            &lockfile,
+            options.locked,
+            &net,
+        )?;
         let locks = crate::plugin::build_plugin_locks(&results);
         let jars: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
         (jars, locks)
@@ -371,7 +380,7 @@ pub(crate) fn resolve_build_context(
     // 7a. Resolve and download Maven dependency klibs for the current target.
     //     Each Maven klib comes back with a precomputed sha256 from
     //     `download_artifact`, which the cache-key code reuses to skip rehashing.
-    let maven_klibs = resolve_maven_deps(&effective_lockfile, &target)?;
+    let maven_klibs = resolve_maven_deps(&effective_lockfile, &target, &net)?;
     library_inputs.extend(maven_klibs);
 
     let store = ArtifactStore::new(project_root);
@@ -793,6 +802,7 @@ struct PreparedKlib<'a> {
 pub(crate) fn resolve_maven_deps(
     lockfile: &Lockfile,
     target: &Target,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<Vec<LibraryInput>, EngineError> {
     use rayon::prelude::IndexedParallelIterator;
 
@@ -892,7 +902,7 @@ pub(crate) fn resolve_maven_deps(
     let klib_inputs: Vec<Result<LibraryInput, EngineError>> = prepared
         .par_iter()
         .zip(aligned_bars.par_iter())
-        .map(|(p, maybe_bar)| download_one_klib(p, *maybe_bar))
+        .map(|(p, maybe_bar)| download_one_klib(p, *maybe_bar, net))
         .collect();
 
     // Trailing newline only if we actually rendered any bars.
@@ -909,9 +919,11 @@ pub(crate) fn resolve_maven_deps(
 fn download_one_klib(
     p: &PreparedKlib<'_>,
     maybe_bar: Option<&konvoy_util::progress::DownloadBar>,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<LibraryInput, EngineError> {
     let dep_name = p.entry.name.to_owned();
     let result = konvoy_util::progress::fetch(
+        net,
         &p.url,
         &p.dest,
         Some(p.expected_sha256),
@@ -3129,7 +3141,12 @@ mod tests {
         let lockfile = Lockfile::with_toolchain("2.1.0");
         let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
 
-        let result = resolve_maven_deps(&lockfile, &target).unwrap();
+        let result = resolve_maven_deps(
+            &lockfile,
+            &target,
+            &konvoy_util::net::NetworkClient::new(false),
+        )
+        .unwrap();
         assert!(
             result.is_empty(),
             "expected empty vec for path-only deps, got: {result:?}"
@@ -3143,7 +3160,12 @@ mod tests {
         let lockfile = Lockfile::with_toolchain("2.1.0");
         let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
 
-        let result = resolve_maven_deps(&lockfile, &target).unwrap();
+        let result = resolve_maven_deps(
+            &lockfile,
+            &target,
+            &konvoy_util::net::NetworkClient::new(false),
+        )
+        .unwrap();
         assert!(
             result.is_empty(),
             "expected empty vec when lockfile has no Maven entries, got: {result:?}"
@@ -3167,7 +3189,11 @@ mod tests {
         });
         let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
 
-        let result = resolve_maven_deps(&lockfile, &target);
+        let result = resolve_maven_deps(
+            &lockfile,
+            &target,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3309,7 +3335,11 @@ linux_x64 = "1111"
         });
         let target: konvoy_targets::Target = "linux_x64".parse().unwrap();
 
-        let result = resolve_maven_deps(&lockfile, &target);
+        let result = resolve_maven_deps(
+            &lockfile,
+            &target,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -230,6 +230,7 @@ fn predicted_effective_lockfile(
 pub(crate) fn resolve_build_context(
     project_root: &Path,
     options: &BuildOptions,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<ResolvedBuildContext, EngineError> {
     // 1. Read konvoy.toml.
     let manifest_path = project_root.join("konvoy.toml");
@@ -239,17 +240,16 @@ pub(crate) fn resolve_build_context(
     let lockfile_path = project_root.join("konvoy.lock");
     let lockfile = Lockfile::from_path(&lockfile_path)?;
 
-    // One client per build, threaded to everything that may fetch — the single
-    // funnel for outbound HTTP (see konvoy_util::net). Always online for now;
-    // the --offline flag (#295) will feed this constructor when it lands.
-    let net = konvoy_util::net::NetworkClient::new(false);
+    // `net` is the process-wide outbound-HTTP funnel, constructed once at the
+    // program entry point and threaded in here (see konvoy_util::net) — every
+    // fetch below routes through it.
 
     // 3. Auto-resolve Maven deps if needed (unless --locked).
     //    When the manifest declares Maven deps that aren't in the lockfile,
     //    run `konvoy update` automatically so users don't have to.
     let lockfile = if !options.locked && has_unresolved_maven_deps(&manifest, &lockfile) {
         eprintln!("  Maven dependencies not resolved \u{2014} running update automatically...");
-        crate::update::update(project_root, &net)?;
+        crate::update::update(project_root, net)?;
         // Re-read the lockfile after update wrote it.
         Lockfile::from_path(&lockfile_path)?
     } else {
@@ -274,7 +274,7 @@ pub(crate) fn resolve_build_context(
             version: manifest.toolchain.kotlin,
         });
     }
-    let resolved = resolve_konanc(&manifest.toolchain.kotlin, &net)?;
+    let resolved = resolve_konanc(&manifest.toolchain.kotlin, net)?;
     let konanc = resolved.info;
     let jre_home = resolved.jre_home;
     let konanc_tarball_sha256 = resolved.konanc_tarball_sha256;
@@ -306,7 +306,7 @@ pub(crate) fn resolve_build_context(
             &resolved_artifacts,
             &lockfile,
             options.locked,
-            &net,
+            net,
         )?;
         let locks = crate::plugin::build_plugin_locks(&results);
         let jars: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
@@ -380,7 +380,7 @@ pub(crate) fn resolve_build_context(
     // 7a. Resolve and download Maven dependency klibs for the current target.
     //     Each Maven klib comes back with a precomputed sha256 from
     //     `download_artifact`, which the cache-key code reuses to skip rehashing.
-    let maven_klibs = resolve_maven_deps(&effective_lockfile, &target, &net)?;
+    let maven_klibs = resolve_maven_deps(&effective_lockfile, &target, net)?;
     library_inputs.extend(maven_klibs);
 
     let store = ArtifactStore::new(project_root);
@@ -423,9 +423,13 @@ pub(crate) fn resolve_build_context(
 /// # Errors
 /// Returns an error if any step fails (config parsing, compiler detection,
 /// compilation failure, filesystem errors, etc.).
-pub fn build(project_root: &Path, options: &BuildOptions) -> Result<BuildResult, EngineError> {
+pub fn build(
+    project_root: &Path,
+    options: &BuildOptions,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<BuildResult, EngineError> {
     let start = Instant::now();
-    let ctx = resolve_build_context(project_root, options)?;
+    let ctx = resolve_build_context(project_root, options, net)?;
 
     // 8. Build the root project.
     let cc = CompileContext {
@@ -1270,7 +1274,11 @@ mod tests {
             force: false,
             locked: false,
         };
-        let result = build(tmp.path(), &options);
+        let result = build(
+            tmp.path(),
+            &options,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
     }
 
@@ -1302,6 +1310,7 @@ mod tests {
                 force: false,
                 locked: true,
             },
+            &konvoy_util::net::NetworkClient::new(false),
         );
 
         assert!(result.is_err(), "expected Err, got: {result:?}");
@@ -1335,7 +1344,11 @@ mod tests {
             force: false,
             locked: false,
         };
-        let result = build(&project, &options);
+        let result = build(
+            &project,
+            &options,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(

--- a/crates/konvoy-engine/src/codegen/openapi.rs
+++ b/crates/konvoy-engine/src/codegen/openapi.rs
@@ -82,6 +82,7 @@ pub fn is_installed(version: &str) -> Result<bool, EngineError> {
 pub fn ensure_fabrikt(
     version: &str,
     expected_sha256: Option<&str>,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<(PathBuf, String), EngineError> {
     // Pre-validate for an actionable, Fabrikt-specific message; the shared tool
     // also validates, but its raw error would map to a generic one. Use the same
@@ -96,7 +97,7 @@ pub fn ensure_fabrikt(
         ),
     })?;
     fabrikt_tool(version)
-        .ensure(expected_sha256)
+        .ensure(expected_sha256, net)
         .map_err(|e| map_fabrikt_download_err(version, e))
 }
 

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -109,6 +109,7 @@ pub fn is_installed(version: &str) -> Result<bool, EngineError> {
 pub fn ensure_detekt(
     version: &str,
     expected_sha256: Option<&str>,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<(PathBuf, String), EngineError> {
     // Use the same `validate_identifier` the spec uses (it rejects `..`), so a
     // traversal-laden version yields this actionable, detekt-branded message
@@ -121,7 +122,7 @@ pub fn ensure_detekt(
     })?;
 
     detekt_tool(version)
-        .ensure(expected_sha256)
+        .ensure(expected_sha256, net)
         .map_err(|e| map_download_err(version, e))
 }
 
@@ -176,7 +177,11 @@ fn persist_detekt_hash(
 /// `--locked` forbids downloads, so a missing toolchain is an error. The actual
 /// `java` invocation is delegated to [`ManagedToolSpec::run`], which derives the
 /// binary from this home.
-fn resolve_jre_home(kotlin_version: &str, locked: bool) -> Result<PathBuf, EngineError> {
+fn resolve_jre_home(
+    kotlin_version: &str,
+    locked: bool,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<PathBuf, EngineError> {
     if !konvoy_konanc::toolchain::is_installed(kotlin_version)? {
         if locked {
             return Err(EngineError::DetektJreLocked {
@@ -184,7 +189,7 @@ fn resolve_jre_home(kotlin_version: &str, locked: bool) -> Result<PathBuf, Engin
             });
         }
         eprintln!("    Installing Kotlin/Native {kotlin_version} (for JRE)...");
-        konvoy_konanc::toolchain::install(kotlin_version)?;
+        konvoy_konanc::toolchain::install(kotlin_version, net)?;
     }
 
     let jre_home = konvoy_konanc::toolchain::jre_home_path(kotlin_version)?;
@@ -283,6 +288,12 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     // Read lockfile and resolve expected hash.
     let lockfile_path = root.join("konvoy.lock");
     let lockfile = konvoy_config::lockfile::Lockfile::from_path(&lockfile_path)?;
+
+    // One client per lint invocation — the single funnel for the detekt JAR
+    // and JRE downloads below. Always online for now; --offline (#295) will
+    // feed this constructor when it lands.
+    let net = konvoy_util::net::NetworkClient::new(false);
+
     let expected_hash = resolve_lockfile_hash(&lockfile, detekt_version);
 
     // In --locked mode, require pinned hash and pre-downloaded JAR.
@@ -300,7 +311,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
 
     // Ensure detekt jar is available and hash-verified. The path is derived again
     // (from the same spec) inside `run_detekt_process`, so it is discarded here.
-    let (_, actual_hash) = ensure_detekt(detekt_version, expected_hash)?;
+    let (_, actual_hash) = ensure_detekt(detekt_version, expected_hash, &net)?;
 
     // Persist hash to lockfile if not already stored.
     if expected_hash.is_none() {
@@ -314,7 +325,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     }
 
     // Resolve JRE.
-    let jre_home = resolve_jre_home(&manifest.toolchain.kotlin, options.locked)?;
+    let jre_home = resolve_jre_home(&manifest.toolchain.kotlin, options.locked, &net)?;
 
     // Check for sources.
     let src_dir = root.join("src");
@@ -609,6 +620,7 @@ src/main.kt:3:5: Magic number. [MagicNumber]
         let result = super::ensure_detekt(
             version,
             Some("0000000000000000000000000000000000000000000000000000000000000000"),
+            &konvoy_util::net::NetworkClient::new(false),
         );
         // Clean up before asserting.
         let _ = std::fs::remove_file(&jar);
@@ -634,7 +646,11 @@ src/main.kt:3:5: Magic number. [MagicNumber]
         std::fs::write(&jar, content).unwrap();
 
         let real_hash = konvoy_util::hash::sha256_bytes(content);
-        let result = super::ensure_detekt(version, Some(&real_hash));
+        let result = super::ensure_detekt(
+            version,
+            Some(&real_hash),
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         // Clean up.
         let _ = std::fs::remove_file(&jar);
         let _ = std::fs::remove_dir(jar.parent().unwrap());
@@ -652,7 +668,7 @@ src/main.kt:3:5: Magic number. [MagicNumber]
     /// be caught by either, so it does not exercise the difference).
     #[test]
     fn ensure_detekt_rejects_dotdot_version() {
-        let err = super::ensure_detekt("1..2", None)
+        let err = super::ensure_detekt("1..2", None, &konvoy_util::net::NetworkClient::new(false))
             .expect_err("a `..` version must be rejected before any download");
         let msg = err.to_string();
         assert!(

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -276,7 +276,11 @@ fn run_detekt_process(
 /// Returns an error if the explicitly provided config file does not exist,
 /// detekt cannot be downloaded, the JRE is unavailable, or the detekt
 /// process fails to execute.
-pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineError> {
+pub fn lint(
+    root: &Path,
+    options: &LintOptions,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<LintResult, EngineError> {
     let manifest = konvoy_config::Manifest::from_path(&root.join("konvoy.toml"))?;
 
     let detekt_version = manifest
@@ -289,10 +293,9 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     let lockfile_path = root.join("konvoy.lock");
     let lockfile = konvoy_config::lockfile::Lockfile::from_path(&lockfile_path)?;
 
-    // One client per lint invocation — the single funnel for the detekt JAR
-    // and JRE downloads below. Always online for now; --offline (#295) will
-    // feed this constructor when it lands.
-    let net = konvoy_util::net::NetworkClient::new(false);
+    // `net` is the process-wide outbound-HTTP funnel, constructed once at the
+    // program entry point and threaded in — the detekt JAR and JRE downloads
+    // below route through it.
 
     let expected_hash = resolve_lockfile_hash(&lockfile, detekt_version);
 
@@ -311,7 +314,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
 
     // Ensure detekt jar is available and hash-verified. The path is derived again
     // (from the same spec) inside `run_detekt_process`, so it is discarded here.
-    let (_, actual_hash) = ensure_detekt(detekt_version, expected_hash, &net)?;
+    let (_, actual_hash) = ensure_detekt(detekt_version, expected_hash, net)?;
 
     // Persist hash to lockfile if not already stored.
     if expected_hash.is_none() {
@@ -325,7 +328,7 @@ pub fn lint(root: &Path, options: &LintOptions) -> Result<LintResult, EngineErro
     }
 
     // Resolve JRE.
-    let jre_home = resolve_jre_home(&manifest.toolchain.kotlin, options.locked, &net)?;
+    let jre_home = resolve_jre_home(&manifest.toolchain.kotlin, options.locked, net)?;
 
     // Check for sources.
     let src_dir = root.join("src");
@@ -718,6 +721,7 @@ src/main.kt:3:5: Magic number. [MagicNumber]
                 config: None,
                 locked: true,
             },
+            &konvoy_util::net::NetworkClient::new(false),
         );
 
         // Clean up the fake JAR before asserting.

--- a/crates/konvoy-engine/src/managed_tool.rs
+++ b/crates/konvoy-engine/src/managed_tool.rs
@@ -200,7 +200,11 @@ impl ManagedToolSpec {
     /// # Errors
     /// Returns an error if the id/version/filename is unsafe, the artifact cannot
     /// be downloaded, or the expected SHA-256 does not match.
-    pub fn ensure(&self, expected_sha256: Option<&str>) -> Result<(PathBuf, String), UtilError> {
+    pub fn ensure(
+        &self,
+        expected_sha256: Option<&str>,
+        net: &konvoy_util::net::NetworkClient,
+    ) -> Result<(PathBuf, String), UtilError> {
         // Validate here (the only method that writes), so a traversal-laden
         // version/filename can never escape the tools dir during a download.
         self.validate()?;
@@ -219,6 +223,7 @@ impl ManagedToolSpec {
         // label — download_artifact embeds it in a temp filename, so a separator
         // in display_name would point the temp path at a missing directory.
         let result = konvoy_util::progress::fetch(
+            net,
             &self.download_url(),
             &artifact_path,
             expected_sha256,

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -154,6 +154,7 @@ pub fn ensure_plugin_artifacts(
     artifacts: &[ResolvedPluginArtifact],
     lockfile: &Lockfile,
     locked: bool,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<Vec<PluginArtifactResult>, EngineError> {
     use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
@@ -203,6 +204,7 @@ pub fn ensure_plugin_artifacts(
         .map(|(artifact, maybe_bar)| {
             let expected_hash = find_lockfile_hash(lockfile, &artifact.plugin_name);
             let util_result = konvoy_util::progress::fetch(
+                net,
                 &artifact.url,
                 &artifact.cache_path,
                 expected_hash,
@@ -826,7 +828,12 @@ mod tests {
         let artifacts = resolve_plugin_artifacts(&manifest).unwrap();
         let lockfile = Lockfile::default(); // no plugin hashes
 
-        let result = ensure_plugin_artifacts(&artifacts, &lockfile, true);
+        let result = ensure_plugin_artifacts(
+            &artifacts,
+            &lockfile,
+            true,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(
             result.is_err(),
             "expected error in locked mode without hash"
@@ -838,7 +845,13 @@ mod tests {
     #[test]
     fn ensure_plugin_artifacts_empty_input_returns_empty() {
         let lockfile = Lockfile::default();
-        let result = ensure_plugin_artifacts(&[], &lockfile, false).unwrap();
+        let result = ensure_plugin_artifacts(
+            &[],
+            &lockfile,
+            false,
+            &konvoy_util::net::NetworkClient::new(false),
+        )
+        .unwrap();
         assert!(result.is_empty());
     }
 
@@ -874,7 +887,12 @@ mod tests {
             },
         ];
 
-        let result = ensure_plugin_artifacts(&artifacts, &lockfile, true);
+        let result = ensure_plugin_artifacts(
+            &artifacts,
+            &lockfile,
+            true,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(matches!(result, Err(EngineError::LockfileUpdateRequired)));
     }
 
@@ -906,7 +924,13 @@ mod tests {
             cache_path: cache_path.clone(),
         }];
 
-        let result = ensure_plugin_artifacts(&artifacts, &lockfile, true).unwrap();
+        let result = ensure_plugin_artifacts(
+            &artifacts,
+            &lockfile,
+            true,
+            &konvoy_util::net::NetworkClient::new(false),
+        )
+        .unwrap();
         assert_eq!(result.len(), 1);
         let r = &result[0];
         assert_eq!(r.plugin_name, "test-plugin");
@@ -929,7 +953,12 @@ mod tests {
             cache_path: tmp.path().join("lib.jar"),
         };
         let lockfile = Lockfile::default();
-        let result = ensure_plugin_artifacts(&[artifact], &lockfile, false);
+        let result = ensure_plugin_artifacts(
+            &[artifact],
+            &lockfile,
+            false,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
     }
 }

--- a/crates/konvoy-engine/src/test_build.rs
+++ b/crates/konvoy-engine/src/test_build.rs
@@ -37,9 +37,10 @@ pub struct TestBuildResult {
 pub fn build_tests(
     project_root: &Path,
     options: &BuildOptions,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<TestBuildResult, EngineError> {
     let start = Instant::now();
-    let ctx = resolve_build_context(project_root, options)?;
+    let ctx = resolve_build_context(project_root, options, net)?;
 
     // Collect project sources (excluding src/test/) and test sources.
     let src_dir = project_root.join("src");
@@ -195,7 +196,11 @@ mod tests {
             locked: false,
         };
 
-        let result = build_tests(&project, &options);
+        let result = build_tests(
+            &project,
+            &options,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -224,7 +229,11 @@ mod tests {
             locked: false,
         };
 
-        let result = build_tests(&project, &options);
+        let result = build_tests(
+            &project,
+            &options,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -244,7 +253,11 @@ mod tests {
             locked: false,
         };
 
-        let result = build_tests(tmp.path(), &options);
+        let result = build_tests(
+            tmp.path(),
+            &options,
+            &konvoy_util::net::NetworkClient::new(false),
+        );
         assert!(result.is_err());
     }
 }

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -75,6 +75,7 @@ fn download_dep(
     dep: &ResolvedMavenDep,
     cache_root: &Path,
     bars: &[konvoy_util::progress::DownloadBar],
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<DependencyLock, EngineError> {
     let known_targets = konvoy_targets::KNOWN_TARGETS;
     let maven_coord = dep.key();
@@ -82,7 +83,7 @@ fn download_dep(
     let target_results: Vec<Result<(konvoy_targets::Target, String), EngineError>> = known_targets
         .par_iter()
         .zip(bars.par_iter())
-        .map(|(&target, bar)| download_target_klib(dep, target, cache_root, bar))
+        .map(|(&target, bar)| download_target_klib(dep, target, cache_root, bar, net))
         .collect();
 
     let mut targets_map: BTreeMap<String, String> = BTreeMap::new();
@@ -121,6 +122,7 @@ fn download_target_klib(
     target: konvoy_targets::Target,
     cache_root: &Path,
     progress: &konvoy_util::progress::DownloadBar,
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<(konvoy_targets::Target, String), EngineError> {
     let maven_suffix = target.to_maven_suffix();
     let per_target_artifact_id = format!("{}-{}", dep.artifact_id, maven_suffix);
@@ -138,8 +140,8 @@ fn download_target_klib(
     let dest = coord.cache_path(cache_root);
     let label = format!("{}:{}", dep.name, target);
 
-    let result = konvoy_util::progress::fetch(&url, &dest, None, &label, Some(progress)).map_err(
-        |e| match e {
+    let result = konvoy_util::progress::fetch(net, &url, &dest, None, &label, Some(progress))
+        .map_err(|e| match e {
             konvoy_util::error::UtilError::Download { message } => {
                 EngineError::LibraryDownloadFailed {
                     name: dep.name.clone(),
@@ -148,8 +150,7 @@ fn download_target_klib(
                 }
             }
             other => EngineError::Util(other),
-        },
-    )?;
+        })?;
 
     Ok((target, result.sha256))
 }
@@ -172,7 +173,10 @@ pub struct UpdateResult {
 ///
 /// Returns an error if a POM fetch or parse fails, a version conflict is
 /// detected, a download fails, or the lockfile cannot be written.
-pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
+pub fn update(
+    project_root: &Path,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<UpdateResult, EngineError> {
     // 1. Read konvoy.toml and konvoy.lock.
     let manifest_path = project_root.join("konvoy.toml");
     let manifest = Manifest::from_path(&manifest_path)?;
@@ -220,7 +224,7 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
     }
 
     // 4. Resolve transitive dependencies via BFS on POM files.
-    let all_deps = resolve_transitive(&direct_deps)?;
+    let all_deps = resolve_transitive(&direct_deps, net)?;
 
     eprintln!(
         "  Resolved {} dependencies ({} direct, {} transitive)",
@@ -299,7 +303,7 @@ pub fn update(project_root: &Path) -> Result<UpdateResult, EngineError> {
         .par_iter()
         .zip(dep_bars.par_iter())
         .map(|((idx, dep), bars)| {
-            let lock = download_dep(dep, &cache_root, bars)?;
+            let lock = download_dep(dep, &cache_root, bars, net)?;
             Ok((*idx, lock))
         })
         .collect();
@@ -550,6 +554,7 @@ fn finalize_required_by(
 /// cycle is found.
 fn resolve_transitive(
     direct_deps: &[ResolvedMavenDep],
+    net: &konvoy_util::net::NetworkClient,
 ) -> Result<Vec<ResolvedMavenDep>, EngineError> {
     // Use the first known target for metadata fetching — the transitive graph is
     // identical across targets since every Kotlin/Native artifact publishes
@@ -633,6 +638,7 @@ fn resolve_transitive(
             .par_iter()
             .map(|(group_id, per_target_artifact_id, version, cache_key)| {
                 let metadata = konvoy_util::metadata::fetch_artifact_metadata(
+                    net,
                     group_id,
                     per_target_artifact_id,
                     version,
@@ -860,7 +866,7 @@ my-utils = { path = "../my-utils" }
             .write_to(&project.path().join("konvoy.lock"))
             .unwrap();
 
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         // Verify the lockfile still has the path dep.
@@ -896,7 +902,7 @@ my-utils = { path = "../my-utils" }
             .write_to(&project.path().join("konvoy.lock"))
             .unwrap();
 
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
@@ -926,7 +932,7 @@ kotlin = "2.1.0"
             .write_to(&project.path().join("konvoy.lock"))
             .unwrap();
 
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
@@ -948,7 +954,7 @@ kotlin = "2.1.0"
 "#,
         );
 
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         // Lockfile should exist (possibly empty/default).
@@ -1063,7 +1069,7 @@ kotlinx-coroutines = { maven = "org.jetbrains.kotlinx:kotlinx-coroutines-core", 
 
     #[test]
     fn resolve_transitive_empty_direct_deps() {
-        let result = resolve_transitive(&[]).unwrap();
+        let result = resolve_transitive(&[], &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert!(result.is_empty());
     }
 
@@ -1115,7 +1121,7 @@ kotlin = "2.1.0"
 "#,
         );
         // No konvoy.lock on disk — `update` creates it from scratch.
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
@@ -1144,7 +1150,7 @@ kotlin = "2.1.0"
             .write_to(&project.path().join("konvoy.lock"))
             .unwrap();
 
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert_eq!(result.updated_count, 0);
 
         let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
@@ -1219,7 +1225,7 @@ kotlin = "2.1.0"
 
     #[test]
     fn resolve_transitive_no_direct_deps_returns_empty() {
-        let result = resolve_transitive(&[]).unwrap();
+        let result = resolve_transitive(&[], &konvoy_util::net::NetworkClient::new(false)).unwrap();
         assert!(result.is_empty());
     }
 
@@ -1459,7 +1465,7 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
 
         // Running update should detect these as already locked (same version
         // and classifier) and skip re-downloading.
-        let result = update(project.path()).unwrap();
+        let result = update(project.path(), &konvoy_util::net::NetworkClient::new(false)).unwrap();
         // updated_count reflects total resolved deps (already-locked or new).
         assert!(
             result.updated_count >= 2,

--- a/crates/konvoy-engine/tests/codegen_openapi.rs
+++ b/crates/konvoy-engine/tests/codegen_openapi.rs
@@ -383,7 +383,11 @@ fn fabrikt_jar_path_format() {
 
 #[test]
 fn ensure_fabrikt_rejects_invalid_version() {
-    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("../bad", None);
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        "../bad",
+        None,
+        &konvoy_util::net::NetworkClient::new(false),
+    );
     assert!(result.is_err());
     let message = result.unwrap_err().to_string();
     assert!(
@@ -398,7 +402,11 @@ fn ensure_fabrikt_rejects_dotdot_version() {
     // validate_version would have let this through, so this is the regression guard
     // for the validate_identifier fix. `../bad` above does NOT exercise it (the `/`
     // is rejected by either check).
-    let result = konvoy_engine::codegen::openapi::ensure_fabrikt("1..2", None);
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        "1..2",
+        None,
+        &konvoy_util::net::NetworkClient::new(false),
+    );
     let message = result
         .expect_err("a `..` version must be rejected")
         .to_string();
@@ -425,6 +433,7 @@ fn ensure_fabrikt_hash_mismatch_on_existing_jar() {
     let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
         &version,
         Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        &konvoy_util::net::NetworkClient::new(false),
     );
 
     assert!(result.is_err());
@@ -448,7 +457,11 @@ fn ensure_fabrikt_accepts_matching_hash_on_existing_jar() {
     fs::write(&jar, b"already cached").unwrap();
     let real_hash = konvoy_util::hash::sha256_file(&jar).unwrap();
 
-    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(&version, Some(&real_hash));
+    let result = konvoy_engine::codegen::openapi::ensure_fabrikt(
+        &version,
+        Some(&real_hash),
+        &konvoy_util::net::NetworkClient::new(false),
+    );
 
     assert!(result.is_ok(), "matching hash should pass: {result:?}");
     let (path, hash) = result.unwrap();

--- a/crates/konvoy-konanc/src/detect.rs
+++ b/crates/konvoy-konanc/src/detect.rs
@@ -39,12 +39,15 @@ pub struct ResolvedKonanc {
 /// # Errors
 /// Returns an error if the toolchain cannot be installed, the version
 /// doesn't match, or the binary cannot be fingerprinted.
-pub fn resolve_konanc(version: &str) -> Result<ResolvedKonanc, KonancError> {
+pub fn resolve_konanc(
+    version: &str,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<ResolvedKonanc, KonancError> {
     let installed = toolchain::is_installed(version)?;
 
     let (konanc_tarball_sha256, jre_tarball_sha256) = if !installed {
         eprintln!("    Installing Kotlin/Native {version}...");
-        let result = toolchain::install(version)?;
+        let result = toolchain::install(version, net)?;
         (result.konanc_tarball_sha256, result.jre_tarball_sha256)
     } else {
         (None, None)

--- a/crates/konvoy-konanc/src/toolchain.rs
+++ b/crates/konvoy-konanc/src/toolchain.rs
@@ -155,7 +155,10 @@ pub fn list_installed() -> Result<Vec<String>, KonancError> {
 /// # Errors
 /// Returns an error if the download fails, the tarball is corrupt, or the
 /// extraction fails.
-pub fn install(version: &str) -> Result<InstallResult, KonancError> {
+pub fn install(
+    version: &str,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<InstallResult, KonancError> {
     let dest = version_dir(version)?;
 
     // Check if konanc is already installed.
@@ -189,8 +192,9 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
         let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
         let progress = konvoy_util::progress::new_download_bar(format!("Kotlin/Native {version}"));
-        let sha256 = konvoy_util::progress::stream_with_bar(&url, &tmp_tarball, Some(&progress))
-            .map_err(|e| map_download_err(version, e))?;
+        let sha256 =
+            konvoy_util::progress::stream_with_bar(net, &url, &tmp_tarball, Some(&progress))
+                .map_err(|e| map_download_err(version, e))?;
         eprintln!();
 
         let (_extract_guard, tmp_extract) = temp_extract_dir(&toolchains_root, &prefix)?;
@@ -213,7 +217,7 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
     };
 
     // --- Install JRE if needed ---
-    let (jre_home, jre_sha256) = install_jre(version)?;
+    let (jre_home, jre_sha256) = install_jre(version, net)?;
 
     Ok(InstallResult {
         konanc_path: dest.join("bin").join("konanc"),
@@ -227,7 +231,10 @@ pub fn install(version: &str) -> Result<InstallResult, KonancError> {
 ///
 /// Returns `(jre_home, tarball_sha256)`. The SHA-256 is `None` if the JRE was
 /// already installed and no download occurred.
-fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> {
+fn install_jre(
+    version: &str,
+    net: &konvoy_util::net::NetworkClient,
+) -> Result<(PathBuf, Option<String>), KonancError> {
     let jre_root = jre_dir(version)?;
 
     // Already installed — return existing path.
@@ -243,7 +250,7 @@ fn install_jre(version: &str) -> Result<(PathBuf, Option<String>), KonancError> 
     let (_tarball_guard, tmp_tarball) = temp_tarball(&toolchains_root, &prefix)?;
 
     let progress = konvoy_util::progress::new_download_bar(format!("JRE {version}"));
-    let sha256 = konvoy_util::progress::stream_with_bar(&url, &tmp_tarball, Some(&progress))
+    let sha256 = konvoy_util::progress::stream_with_bar(net, &url, &tmp_tarball, Some(&progress))
         .map_err(|e| map_download_err(version, e))?;
     eprintln!();
 

--- a/crates/konvoy-util/src/artifact.rs
+++ b/crates/konvoy-util/src/artifact.rs
@@ -123,6 +123,7 @@ pub fn check_cached(
 /// Returns an error if the download fails, the hash does not match, or an
 /// I/O operation fails.
 pub fn download_artifact<F>(
+    net: &crate::net::NetworkClient,
     url: &str,
     dest: &Path,
     expected_sha256: Option<&str>,
@@ -150,7 +151,7 @@ where
         .unwrap_or_else(|| PathBuf::from(&tmp_name));
 
     // Download to temp file.
-    let download_hash = crate::download::stream_download(url, &tmp_path, on_progress)?;
+    let download_hash = crate::download::stream_download(net, url, &tmp_path, on_progress)?;
 
     // Verify hash of downloaded file before placing it.
     if let Some(expected) = expected_sha256 {
@@ -327,6 +328,7 @@ mod tests {
         let dest = tmp.path().join("missing.jar");
 
         let result = download_artifact(
+            &crate::net::NetworkClient::new(false),
             "http://127.0.0.1:1/nonexistent",
             &dest,
             None,

--- a/crates/konvoy-util/src/download.rs
+++ b/crates/konvoy-util/src/download.rs
@@ -12,21 +12,10 @@ fn u64_from_usize(n: usize) -> u64 {
     u64::try_from(n).unwrap_or(u64::MAX)
 }
 
-/// Create an HTTP agent with the given global timeout.
-///
-/// Uses a 30-second connect timeout for all requests.
-pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
-    ureq::Agent::new_with_config(
-        ureq::config::Config::builder()
-            .timeout_connect(Some(std::time::Duration::from_secs(30)))
-            .timeout_global(Some(std::time::Duration::from_secs(global_timeout_secs)))
-            .build(),
-    )
-}
-
 /// Stream a URL to a file, calling `on_progress` as bytes arrive and computing SHA-256.
 ///
-/// Pure network primitive: no UI dependencies. Callers in
+/// Pure network primitive: no UI dependencies. All wire access goes through
+/// the supplied [`NetworkClient`](crate::net::NetworkClient). Callers in
 /// [`crate::artifact`] and [`crate::progress`] adapt it to higher-level
 /// flows; engine code should not call this directly — use
 /// [`crate::progress::stream_with_bar`] for tarballs or
@@ -45,6 +34,7 @@ pub fn http_agent(global_timeout_secs: u64) -> ureq::Agent {
 /// Returns an error if the HTTP request fails, the file cannot be written,
 /// or a read error occurs during streaming.
 pub(crate) fn stream_download<F>(
+    net: &crate::net::NetworkClient,
     url: &str,
     dest: &Path,
     mut on_progress: F,
@@ -52,10 +42,12 @@ pub(crate) fn stream_download<F>(
 where
     F: FnMut(u64, Option<u64>),
 {
-    let agent = http_agent(600);
-
-    let response = agent.get(url).call().map_err(|e| UtilError::Download {
-        message: e.to_string(),
+    let response = net.get(url, 600).map_err(|e| match e {
+        crate::net::RequestError::Offline => UtilError::Offline {
+            url: url.to_owned(),
+        },
+        crate::net::RequestError::Status { message, .. }
+        | crate::net::RequestError::Transport { message } => UtilError::Download { message },
     })?;
 
     let content_length: Option<u64> = response
@@ -122,11 +114,21 @@ mod tests {
         assert!(result > 0);
     }
 
+    /// An online client for tests that exercise the error paths past the wire.
+    fn online() -> crate::net::NetworkClient {
+        crate::net::NetworkClient::new(false)
+    }
+
     #[test]
     fn download_invalid_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result = stream_download("http://127.0.0.1:1/nonexistent", &dest, ignore_progress);
+        let result = stream_download(
+            &online(),
+            "http://127.0.0.1:1/nonexistent",
+            &dest,
+            ignore_progress,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("download failed"), "error was: {err}");
@@ -136,17 +138,37 @@ mod tests {
     fn download_malformed_url_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("out.bin");
-        let result = stream_download("not-a-valid-url", &dest, ignore_progress);
+        let result = stream_download(&online(), "not-a-valid-url", &dest, ignore_progress);
         assert!(result.is_err());
     }
 
     #[test]
     fn download_unwritable_dest_returns_error() {
         let result = stream_download(
+            &online(),
             "http://127.0.0.1:1/file.bin",
             std::path::Path::new("/nonexistent_root/subdir/out.bin"),
             ignore_progress,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn download_offline_refuses_before_any_io() {
+        // The wire-level floor: an offline client refuses the request with
+        // UtilError::Offline — no connection attempt, no dest file created.
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("out.bin");
+        let result = stream_download(
+            &crate::net::NetworkClient::new(true),
+            "http://127.0.0.1:1/never",
+            &dest,
+            ignore_progress,
+        );
+        assert!(
+            matches!(result, Err(crate::error::UtilError::Offline { .. })),
+            "expected UtilError::Offline, got: {result:?}"
+        );
+        assert!(!dest.exists(), "no file must be created when offline");
     }
 }

--- a/crates/konvoy-util/src/error.rs
+++ b/crates/konvoy-util/src/error.rs
@@ -22,6 +22,14 @@ pub enum UtilError {
     #[error("download failed: {message}")]
     Download { message: String },
 
+    /// An outbound request was refused because offline mode is active.
+    ///
+    /// Raised by the wire-level [`NetworkClient`](crate::net::NetworkClient)
+    /// floor; engine-level gates normally fail first with artifact-specific
+    /// errors, so reaching this means a fetch path had no earlier gate.
+    #[error("network access is disabled (--offline) — refused to fetch {url}")]
+    Offline { url: String },
+
     /// A Maven coordinate string is malformed.
     #[error("invalid Maven coordinate \"{coordinate}\": {reason}")]
     InvalidMavenCoordinate { coordinate: String, reason: String },

--- a/crates/konvoy-util/src/lib.rs
+++ b/crates/konvoy-util/src/lib.rs
@@ -10,6 +10,7 @@ pub mod maven;
 pub mod metadata;
 pub mod module_metadata;
 pub mod naming;
+pub mod net;
 pub mod pom;
 pub mod progress;
 

--- a/crates/konvoy-util/src/metadata.rs
+++ b/crates/konvoy-util/src/metadata.rs
@@ -61,13 +61,14 @@ pub struct MetadataFile {
 ///
 /// Returns an error if both `.module` and POM fetching/parsing fail.
 pub fn fetch_artifact_metadata(
+    net: &crate::net::NetworkClient,
     group_id: &str,
     artifact_id: &str,
     version: &str,
     maven_suffix: &str,
 ) -> Result<ArtifactMetadata, UtilError> {
     // Try Gradle Module Metadata first.
-    match fetch_module_metadata(group_id, artifact_id, version) {
+    match fetch_module_metadata(net, group_id, artifact_id, version) {
         Ok(Some(json)) => {
             return parse_module_metadata(&json);
         }
@@ -75,12 +76,13 @@ pub fn fetch_artifact_metadata(
             // 404 — fall through to POM.
         }
         Err(_) => {
-            // Network error fetching .module — fall through to POM.
+            // Network error (or offline refusal) fetching .module — fall
+            // through to the POM, which may still be served from its cache.
         }
     }
 
     // Fall back to POM.
-    let pom_xml = fetch_pom(group_id, artifact_id, version)?;
+    let pom_xml = fetch_pom(net, group_id, artifact_id, version)?;
     let pom = parse_pom(&pom_xml, Some(group_id), Some(version))?;
     Ok(pom_to_metadata(&pom, maven_suffix))
 }
@@ -138,6 +140,7 @@ mod tests {
     fn fetch_artifact_metadata_nonexistent_fails() {
         // Both .module and POM will fail for a non-existent artifact.
         let result = fetch_artifact_metadata(
+            &crate::net::NetworkClient::new(false),
             "com.nonexistent.fake",
             "no-such-artifact",
             "0.0.0",

--- a/crates/konvoy-util/src/metadata.rs
+++ b/crates/konvoy-util/src/metadata.rs
@@ -95,6 +95,7 @@ pub fn fetch_artifact_metadata(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::test_util::ENV_LOCK;
 
     #[test]
     fn artifact_metadata_default_construction() {
@@ -147,6 +148,71 @@ mod tests {
             "linuxx64",
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn fetch_artifact_metadata_offline_falls_back_to_cached_pom() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved_home = std::env::var("HOME").ok();
+        let saved_profile = std::env::var("USERPROFILE").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var("USERPROFILE");
+
+        let pom_path = crate::fs::konvoy_home()
+            .unwrap()
+            .join("cache")
+            .join("pom")
+            .join("com")
+            .join("example")
+            .join("lib-linuxx64-1.0.0.pom");
+        std::fs::create_dir_all(pom_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &pom_path,
+            r#"
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib-linuxx64</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>dep-linuxx64</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+  </dependencies>
+</project>
+"#,
+        )
+        .unwrap();
+
+        let result = fetch_artifact_metadata(
+            &crate::net::NetworkClient::new(true),
+            "com.example",
+            "lib-linuxx64",
+            "1.0.0",
+            "linuxx64",
+        );
+
+        if let Some(v) = saved_home {
+            std::env::set_var("HOME", v);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(v) = saved_profile {
+            std::env::set_var("USERPROFILE", v);
+        }
+
+        let metadata = result.unwrap();
+        assert_eq!(metadata.files, Vec::new());
+        let [dep] = metadata.dependencies.as_slice() else {
+            assert_eq!(metadata.dependencies.len(), 1);
+            return;
+        };
+        assert_eq!(dep.group_id, "com.example");
+        assert_eq!(dep.artifact_id, "dep");
+        assert_eq!(dep.version, "2.0.0");
     }
 
     #[test]

--- a/crates/konvoy-util/src/module_metadata.rs
+++ b/crates/konvoy-util/src/module_metadata.rs
@@ -181,6 +181,7 @@ fn module_404_sentinel_path(body: &std::path::Path) -> Result<std::path::PathBuf
 /// error or the response body cannot be read. Returns `UtilError::InvalidVersion`
 /// if any of `group_id`/`artifact_id`/`version` fail validation.
 pub fn fetch_module_metadata(
+    net: &crate::net::NetworkClient,
     group_id: &str,
     artifact_id: &str,
     version: &str,
@@ -188,7 +189,8 @@ pub fn fetch_module_metadata(
     // 1. Try the disk cache. Check the body file first, then the 404 sentinel.
     // Body file wins over the 404 sentinel if both exist. This recovers
     // gracefully from the case where Maven Central publishes a previously
-    // missing artifact between two `konvoy update` runs.
+    // missing artifact between two `konvoy update` runs. No network is
+    // involved here, so cached metadata resolves offline too.
     let cache_path = module_cache_path(group_id, artifact_id, version)?;
     if cache_path.exists() {
         if let Ok(body) = std::fs::read_to_string(&cache_path) {
@@ -204,9 +206,8 @@ pub fn fetch_module_metadata(
 
     // 2. Cache miss — fetch from Maven Central.
     let url = module_metadata_url(group_id, artifact_id, version);
-    let agent = crate::download::http_agent(60);
 
-    match agent.get(&url).call() {
+    match net.get(&url, 60) {
         Ok(response) => {
             let body = response
                 .into_body()
@@ -226,7 +227,7 @@ pub fn fetch_module_metadata(
 
             Ok(Some(body))
         }
-        Err(ureq::Error::StatusCode(404)) => {
+        Err(crate::net::RequestError::Status { code: 404, .. }) => {
             // Persist the 404 so we don't re-hit the network on every run.
             if let Err(e) = crate::pom::write_cache_atomic(&sentinel_path, &[]) {
                 eprintln!(
@@ -236,8 +237,10 @@ pub fn fetch_module_metadata(
             }
             Ok(None)
         }
-        Err(e) => Err(UtilError::Download {
-            message: format!("failed to fetch module metadata from {url}: {e}"),
+        Err(crate::net::RequestError::Offline) => Err(UtilError::Offline { url }),
+        Err(crate::net::RequestError::Status { message, .. })
+        | Err(crate::net::RequestError::Transport { message }) => Err(UtilError::Download {
+            message: format!("failed to fetch module metadata from {url}: {message}"),
         }),
     }
 }
@@ -250,6 +253,11 @@ pub fn fetch_module_metadata(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// An online client for tests exercising fetch paths.
+    fn online() -> crate::net::NetworkClient {
+        crate::net::NetworkClient::new(false)
+    }
 
     /// Real-world `.module` JSON for kotlinx-coroutines-core-linuxx64 (trimmed).
     const COROUTINES_MODULE: &str = r#"{
@@ -622,13 +630,13 @@ mod tests {
 
     #[test]
     fn fetch_module_metadata_rejects_path_traversal_in_group_id() {
-        let result = fetch_module_metadata("../etc/passwd", "lib", "1.0.0");
+        let result = fetch_module_metadata(&online(), "../etc/passwd", "lib", "1.0.0");
         assert!(result.is_err());
     }
 
     #[test]
     fn fetch_module_metadata_rejects_invalid_version() {
-        let err = fetch_module_metadata("com.example", "lib", "1.0/0").unwrap_err();
+        let err = fetch_module_metadata(&online(), "com.example", "lib", "1.0/0").unwrap_err();
         assert!(
             matches!(err, UtilError::InvalidVersion { .. }),
             "expected InvalidVersion, got: {err:?}"
@@ -638,7 +646,12 @@ mod tests {
     #[test]
     fn fetch_module_metadata_nonexistent_returns_none() {
         // Use a non-existent artifact to test 404 handling.
-        let result = fetch_module_metadata("com.nonexistent.fake", "no-such-artifact", "0.0.0");
+        let result = fetch_module_metadata(
+            &online(),
+            "com.nonexistent.fake",
+            "no-such-artifact",
+            "0.0.0",
+        );
         // This may either return None (404) or Err (connection refused).
         // Both are acceptable for a non-existent artifact — we just verify no panic.
         match result {
@@ -807,7 +820,7 @@ mod tests {
             let expected = r#"{"variants":[{"name":"x"}]}"#;
             std::fs::write(&body_path, expected).unwrap();
 
-            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            let result = fetch_module_metadata(&online(), group, artifact, version).unwrap();
             assert_eq!(
                 result.as_deref(),
                 Some(expected),
@@ -829,7 +842,7 @@ mod tests {
             std::fs::create_dir_all(sentinel.parent().unwrap()).unwrap();
             std::fs::write(&sentinel, b"").unwrap();
 
-            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            let result = fetch_module_metadata(&online(), group, artifact, version).unwrap();
             assert!(
                 result.is_none(),
                 "sentinel hit must return None (no .module published)"
@@ -853,11 +866,34 @@ mod tests {
             std::fs::write(&body_path, expected).unwrap();
             std::fs::write(&sentinel, b"").unwrap();
 
-            let result = fetch_module_metadata(group, artifact, version).unwrap();
+            let result = fetch_module_metadata(&online(), group, artifact, version).unwrap();
             assert_eq!(
                 result.as_deref(),
                 Some(expected),
                 "body file must take precedence over stale 404 sentinel"
+            );
+        });
+    }
+
+    #[test]
+    fn fetch_module_metadata_offline_cached_ok_uncached_refuses() {
+        // Offline policy: a cached body or 404 sentinel resolves from disk;
+        // an uncached coordinate is refused at the wire (UtilError::Offline),
+        // NOT silently treated as "no .module published" (Ok(None)).
+        with_fake_home(|_home| {
+            let offline = crate::net::NetworkClient::new(true);
+
+            let body_path = module_cache_path("com.example", "cached", "1.0.0").unwrap();
+            std::fs::create_dir_all(body_path.parent().unwrap()).unwrap();
+            std::fs::write(&body_path, r#"{"variants":[]}"#).unwrap();
+
+            let cached = fetch_module_metadata(&offline, "com.example", "cached", "1.0.0");
+            assert_eq!(cached.unwrap().as_deref(), Some(r#"{"variants":[]}"#));
+
+            let uncached = fetch_module_metadata(&offline, "com.example", "uncached", "1.0.0");
+            assert!(
+                matches!(uncached, Err(UtilError::Offline { .. })),
+                "uncached .module under offline must refuse, got: {uncached:?}"
             );
         });
     }

--- a/crates/konvoy-util/src/net.rs
+++ b/crates/konvoy-util/src/net.rs
@@ -92,6 +92,29 @@ impl NetworkClient {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn serve_once(status_line: &str, body: &str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let status_line = status_line.to_owned();
+        let body = body.to_owned();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            let response = format!(
+                "{status_line}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        url
+    }
 
     #[test]
     fn offline_client_refuses_get_without_touching_network() {
@@ -115,6 +138,37 @@ mod tests {
             matches!(result, Err(RequestError::Transport { .. })),
             "connection refused must map to Transport, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn online_client_returns_successful_response_body() {
+        let url = serve_once("HTTP/1.1 200 OK", "hello");
+        let response = NetworkClient::new(false)
+            .get(&url, 5)
+            .expect("successful local response");
+
+        let body = response.into_body().read_to_string().unwrap();
+        assert_eq!(body, "hello");
+    }
+
+    #[test]
+    fn online_client_maps_http_status_errors_with_status_code() {
+        let url = serve_once("HTTP/1.1 503 Service Unavailable", "down");
+        let result = NetworkClient::new(false).get(&url, 5);
+
+        match result {
+            Err(RequestError::Status { code, message }) => {
+                assert_eq!(code, 503);
+                assert!(
+                    message.contains("503"),
+                    "status error should preserve the upstream status in its message: {message}"
+                );
+            }
+            other => assert!(
+                matches!(other, Err(RequestError::Status { .. })),
+                "expected RequestError::Status, got: {other:?}"
+            ),
+        }
     }
 
     #[test]

--- a/crates/konvoy-util/src/net.rs
+++ b/crates/konvoy-util/src/net.rs
@@ -1,0 +1,125 @@
+//! The single funnel for outbound HTTP requests.
+//!
+//! Every byte Konvoy sends or receives over the network goes through
+//! `NetworkClient::get` — toolchain tarballs, plugin JARs, dependency
+//! klibs, detekt releases, POMs, and `.module` metadata alike. The raw
+//! request method is `pub(crate)`, so code outside `konvoy-util` *cannot*
+//! make an HTTP request except via this crate's higher-level fetchers
+//! (`progress::fetch`, `pom::fetch_pom`, …), all of which take a
+//! `&NetworkClient`.
+//!
+//! This is what makes `--offline` a structural guarantee rather than a
+//! per-call-site convention: an offline client refuses the request at the
+//! wire, before any connection attempt, no matter which path asked.
+//! Engine-level gates still fail fast earlier with friendlier, artifact-
+//! specific errors — this is the floor beneath them.
+
+/// Owns Konvoy's outbound network access and the offline policy.
+///
+/// Construct ONCE at a command entry point (from `--offline` for builds, or
+/// `new(false)` for inherently-online commands like `konvoy update` and
+/// `konvoy toolchain install`) and thread it to everything that may fetch.
+/// Do not construct ad-hoc clients deep inside resolution paths — that
+/// reintroduces the per-site-policy problem this type exists to end.
+#[derive(Debug, Clone, Copy)]
+pub struct NetworkClient {
+    offline: bool,
+}
+
+/// Outcome of a refused or failed request, before any domain mapping.
+///
+/// Kept `pub(crate)` (like [`NetworkClient::get`]) so ureq never leaks out of
+/// this crate; call sites map these onto `UtilError` with their own context.
+/// `Status`/`Transport` carry the original error's display string so existing
+/// error-message text is preserved exactly.
+#[derive(Debug)]
+pub(crate) enum RequestError {
+    /// The client is offline; the request was refused before any network I/O.
+    Offline,
+    /// The server answered with a non-success HTTP status.
+    Status { code: u16, message: String },
+    /// DNS/connect/read or any other transport-level failure.
+    Transport { message: String },
+}
+
+impl NetworkClient {
+    /// Create a client. `offline = true` makes every `get` fail with
+    /// `RequestError::Offline` without touching the network.
+    #[must_use]
+    pub const fn new(offline: bool) -> Self {
+        Self { offline }
+    }
+
+    /// Whether this client refuses network access. Engine gates read this to
+    /// fail fast with artifact-specific errors before the wire-level refusal.
+    #[must_use]
+    pub const fn is_offline(&self) -> bool {
+        self.offline
+    }
+
+    /// Issue a GET request — the one place in the workspace where an outbound
+    /// HTTP request is made.
+    ///
+    /// Uses a 30-second connect timeout and the supplied global timeout
+    /// (artifact downloads pass 600s, metadata fetches 60s, matching the agent
+    /// configuration this replaces). A fresh agent per call mirrors the
+    /// previous behavior — no connection pooling existed before either.
+    pub(crate) fn get(
+        &self,
+        url: &str,
+        global_timeout_secs: u64,
+    ) -> Result<ureq::http::Response<ureq::Body>, RequestError> {
+        if self.offline {
+            return Err(RequestError::Offline);
+        }
+        let agent = ureq::Agent::new_with_config(
+            ureq::config::Config::builder()
+                .timeout_connect(Some(std::time::Duration::from_secs(30)))
+                .timeout_global(Some(std::time::Duration::from_secs(global_timeout_secs)))
+                .build(),
+        );
+        agent.get(url).call().map_err(|e| {
+            let message = e.to_string();
+            match e {
+                ureq::Error::StatusCode(code) => RequestError::Status { code, message },
+                _ => RequestError::Transport { message },
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offline_client_refuses_get_without_touching_network() {
+        // The URL points at a port that would hang or refuse; an offline client
+        // must return Offline immediately, before any connection attempt.
+        let client = NetworkClient::new(true);
+        let result = client.get("http://127.0.0.1:1/never-contacted", 5);
+        assert!(
+            matches!(result, Err(RequestError::Offline)),
+            "offline client must refuse with RequestError::Offline"
+        );
+    }
+
+    #[test]
+    fn online_client_maps_transport_errors() {
+        // Port 1 refuses connections — an online client surfaces a Transport
+        // error (not Offline, not a panic).
+        let client = NetworkClient::new(false);
+        let result = client.get("http://127.0.0.1:1/unreachable", 5);
+        assert!(
+            matches!(result, Err(RequestError::Transport { .. })),
+            "connection refused must map to Transport, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn is_offline_reports_construction_flag() {
+        assert!(NetworkClient::new(true).is_offline());
+        assert!(!NetworkClient::new(false).is_offline());
+    }
+}

--- a/crates/konvoy-util/src/net.rs
+++ b/crates/konvoy-util/src/net.rs
@@ -16,10 +16,10 @@
 
 /// Owns Konvoy's outbound network access and the offline policy.
 ///
-/// Construct ONCE at a command entry point (from `--offline` for builds, or
-/// `new(false)` for inherently-online commands like `konvoy update` and
-/// `konvoy toolchain install`) and thread it to everything that may fetch.
-/// Do not construct ad-hoc clients deep inside resolution paths — that
+/// Construct ONCE at the program entry point (`konvoy-cli`'s `main`) and thread
+/// it down to everything that may fetch — builds, lint, `konvoy update`, and
+/// `konvoy toolchain install` all receive the same client. Do not construct
+/// ad-hoc clients deep inside resolution paths (or per-command): that
 /// reintroduces the per-site-policy problem this type exists to end.
 #[derive(Debug, Clone, Copy)]
 pub struct NetworkClient {

--- a/crates/konvoy-util/src/pom.rs
+++ b/crates/konvoy-util/src/pom.rs
@@ -429,8 +429,13 @@ pub(crate) fn write_cache_atomic(dest: &std::path::Path, contents: &[u8]) -> Res
 /// Returns `UtilError::Download` if the HTTP request fails or the response
 /// body cannot be read. Returns `UtilError::InvalidVersion` if any of
 /// `group_id`/`artifact_id`/`version` fail validation.
-pub fn fetch_pom(group_id: &str, artifact_id: &str, version: &str) -> Result<String, UtilError> {
-    // 1. Try the on-disk cache.
+pub fn fetch_pom(
+    net: &crate::net::NetworkClient,
+    group_id: &str,
+    artifact_id: &str,
+    version: &str,
+) -> Result<String, UtilError> {
+    // 1. Try the on-disk cache (no network involvement — works offline too).
     let cache_path = pom_cache_path(group_id, artifact_id, version)?;
     if cache_path.exists() {
         if let Ok(body) = std::fs::read_to_string(&cache_path) {
@@ -443,10 +448,12 @@ pub fn fetch_pom(group_id: &str, artifact_id: &str, version: &str) -> Result<Str
     // 2. Cache miss — fetch from Maven Central.
     let url = pom_url(group_id, artifact_id, version);
 
-    let agent = crate::download::http_agent(60);
-
-    let response = agent.get(&url).call().map_err(|e| UtilError::Download {
-        message: format!("failed to fetch POM from {url}: {e}"),
+    let response = net.get(&url, 60).map_err(|e| match e {
+        crate::net::RequestError::Offline => UtilError::Offline { url: url.clone() },
+        crate::net::RequestError::Status { message, .. }
+        | crate::net::RequestError::Transport { message } => UtilError::Download {
+            message: format!("failed to fetch POM from {url}: {message}"),
+        },
     })?;
 
     let body = response
@@ -515,6 +522,11 @@ pub fn pom_to_metadata(pom: &Pom, maven_suffix: &str) -> ArtifactMetadata {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// An online client for tests exercising fetch paths.
+    fn online() -> crate::net::NetworkClient {
+        crate::net::NetworkClient::new(false)
+    }
 
     /// A trimmed-down POM based on kotlinx-coroutines-core-macosarm64.
     const COROUTINES_POM: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -957,7 +969,12 @@ mod tests {
         // We can't easily test fetch_pom against real Maven Central in unit tests,
         // but we can verify it returns an error for unreachable hosts by using
         // a coordinate that doesn't exist.
-        let result = fetch_pom("com.nonexistent.fake", "no-such-artifact", "0.0.0");
+        let result = fetch_pom(
+            &online(),
+            "com.nonexistent.fake",
+            "no-such-artifact",
+            "0.0.0",
+        );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("download failed"), "error was: {msg}");
@@ -967,13 +984,13 @@ mod tests {
     fn fetch_pom_rejects_path_traversal_in_group_id() {
         // Path-traversal in the group must be caught before any HTTP work or
         // cache-path construction.
-        let result = fetch_pom("../etc/passwd", "lib", "1.0.0");
+        let result = fetch_pom(&online(), "../etc/passwd", "lib", "1.0.0");
         assert!(result.is_err());
     }
 
     #[test]
     fn fetch_pom_rejects_invalid_version() {
-        let err = fetch_pom("com.example", "lib", "1.0/0").unwrap_err();
+        let err = fetch_pom(&online(), "com.example", "lib", "1.0/0").unwrap_err();
         assert!(
             matches!(err, UtilError::InvalidVersion { .. }),
             "expected InvalidVersion, got: {err:?}"
@@ -1410,7 +1427,7 @@ mod tests {
         let expected_body = "<project><artifactId>cached-lib</artifactId></project>";
         std::fs::write(&cache_path, expected_body).unwrap();
 
-        let result = fetch_pom(group, artifact, version);
+        let result = fetch_pom(&online(), group, artifact, version);
 
         // Restore HOME/USERPROFILE before asserting so a panic leaves the
         // environment clean for other tests.
@@ -1425,5 +1442,46 @@ mod tests {
 
         let body = result.unwrap();
         assert_eq!(body, expected_body, "cache hit must return the disk bytes");
+    }
+
+    #[test]
+    fn fetch_pom_offline_cached_ok_uncached_refuses() {
+        // Offline policy at the POM fetcher: a cached POM is served from disk
+        // (the cache check precedes any network involvement); a cache miss is
+        // refused at the wire with UtilError::Offline.
+        let _guard = crate::test_util::ENV_LOCK.lock().unwrap();
+
+        let saved_home = std::env::var("HOME").ok();
+        let saved_profile = std::env::var("USERPROFILE").ok();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var("USERPROFILE");
+
+        let offline = crate::net::NetworkClient::new(true);
+
+        // Pre-populate one POM in the cache.
+        let cache_path = pom_cache_path("com.example", "cached-lib", "1.2.3").unwrap();
+        std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        std::fs::write(&cache_path, "<project/>").unwrap();
+
+        let cached = fetch_pom(&offline, "com.example", "cached-lib", "1.2.3");
+        let uncached = fetch_pom(&offline, "com.example", "never-cached", "9.9.9");
+
+        // Restore HOME/USERPROFILE before asserting so a panic leaves the
+        // environment clean for other tests.
+        if let Some(v) = saved_home {
+            std::env::set_var("HOME", v);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(v) = saved_profile {
+            std::env::set_var("USERPROFILE", v);
+        }
+
+        assert_eq!(cached.unwrap(), "<project/>");
+        assert!(
+            matches!(uncached, Err(UtilError::Offline { .. })),
+            "uncached POM under offline must refuse, got: {uncached:?}"
+        );
     }
 }

--- a/crates/konvoy-util/src/progress.rs
+++ b/crates/konvoy-util/src/progress.rs
@@ -356,17 +356,20 @@ const fn ignore_progress(_: u64, _: Option<u64>) {}
 ///   has the wrong hash, or the downloaded file has the wrong hash.
 /// - Other [`crate::error::UtilError`] variants for I/O / network failures.
 pub fn fetch(
+    net: &crate::net::NetworkClient,
     url: &str,
     dest: &std::path::Path,
     expected_sha256: Option<&str>,
     label: &str,
     bar: Option<&DownloadBar>,
 ) -> Result<crate::artifact::ArtifactResult, crate::error::UtilError> {
+    // The cache check runs before any network involvement, so an offline
+    // client resolves already-cached artifacts exactly like an online one.
     if let Some(cached) = crate::artifact::check_cached(dest, expected_sha256)? {
         return Ok(cached);
     }
     let download = |on_progress: &mut dyn FnMut(u64, Option<u64>)| {
-        crate::artifact::download_artifact(url, dest, expected_sha256, label, on_progress)
+        crate::artifact::download_artifact(net, url, dest, expected_sha256, label, on_progress)
     };
     if let Some(b) = bar {
         b.run(|pb| download(&mut bar_progress(pb)))
@@ -386,12 +389,13 @@ pub fn fetch(
 /// # Errors
 /// Returns whatever `crate::download::stream_download` returns.
 pub fn stream_with_bar(
+    net: &crate::net::NetworkClient,
     url: &str,
     dest: &std::path::Path,
     bar: Option<&DownloadBar>,
 ) -> Result<String, crate::error::UtilError> {
     let download = |on_progress: &mut dyn FnMut(u64, Option<u64>)| {
-        crate::download::stream_download(url, dest, on_progress)
+        crate::download::stream_download(net, url, dest, on_progress)
     };
     if let Some(b) = bar {
         b.run(|pb| download(&mut bar_progress(pb)))
@@ -864,6 +868,7 @@ mod tests {
         let expected = crate::hash::sha256_bytes(content);
 
         let result = fetch(
+            &crate::net::NetworkClient::new(false),
             "http://127.0.0.1:1/should-not-be-hit",
             &dest,
             Some(&expected),
@@ -889,6 +894,7 @@ mod tests {
         let computed = crate::hash::sha256_bytes(content);
 
         let result = fetch(
+            &crate::net::NetworkClient::new(false),
             "http://127.0.0.1:1/should-not-be-hit",
             &dest,
             None,
@@ -911,6 +917,7 @@ mod tests {
         let bogus = "0".repeat(64);
 
         let result = fetch(
+            &crate::net::NetworkClient::new(false),
             "http://127.0.0.1:1/should-not-be-hit",
             &dest,
             Some(&bogus),
@@ -936,6 +943,7 @@ mod tests {
 
         let bar = new_download_bar("test");
         let result = fetch(
+            &crate::net::NetworkClient::new(false),
             "http://127.0.0.1:1/should-not-be-hit",
             &dest,
             Some(&expected),
@@ -946,5 +954,52 @@ mod tests {
 
         assert!(!result.freshly_downloaded);
         assert_eq!(bar.state.load(Ordering::Relaxed), STATE_IN_PROGRESS);
+    }
+
+    /// An offline client still serves cache hits: `check_cached` runs before
+    /// any network involvement, so a present, hash-matching artifact resolves
+    /// identically to the online case.
+    #[test]
+    fn fetch_offline_serves_cache_hit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("artifact.jar");
+        let content = b"offline cached content";
+        std::fs::write(&dest, content).unwrap();
+        let expected = crate::hash::sha256_bytes(content);
+
+        let result = fetch(
+            &crate::net::NetworkClient::new(true),
+            "http://127.0.0.1:1/never",
+            &dest,
+            Some(&expected),
+            "test",
+            None,
+        )
+        .unwrap();
+
+        assert!(!result.freshly_downloaded);
+        assert_eq!(result.sha256, expected);
+    }
+
+    /// The wire-level floor: an offline client with a cache miss refuses with
+    /// `UtilError::Offline` instead of attempting the download.
+    #[test]
+    fn fetch_offline_cache_miss_refuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("absent.jar");
+
+        let result = fetch(
+            &crate::net::NetworkClient::new(true),
+            "http://127.0.0.1:1/never",
+            &dest,
+            Some(&"0".repeat(64)),
+            "test",
+            None,
+        );
+
+        assert!(
+            matches!(result, Err(crate::error::UtilError::Offline { .. })),
+            "expected UtilError::Offline, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
**Independent of #297** — based directly on `main`, mergeable on its own. Pure infrastructure, no behavior change today.

## Why

The `--locked`/`--offline` work in #297 enforces its offline policy as several per-site checks — and the two leaks found during its review (the auto-`konvoy update`, then Maven klibs) showed why that's fragile: nothing prevents a network path from simply not having a check. This PR adds the construct that makes such a leak structurally impossible, so #297 (and any future flag/policy) plugs into a guarantee instead of a convention.

## What

`konvoy_util::net::NetworkClient` — one type owns Konvoy's outbound network access:

- **`get()` is the only place a request is made, and it's `pub(crate)`.** Code outside `konvoy-util` cannot make a raw HTTP request at all; every fetch path (`progress::fetch`, `stream_with_bar`, `download_artifact`, `fetch_pom`, `fetch_module_metadata`, `fetch_artifact_metadata`) now takes `&NetworkClient`. Verified structurally: zero `.call()` / `ureq::Agent` constructions outside `net.rs` in the workspace. `http_agent` is deleted.
- **The client owns the offline policy.** `new(offline)` + `is_offline()`; an offline `get()` refuses with the new `UtilError::Offline` before any connection attempt. Nothing exposes the knob yet — every production construction site passes `new(false)`, so today's behavior is byte-identical. When `--offline` (#295/#297) lands, it feeds two constructors (`resolve_build_context`, `lint`) and the guarantee is live.
- **Cache-first behavior preserved for free**: cache checks precede `get()`, so cached artifacts/POMs/`.module` files resolve identically offline (tested at each fetcher).
- **Constructed once per command entry**, documented on the type: build pipeline, lint, `konvoy update`, `konvoy toolchain install`. Threaded through konanc `install`/`resolve_konanc`, `ManagedToolSpec::ensure`, `ensure_detekt`, `ensure_fabrikt`, and the whole update pipeline.
- `ureq` no longer leaks past `konvoy-util` (`RequestError { Offline, Status, Transport }` is crate-internal); existing error-message text preserved byte-for-byte.

## Tests

- `NetworkClient`: offline refusal (no connection attempt), transport-error mapping, `is_offline`.
- Offline floor at each fetcher: `stream_download` (refuses, creates no file), `progress::fetch` (cache hit OK / cache miss refuses), `fetch_pom` and `fetch_module_metadata` (cached OK / uncached refuses — **not** silently treated as a 404).

Gates green: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (13 binaries), `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`.

## Relationship to #297

Either merge order works; whichever lands second needs a small rebase (the same functions are threaded in both). If this merges first, #297's rebase is: feed `options.offline` into the two `NetworkClient::new(false)` constructors, and collapse its per-fn `offline: bool` params into `net.is_offline()`. Happy to do that rebase on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)