### PR TITLE
konvoy-engine: apply path-dep [plugins] AND [dependencies] to the dep's own build (graph-wide pinning) (#293)

### DIFF
--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -162,6 +162,21 @@ impl Lockfile {
             .iter()
             .any(|d| d.name == dep_name && matches!(&d.source, DepSource::Maven { .. }))
     }
+
+    /// Whether the lockfile pins a Maven dependency at the given
+    /// `groupId:artifactId` coordinate and version.
+    ///
+    /// Matches by COORDINATE, not by konvoy key: the graph-wide union dedups a
+    /// shared dependency under whichever project declared it first, so a path-dep
+    /// that declares the same artifact under a different key is still resolved.
+    /// A name match would spuriously report it unresolved/stale.
+    #[must_use]
+    pub fn has_maven_coord(&self, maven: &str, version: &str) -> bool {
+        self.dependencies.iter().any(|d| {
+            matches!(&d.source, DepSource::Maven { maven: m, version: v, .. }
+                if m == maven && v == version)
+        })
+    }
 }
 
 /// Errors produced when reading, parsing, or writing a `konvoy.lock` lockfile.

--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -1202,6 +1202,45 @@ url = "https://example.com/plugin.jar"
     }
 
     #[test]
+    fn has_maven_coord_matches_coordinate_and_version_not_name() {
+        let mut lockfile = Lockfile::default();
+        // The lock entry's konvoy key ("coroutines") differs from a consumer's
+        // key — has_maven_coord must still find it by COORDINATE + version.
+        lockfile.dependencies.push(DependencyLock {
+            name: "coroutines".to_owned(),
+            source: DepSource::Maven {
+                version: "1.8.0".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: Vec::new(),
+                classifier: None,
+            },
+            source_hash: "abc".to_owned(),
+        });
+
+        // Exact coordinate + version → found, regardless of the lock entry's name.
+        assert!(lockfile.has_maven_coord("org.jetbrains.kotlinx:kotlinx-coroutines-core", "1.8.0"));
+        // Same coordinate, different version → not pinned.
+        assert!(!lockfile.has_maven_coord("org.jetbrains.kotlinx:kotlinx-coroutines-core", "1.7.3"));
+        // Different coordinate → not pinned.
+        assert!(!lockfile.has_maven_coord("org.jetbrains.kotlinx:kotlinx-datetime", "1.8.0"));
+    }
+
+    #[test]
+    fn has_maven_coord_ignores_path_entries() {
+        let mut lockfile = Lockfile::default();
+        lockfile.dependencies.push(DependencyLock {
+            name: "my-lib".to_owned(),
+            source: DepSource::Path {
+                path: "../my-lib".to_owned(),
+            },
+            source_hash: "abc".to_owned(),
+        });
+        // A path dep is never a Maven coordinate match.
+        assert!(!lockfile.has_maven_coord("../my-lib", "1.0.0"));
+    }
+
+    #[test]
     fn has_maven_entry_ignores_path_deps() {
         let mut lockfile = Lockfile::default();
         lockfile.dependencies.push(DependencyLock {

--- a/crates/konvoy-config/src/lockfile.rs
+++ b/crates/konvoy-config/src/lockfile.rs
@@ -1241,6 +1241,57 @@ url = "https://example.com/plugin.jar"
     }
 
     #[test]
+    fn has_maven_coord_on_empty_lockfile_is_false() {
+        assert!(!Lockfile::default().has_maven_coord("g:a", "1.0.0"));
+    }
+
+    #[test]
+    fn has_maven_coord_distinguishes_among_multiple_versions() {
+        // Two pins of the same coordinate at different versions (allowed in the
+        // graph-wide union): each version matches only itself.
+        let mk = |version: &str| DependencyLock {
+            name: "lib".to_owned(),
+            source: DepSource::Maven {
+                version: version.to_owned(),
+                maven: "g:lib".to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: Vec::new(),
+                classifier: None,
+            },
+            source_hash: "h".to_owned(),
+        };
+        let lockfile = Lockfile {
+            dependencies: vec![mk("1.0.0"), mk("2.0.0")],
+            ..Lockfile::default()
+        };
+        assert!(lockfile.has_maven_coord("g:lib", "1.0.0"));
+        assert!(lockfile.has_maven_coord("g:lib", "2.0.0"));
+        assert!(!lockfile.has_maven_coord("g:lib", "3.0.0"));
+    }
+
+    #[test]
+    fn has_maven_coord_matches_a_classifier_bearing_entry() {
+        // has_maven_coord keys on (coordinate, version) only — a cinterop entry
+        // (which shares its parent's coordinate + version) still counts as a
+        // match. Documents the classifier-agnostic contract.
+        let lockfile = Lockfile {
+            dependencies: vec![DependencyLock {
+                name: "atomicfu-cinterop".to_owned(),
+                source: DepSource::Maven {
+                    version: "0.23.1".to_owned(),
+                    maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                    targets: std::collections::BTreeMap::new(),
+                    required_by: vec!["atomicfu".to_owned()],
+                    classifier: Some("cinterop-interop".to_owned()),
+                },
+                source_hash: "h".to_owned(),
+            }],
+            ..Lockfile::default()
+        };
+        assert!(lockfile.has_maven_coord("org.jetbrains.kotlinx:atomicfu", "0.23.1"));
+    }
+
+    #[test]
     fn has_maven_entry_ignores_path_deps() {
         let mut lockfile = Lockfile::default();
         lockfile.dependencies.push(DependencyLock {

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -16,7 +16,7 @@ use konvoy_targets::{host_target, Target};
 use crate::artifact::{ArtifactStore, BuildMetadata};
 use crate::cache::{CacheInputs, CacheKey};
 use crate::error::EngineError;
-use crate::resolve::{parallel_levels, resolve_dependencies, ResolvedGraph};
+use crate::resolve::{parallel_levels, resolve_dependencies, ResolvedDep, ResolvedGraph};
 
 /// Options controlling a build invocation.
 #[derive(Debug, Clone)]
@@ -312,24 +312,40 @@ pub(crate) fn resolve_build_context(
     // the program entry point next to the process-wide NetworkClient and
     // threaded through everything that may fetch or reject artifact resolution.
 
+    // 2a. Resolve the path-dependency graph up front. Maven-dep AND plugin pinning
+    //     both span the WHOLE graph (root + path-deps), so every dependency's
+    //     manifest must be known before the auto-update / staleness gates and the
+    //     lockfile prediction. `resolve_dependencies` only reads dep manifests +
+    //     source hashes (it also enforces the shared Kotlin version), so it is
+    //     safe to run this early, and reusing it avoids resolving the graph twice.
+    let dep_graph = resolve_dependencies(project_root, &manifest)?;
+
     // 3. Auto-resolve Maven deps if needed (unless --locked or --offline).
-    //    When the manifest declares Maven deps that aren't in the lockfile,
-    //    run `konvoy update` automatically so users don't have to.
+    //    When ANY project in the graph (root or a path-dep) declares Maven deps
+    //    that aren't in the lockfile, run `konvoy update` automatically so users
+    //    don't have to — `update` resolves the graph-wide union into the root lock.
     //    - Under --locked the branch is skipped and the staleness check below
     //      reports the drift (this also makes drift win under --frozen).
     //    - Under --offline auto-resolving is forbidden outright: `update`
     //      fetches POMs and klibs from Maven Central, so an unresolved dep is
     //      a hard error here instead of a silent network access.
-    let lockfile = match first_unresolved_maven_dep(&manifest, &lockfile) {
+    let lockfile = match first_unresolved_graph_maven_dep(
+        std::iter::once(&manifest).chain(dep_graph.order.iter().map(|d| &d.manifest)),
+        &lockfile,
+    ) {
         Some(name) => {
             resolver.resolve_missing_maven_dependencies(project_root, &lockfile_path, name)?
         }
         _ => lockfile,
     };
 
-    // In --locked mode, verify the lockfile is complete and consistent
-    // with what konvoy.toml specifies before doing any work.
-    resolver.require_manifest_artifacts_resolvable(&manifest, &lockfile)?;
+    // In --locked mode, verify the lockfile is complete and consistent with what
+    // the whole graph's konvoy.toml files specify before doing any work.
+    resolver.require_graph_artifacts_resolvable(
+        &manifest,
+        dep_graph.order.iter().map(|d| &d.manifest),
+        &lockfile,
+    )?;
 
     // 4. Resolve target.
     let target = resolve_target(&options.target)?;
@@ -373,16 +389,9 @@ pub(crate) fn resolve_build_context(
         )?;
     }
 
-    // 6. Resolve the dependency graph up front. Plugin pinning spans the WHOLE
-    //    graph (root + path-deps), so every dependency's manifest must be known
-    //    before plugins are resolved and the lockfile is predicted.
-    //    `resolve_dependencies` only reads dep manifests + source hashes (no
-    //    toolchain/plugin state), so running it here — earlier than the build
-    //    loop below — is safe.
-    let dep_graph = resolve_dependencies(project_root, &manifest)?;
-
-    // 6a. Resolve + ensure plugin artifacts graph-wide, then pre-stabilize the
-    //     lockfile for cache-key consistency (issue #133).
+    // 6. Resolve + ensure plugin artifacts graph-wide (the dependency graph was
+    //    resolved up front at step 2a), then pre-stabilize the lockfile for
+    //    cache-key consistency (issue #133).
     //
     // When `konvoy.lock` does not exist (first build) or the toolchain version
     // has changed, the lockfile read at step 2 will differ from what
@@ -434,7 +443,32 @@ pub(crate) fn resolve_build_context(
         resolver,
     );
 
-    // 7. Build path dependencies in topological order.
+    // 7. Resolve & download the graph-wide Maven klib union ONCE, up front, so
+    //    each project's own compile (root or path-dep) can be handed the klibs
+    //    it links. Each klib comes back with a precomputed sha256 from
+    //    `download_artifact`, reused by the cache-key code. The union is keyed by
+    //    lock-entry name so a per-project subset can be assembled below.
+    let all_maven_entries: Vec<&DependencyLock> = effective_lockfile.dependencies.iter().collect();
+    let all_maven_klibs = resolve_maven_klibs(&all_maven_entries, &target, resolver)?;
+    let klib_by_name: HashMap<&str, LibraryInput> = effective_lockfile
+        .dependencies
+        .iter()
+        .filter(|d| matches!(&d.source, DepSource::Maven { .. }))
+        .map(|d| d.name.as_str())
+        .zip(all_maven_klibs.iter().cloned())
+        .collect();
+
+    // Index path-deps by name so a project's path-dep SUBTREE can be walked for
+    // its transitive Maven closure (a klib that exposes a Maven type in its API
+    // forces every dependent's compile to also see that Maven klib — verified:
+    // compiling against a klib whose API returns `Flow` needs coroutines.klib).
+    let dep_by_name: HashMap<&str, &ResolvedDep> = dep_graph
+        .order
+        .iter()
+        .map(|dep| (dep.name.as_str(), dep))
+        .collect();
+
+    // 8. Build path dependencies in topological order.
     let lockfile_content = lockfile_toml_content(&effective_lockfile)?;
 
     let levels = parallel_levels(&dep_graph);
@@ -443,7 +477,7 @@ pub(crate) fn resolve_build_context(
     for level in &levels {
         // Path-deps don't carry a pre-computed hash through the build pipeline,
         // so the cache-key code rehashes them as needed.
-        let lib_inputs: Vec<LibraryInput> = completed
+        let completed_path_klibs: Vec<LibraryInput> = completed
             .values()
             .cloned()
             .map(LibraryInput::unhashed)
@@ -451,6 +485,20 @@ pub(crate) fn resolve_build_context(
         let results: Vec<Result<(String, PathBuf, BuildOutcome), EngineError>> = level
             .par_iter()
             .map(|dep| {
+                // This dep links the path-dep klibs built so far plus the Maven
+                // closure of ITS OWN subtree — the `[dependencies]` analogue of
+                // deriving each project's own `-Xplugin` set (#293). A path-dep
+                // is thus compiled against exactly the klibs it (transitively)
+                // declares: identical to building it standalone (parity), and its
+                // cache key is not perturbed by unrelated deps elsewhere.
+                let mut lib_inputs = completed_path_klibs.clone();
+                let subtree =
+                    collect_subtree_manifests(&dep.manifest, &dep.dep_names, &dep_by_name);
+                lib_inputs.extend(project_maven_klibs(
+                    &subtree,
+                    &effective_lockfile,
+                    &klib_by_name,
+                ));
                 let dep_cc = CompileContext {
                     konanc: &konanc,
                     jre_home: jre_home.as_deref(),
@@ -482,11 +530,10 @@ pub(crate) fn resolve_build_context(
         .map(LibraryInput::unhashed)
         .collect();
 
-    // 7a. Resolve and download Maven dependency klibs for the current target.
-    //     Each Maven klib comes back with a precomputed sha256 from
-    //     `download_artifact`, which the cache-key code reuses to skip rehashing.
-    let maven_klibs = resolve_maven_deps(&effective_lockfile, &target, resolver)?;
-    library_inputs.extend(maven_klibs);
+    // The root links every path-dep klib (above) plus the FULL Maven union: the
+    // root's subtree is the whole graph, so its closure is the entire union —
+    // exactly what the root linked before this change.
+    library_inputs.extend(all_maven_klibs);
 
     let store = ArtifactStore::new(project_root);
 
@@ -920,16 +967,146 @@ struct PreparedKlib<'a> {
     needs_download: bool,
 }
 
-pub(crate) fn resolve_maven_deps(
+/// Compute a project's Maven dependency **closure** within the graph-wide union
+/// recorded in the root lock: the project's own direct Maven deps plus
+/// everything they transitively require.
+///
+/// Seeding matches by Maven **coordinate** (`group:artifactId`), not by the lock
+/// entry's `name`: the union dedups by coordinate and may keep another project's
+/// konvoy key for a shared dep, so a name match would miss it. Transitive
+/// expansion follows the lockfile's `required_by` (which lists requirer *names*).
+///
+/// This is the `[dependencies]` analogue of deriving each project's own
+/// `-Xplugin` set (#293): a path-dep is compiled against exactly the klibs it
+/// declares — identical to building it standalone (parity) — and its cache key
+/// is not perturbed by unrelated deps elsewhere in the graph.
+pub(crate) fn project_maven_closure<'a>(
+    manifest: &Manifest,
+    lockfile: &'a Lockfile,
+) -> Vec<&'a DependencyLock> {
+    use std::collections::BTreeSet;
+
+    // The project's direct Maven coordinates (group:artifactId), from its manifest.
+    let direct_coords: BTreeSet<&str> = manifest
+        .dependencies
+        .values()
+        .filter_map(|spec| spec.as_maven_coord().map(|(coord, _)| coord))
+        .collect();
+
+    // Seed the closure with lock entries whose coordinate the project declares.
+    let mut in_closure: BTreeSet<&str> = BTreeSet::new();
+    for dep in &lockfile.dependencies {
+        if let DepSource::Maven { maven, .. } = &dep.source {
+            if direct_coords.contains(maven.as_str()) {
+                in_closure.insert(dep.name.as_str());
+            }
+        }
+    }
+
+    // Expand transitively: a Maven entry is in the closure if any of its
+    // `required_by` requirers is already in the closure. Iterate to a fixpoint
+    // (the dependency graph is small, so a simple pass-until-stable is fine).
+    loop {
+        let mut grew = false;
+        for dep in &lockfile.dependencies {
+            if in_closure.contains(dep.name.as_str()) {
+                continue;
+            }
+            if let DepSource::Maven { required_by, .. } = &dep.source {
+                if required_by.iter().any(|r| in_closure.contains(r.as_str())) {
+                    in_closure.insert(dep.name.as_str());
+                    grew = true;
+                }
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    lockfile
+        .dependencies
+        .iter()
+        .filter(|d| {
+            matches!(&d.source, DepSource::Maven { .. }) && in_closure.contains(d.name.as_str())
+        })
+        .collect()
+}
+
+/// Collect the manifests in a project's path-dependency **subtree**: the project
+/// itself plus every path-dep transitively reachable through `dep_names`.
+///
+/// A project's compile must see the Maven closure of its whole subtree, not just
+/// its own direct deps: a path-dep whose public API exposes a Maven type forces
+/// every dependent's compile to also resolve that Maven klib (konanc rejects a
+/// klib reference whose transitive deps aren't on the library path).
+fn collect_subtree_manifests<'a>(
+    start_manifest: &'a Manifest,
+    start_dep_names: &[String],
+    by_name: &HashMap<&str, &'a ResolvedDep>,
+) -> Vec<&'a Manifest> {
+    use std::collections::BTreeSet;
+    let mut out = vec![start_manifest];
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut stack: Vec<&str> = start_dep_names.iter().map(String::as_str).collect();
+    while let Some(name) = stack.pop() {
+        if !seen.insert(name) {
+            continue;
+        }
+        if let Some(dep) = by_name.get(name) {
+            out.push(&dep.manifest);
+            stack.extend(dep.dep_names.iter().map(String::as_str));
+        }
+    }
+    out
+}
+
+/// The Maven klibs a project links: the union of [`project_maven_closure`] over
+/// its `subtree` manifests, resolved against the already-downloaded
+/// `klib_by_name`. Deduped by lock-entry name.
+fn project_maven_klibs(
+    subtree: &[&Manifest],
     lockfile: &Lockfile,
+    klib_by_name: &HashMap<&str, LibraryInput>,
+) -> Vec<LibraryInput> {
+    use std::collections::BTreeSet;
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for manifest in subtree {
+        for entry in project_maven_closure(manifest, lockfile) {
+            names.insert(entry.name.clone());
+        }
+    }
+    names
+        .iter()
+        .filter_map(|n| klib_by_name.get(n.as_str()).cloned())
+        .collect()
+}
+
+/// Resolve every Maven entry in a lockfile (test convenience). Production builds
+/// resolve per-project subsets via [`project_maven_closure`] +
+/// [`resolve_maven_klibs`]; this whole-lockfile wrapper keeps the focused
+/// download/offline/hash tests independent of closure computation.
+#[cfg(test)]
+fn resolve_maven_deps(
+    lockfile: &Lockfile,
+    target: &Target,
+    resolver: crate::common::ArtifactResolver<'_>,
+) -> Result<Vec<LibraryInput>, EngineError> {
+    let entries: Vec<&DependencyLock> = lockfile.dependencies.iter().collect();
+    resolve_maven_klibs(&entries, target, resolver)
+}
+
+/// Download the per-target klibs for a specific set of lockfile Maven entries
+/// (a project's [`project_maven_closure`]). Non-Maven entries are ignored.
+pub(crate) fn resolve_maven_klibs(
+    entries: &[&DependencyLock],
     target: &Target,
     resolver: crate::common::ArtifactResolver<'_>,
 ) -> Result<Vec<LibraryInput>, EngineError> {
     use rayon::prelude::IndexedParallelIterator;
 
     // Filter to Maven entries AND extract their fields in one pass.
-    let maven_locks: Vec<MavenLockView> = lockfile
-        .dependencies
+    let maven_locks: Vec<MavenLockView> = entries
         .iter()
         .filter_map(|d| match &d.source {
             DepSource::Maven {
@@ -1045,10 +1222,13 @@ fn download_one_klib(
     resolver.resolve_maven_klib(p.entry.name, &p.url, &p.dest, p.expected_sha256, maybe_bar)
 }
 
-/// Returns the name of the first manifest Maven dep that has no matching
-/// lockfile entry, or `None` when everything is resolved. Used to trigger the
-/// automatic `konvoy update` during build — or, under `--offline`, to refuse
-/// it with the offending dependency named in the error.
+/// Returns the konvoy key of the first manifest Maven dep that has no matching
+/// lockfile pin (by COORDINATE + version), or `None` when everything is
+/// resolved. Used to trigger the automatic `konvoy update` during build — or,
+/// under `--offline`, to refuse it with the offending dependency named.
+///
+/// Coordinate matching (not name) lets a path-dep's Maven dep be recognized as
+/// resolved even when the union pinned it under another project's konvoy key.
 pub(crate) fn first_unresolved_maven_dep(
     manifest: &Manifest,
     lockfile: &Lockfile,
@@ -1056,8 +1236,24 @@ pub(crate) fn first_unresolved_maven_dep(
     manifest
         .dependencies
         .iter()
-        .find(|(name, spec)| spec.is_maven() && !lockfile.has_maven_entry(name))
+        .find(|(_, spec)| {
+            spec.as_maven_coord()
+                .is_some_and(|(maven, version)| !lockfile.has_maven_coord(maven, version))
+        })
         .map(|(name, _)| name.clone())
+}
+
+/// Graph-wide [`first_unresolved_maven_dep`]: the first unresolved Maven dep
+/// across the root **and every path-dependency** manifest. A path-dep's
+/// `[dependencies]` must be resolved into the root lock too, so an unresolved
+/// one triggers the same auto-update / `--offline` refusal as the root's.
+pub(crate) fn first_unresolved_graph_maven_dep<'a>(
+    manifests: impl IntoIterator<Item = &'a Manifest>,
+    lockfile: &Lockfile,
+) -> Option<String> {
+    manifests
+        .into_iter()
+        .find_map(|m| first_unresolved_maven_dep(m, lockfile))
 }
 
 /// Check that the lockfile is complete and consistent with the manifest.
@@ -1105,14 +1301,44 @@ pub(crate) fn check_lockfile_staleness(
         }
     }
 
-    // If the manifest has Maven dependencies (maven + version set), the lockfile must
-    // have matching Maven entries for each.
-    for (dep_name, dep_spec) in &manifest.dependencies {
-        if dep_spec.is_maven() && !lockfile.has_maven_entry(dep_name) {
-            return Err(EngineError::LockfileUpdateRequired);
+    // If the manifest has Maven dependencies (maven + version set), the lockfile
+    // must pin each (by coordinate + version).
+    manifest_maven_deps_resolved(manifest, lockfile)?;
+
+    Ok(())
+}
+
+/// Each Maven dep declared by `manifest` must be pinned in `lockfile` (by
+/// coordinate + version). Shared by the root staleness check and the per-path-dep
+/// graph staleness check so both agree on what "resolved" means.
+fn manifest_maven_deps_resolved(
+    manifest: &Manifest,
+    lockfile: &Lockfile,
+) -> Result<(), EngineError> {
+    for spec in manifest.dependencies.values() {
+        if let Some((maven, version)) = spec.as_maven_coord() {
+            if !lockfile.has_maven_coord(maven, version) {
+                return Err(EngineError::LockfileUpdateRequired);
+            }
         }
     }
+    Ok(())
+}
 
+/// Graph-wide staleness: the full root check plus, for every path-dependency,
+/// that its `[dependencies]` Maven deps are pinned in the (shared) root lock.
+/// Path-deps' toolchain is enforced equal to the root's by `resolve_dependencies`
+/// and their plugins are gated by the graph-wide ensure, so only their Maven deps
+/// add a new `--locked` staleness condition here.
+pub(crate) fn check_graph_lockfile_staleness<'a>(
+    manifest: &Manifest,
+    dep_manifests: impl IntoIterator<Item = &'a Manifest>,
+    lockfile: &Lockfile,
+) -> Result<(), EngineError> {
+    check_lockfile_staleness(manifest, lockfile)?;
+    for dep_manifest in dep_manifests {
+        manifest_maven_deps_resolved(dep_manifest, lockfile)?;
+    }
     Ok(())
 }
 
@@ -4177,6 +4403,173 @@ mod tests {
             result.is_empty(),
             "expected empty vec for path-only deps, got: {result:?}"
         );
+    }
+
+    fn maven_lock(name: &str, coord: &str, version: &str, required_by: &[&str]) -> DependencyLock {
+        DependencyLock {
+            name: name.to_owned(),
+            source: DepSource::Maven {
+                version: version.to_owned(),
+                maven: coord.to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: required_by.iter().map(|s| (*s).to_owned()).collect(),
+                classifier: None,
+            },
+            source_hash: "h".to_owned(),
+        }
+    }
+
+    fn closure_names(manifest: &Manifest, lockfile: &Lockfile) -> Vec<String> {
+        let mut names: Vec<String> = project_maven_closure(manifest, lockfile)
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn project_maven_closure_includes_own_direct_and_transitive_only() {
+        // The graph-wide root lock holds the UNION across projects. A given
+        // project's compile must link only ITS OWN closure (direct + transitive),
+        // not another project's deps — otherwise standalone != as-dependency and
+        // its cache key is perturbed by unrelated deps.
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\na = { maven = \"g:a\", version = \"1.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        lockfile.dependencies = vec![
+            maven_lock("a", "g:a", "1.0", &[]),    // this project's direct dep
+            maven_lock("b", "g:b", "1.0", &["a"]), // transitive of a -> in closure
+            maven_lock("c", "g:c", "1.0", &[]),    // ANOTHER project's direct dep
+            maven_lock("d", "g:d", "1.0", &["c"]), // transitive of c -> excluded
+        ];
+
+        assert_eq!(
+            closure_names(&manifest, &lockfile),
+            vec!["a".to_owned(), "b".to_owned()],
+            "closure must be the project's own direct + transitive deps only"
+        );
+    }
+
+    #[test]
+    fn project_maven_closure_matches_by_coordinate_not_lock_name() {
+        // The project declares the dep under a different konvoy key than the lock
+        // entry's name (the union dedups by coordinate and may keep another
+        // project's name). Seeding must match by the maven COORDINATE, not the name.
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\nmy-coroutines = { maven = \"org.jetbrains.kotlinx:kotlinx-coroutines-core\", version = \"1.8.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        // Lock entry uses a DIFFERENT name (e.g. another project declared it first).
+        lockfile.dependencies = vec![maven_lock(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+            &[],
+        )];
+
+        assert_eq!(
+            closure_names(&manifest, &lockfile),
+            vec!["coroutines".to_owned()],
+            "closure must match by coordinate even when the lock name differs"
+        );
+    }
+
+    #[test]
+    fn first_unresolved_graph_maven_dep_finds_path_dep_unresolved() {
+        // The root has its Maven dep pinned; a path-dep declares one that ISN'T
+        // in the lockfile. The graph-wide check must surface it (so auto-update /
+        // --offline refusal covers path-dep Maven deps too).
+        let root = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"app\"\nkind = \"bin\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\ndatetime = { maven = \"org.jetbrains.kotlinx:kotlinx-datetime\", version = \"0.6.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let dep = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"models\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\ncoroutines = { maven = \"org.jetbrains.kotlinx:kotlinx-coroutines-core\", version = \"1.8.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        // Only the root's datetime is pinned; the dep's coroutines is missing.
+        lockfile.dependencies = vec![maven_lock(
+            "datetime",
+            "org.jetbrains.kotlinx:kotlinx-datetime",
+            "0.6.0",
+            &[],
+        )];
+
+        // Root alone: nothing unresolved.
+        assert!(first_unresolved_maven_dep(&root, &lockfile).is_none());
+        // Graph-wide: the dep's coroutines surfaces.
+        assert_eq!(
+            first_unresolved_graph_maven_dep([&root, &dep], &lockfile).as_deref(),
+            Some("coroutines"),
+        );
+    }
+
+    #[test]
+    fn check_graph_lockfile_staleness_flags_unpinned_path_dep_maven() {
+        // Root passes its own staleness, but a path-dep's Maven dep is unpinned →
+        // graph staleness must fail (so --locked refuses an incomplete lock).
+        let root = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"app\"\nkind = \"bin\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let dep = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"models\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\ncoroutines = { maven = \"org.jetbrains.kotlinx:kotlinx-coroutines-core\", version = \"1.8.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let lockfile = Lockfile::with_toolchain("2.2.0");
+
+        // Root-only staleness passes (root declares no Maven deps).
+        assert!(check_lockfile_staleness(&root, &lockfile).is_ok());
+        // Graph staleness fails on the dep's unpinned Maven dep.
+        assert!(check_graph_lockfile_staleness(&root, [&dep], &lockfile).is_err());
+    }
+
+    #[test]
+    fn check_graph_lockfile_staleness_passes_when_path_dep_maven_pinned_by_coord() {
+        // The dep's Maven dep is pinned in the union under a DIFFERENT konvoy key
+        // (coordinate match) — graph staleness must accept it.
+        let root = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"app\"\nkind = \"bin\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let dep = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"models\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\nmy-coroutines = { maven = \"org.jetbrains.kotlinx:kotlinx-coroutines-core\", version = \"1.8.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        lockfile.dependencies = vec![maven_lock(
+            "coroutines", // different konvoy key than the dep's "my-coroutines"
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+            &[],
+        )];
+
+        assert!(check_graph_lockfile_staleness(&root, [&dep], &lockfile).is_ok());
+    }
+
+    #[test]
+    fn project_maven_closure_empty_when_no_maven_deps() {
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"bin\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        lockfile.dependencies = vec![maven_lock("a", "g:a", "1.0", &[])];
+        assert!(project_maven_closure(&manifest, &lockfile).is_empty());
     }
 
     #[test]

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -1,6 +1,6 @@
 //! Build orchestration: resolve config, detect target, invoke compiler, store artifacts.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -278,6 +278,14 @@ fn predicted_dependency_locks(
             new_deps.push(dep_lock.clone());
         }
     }
+
+    // Sort by name, byte-for-byte identical to what `konvoy update` writes
+    // (update.rs sorts its merged dependency set the same way). Without this the
+    // build emits deps in topological+lockfile order while `update` emits them
+    // alphabetically, so `konvoy update` then `konvoy build --locked` would see a
+    // pure ordering difference and spuriously fail (and recompile, since the
+    // lockfile order feeds the cache key).
+    new_deps.sort_by(|a, b| a.name.cmp(&b.name));
     new_deps
 }
 
@@ -333,9 +341,13 @@ pub(crate) fn resolve_build_context(
         std::iter::once(&manifest).chain(dep_graph.order.iter().map(|d| &d.manifest)),
         &lockfile,
     ) {
-        Some(name) => {
-            resolver.resolve_missing_maven_dependencies(project_root, &lockfile_path, name)?
-        }
+        Some(name) => resolver.resolve_missing_maven_dependencies(
+            project_root,
+            &manifest,
+            &dep_graph,
+            &lockfile_path,
+            name,
+        )?,
         _ => lockfile,
     };
 
@@ -446,26 +458,80 @@ pub(crate) fn resolve_build_context(
     // 7. Resolve & download the graph-wide Maven klib union ONCE, up front, so
     //    each project's own compile (root or path-dep) can be handed the klibs
     //    it links. Each klib comes back with a precomputed sha256 from
-    //    `download_artifact`, reused by the cache-key code. The union is keyed by
-    //    lock-entry name so a per-project subset can be assembled below.
+    //    `download_artifact`, reused by the cache-key code. Klibs are keyed by
+    //    COORDINATE (not the konvoy lock name): two coordinates declared under
+    //    the same key across projects must not collapse.
     let all_maven_entries: Vec<&DependencyLock> = effective_lockfile.dependencies.iter().collect();
     let all_maven_klibs = resolve_maven_klibs(&all_maven_entries, &target, resolver)?;
-    let klib_by_name: HashMap<&str, LibraryInput> = effective_lockfile
+    let klib_by_coord: HashMap<MavenCoordKey, LibraryInput> = effective_lockfile
         .dependencies
         .iter()
-        .filter(|d| matches!(&d.source, DepSource::Maven { .. }))
-        .map(|d| d.name.as_str())
+        .filter_map(maven_coord_key)
         .zip(all_maven_klibs.iter().cloned())
         .collect();
 
-    // Index path-deps by name so a project's path-dep SUBTREE can be walked for
-    // its transitive Maven closure (a klib that exposes a Maven type in its API
-    // forces every dependent's compile to also see that Maven klib — verified:
-    // compiling against a klib whose API returns `Flow` needs coroutines.klib).
+    // Index path-deps by name, and precompute each dep's OWN Maven closure
+    // (coordinates) once — a dep shared by several dependents would otherwise be
+    // re-derived per dependent. A project's compile then links the union of its
+    // whole subtree's closures: a klib whose API exposes a Maven type forces
+    // every dependent's compile to also see that klib (verified: compiling
+    // against a klib whose API returns `Flow` needs coroutines.klib).
     let dep_by_name: HashMap<&str, &ResolvedDep> = dep_graph
         .order
         .iter()
         .map(|dep| (dep.name.as_str(), dep))
+        .collect();
+    let own_closure: HashMap<&str, Vec<MavenCoordKey>> = dep_graph
+        .order
+        .iter()
+        .map(|dep| {
+            (
+                dep.name.as_str(),
+                project_maven_closure_coords(&dep.manifest, &effective_lockfile),
+            )
+        })
+        .collect();
+
+    // Resolve the coordinate set into klibs (deduped + sorted for determinism).
+    let coords_to_klibs = |coords: BTreeSet<MavenCoordKey>| -> Vec<LibraryInput> {
+        coords
+            .iter()
+            .filter_map(|c| klib_by_coord.get(c).cloned())
+            .collect()
+    };
+
+    // Per-dep compile inputs, invariant across build levels: its transitive
+    // path-dep descendant NAMES (their klibs are looked up in `completed` during
+    // the loop) and its subtree's Maven klibs (own closure ∪ descendants').
+    let dep_inputs: HashMap<&str, (Vec<String>, Vec<LibraryInput>)> = dep_graph
+        .order
+        .iter()
+        .map(|dep| {
+            let descendants = collect_descendant_deps(&dep.dep_names, &dep_by_name);
+            // own_closure has an entry for every dep in dep_graph.order (incl.
+            // every descendant), so the lookups never miss; `flatten` over the
+            // `Option` keeps it index-panic-free.
+            let mut coords: BTreeSet<MavenCoordKey> = own_closure
+                .get(dep.name.as_str())
+                .into_iter()
+                .flatten()
+                .cloned()
+                .collect();
+            for d in &descendants {
+                coords.extend(
+                    own_closure
+                        .get(d.name.as_str())
+                        .into_iter()
+                        .flatten()
+                        .cloned(),
+                );
+            }
+            let descendant_names = descendants.iter().map(|d| d.name.clone()).collect();
+            (
+                dep.name.as_str(),
+                (descendant_names, coords_to_klibs(coords)),
+            )
+        })
         .collect();
 
     // 8. Build path dependencies in topological order.
@@ -475,37 +541,32 @@ pub(crate) fn resolve_build_context(
     let mut completed: HashMap<String, PathBuf> = HashMap::new();
 
     for level in &levels {
-        // Snapshot of path-dep klibs built in PRIOR levels, keyed by dep name so
-        // each dep can select only its OWN transitive path-dep descendants.
-        // (Same-level deps are independent and not yet in `completed`, so they
-        // never see each other — taking the snapshot before the level enforces
-        // that.) Path-deps don't carry a pre-computed hash through the build
-        // pipeline, so the cache-key code rehashes them as needed.
-        let prior_klibs: HashMap<String, PathBuf> = completed.clone();
         let results: Vec<Result<(String, PathBuf, BuildOutcome), EngineError>> = level
             .par_iter()
             .map(|dep| {
                 // This dep is compiled against exactly its OWN subtree — its
-                // transitive path-dep descendants' klibs plus the Maven closure
-                // of that subtree — the `[dependencies]` analogue of deriving
-                // each project's own `-Xplugin` set (#293). So a path-dep builds
+                // transitive path-dep descendants' klibs plus the Maven closure of
+                // that subtree — the `[dependencies]` analogue of deriving each
+                // project's own `-Xplugin` set (#293). So a path-dep builds
                 // identically standalone and as a dependency (parity): an
                 // undeclared cross-dep import fails here too, not only standalone,
                 // and the dep's cache key is not perturbed by unrelated deps.
-                let descendants = collect_descendant_deps(&dep.dep_names, &dep_by_name);
-                let mut lib_inputs: Vec<LibraryInput> = descendants
+                //
+                // Descendant klibs are read straight from `completed` (built in
+                // strictly-earlier levels; same-level deps aren't inserted until
+                // after the level, so they never see each other). `dep_inputs`
+                // has an entry for every dep in dep_graph.order.
+                let (descendant_names, maven_klibs) = dep_inputs
+                    .get(dep.name.as_str())
+                    .ok_or_else(|| EngineError::InternalInvariantViolated {
+                        context: format!("missing precomputed inputs for dep `{}`", dep.name),
+                    })?;
+                let mut lib_inputs: Vec<LibraryInput> = descendant_names
                     .iter()
-                    .filter_map(|d| prior_klibs.get(&d.name).cloned())
+                    .filter_map(|n| completed.get(n).cloned())
                     .map(LibraryInput::unhashed)
                     .collect();
-                let subtree: Vec<&Manifest> = std::iter::once(&dep.manifest)
-                    .chain(descendants.iter().map(|d| &d.manifest))
-                    .collect();
-                lib_inputs.extend(project_maven_klibs(
-                    &subtree,
-                    &effective_lockfile,
-                    &klib_by_name,
-                ));
+                lib_inputs.extend(maven_klibs.iter().cloned());
                 let dep_cc = CompileContext {
                     konanc: &konanc,
                     jre_home: jre_home.as_deref(),
@@ -537,10 +598,18 @@ pub(crate) fn resolve_build_context(
         .map(LibraryInput::unhashed)
         .collect();
 
-    // The root links every path-dep klib (above) plus the FULL Maven union: the
-    // root's subtree is the whole graph, so its closure is the entire union —
-    // exactly what the root linked before this change.
-    library_inputs.extend(all_maven_klibs);
+    // The root links every path-dep klib (above) plus the Maven closure of its
+    // OWN subtree, which IS the whole graph — same mechanism as every path-dep,
+    // no special case. With the union pinned exactly (no stale entries) this
+    // equals the full union the root linked before.
+    let mut root_coords: BTreeSet<MavenCoordKey> =
+        project_maven_closure_coords(&manifest, &effective_lockfile)
+            .into_iter()
+            .collect();
+    for coords in own_closure.values() {
+        root_coords.extend(coords.iter().cloned());
+    }
+    library_inputs.extend(coords_to_klibs(root_coords));
 
     let store = ArtifactStore::new(project_root);
 
@@ -1072,24 +1141,32 @@ fn collect_descendant_deps<'a>(
     out
 }
 
-/// The Maven klibs a project links: the union of [`project_maven_closure`] over
-/// its `subtree` manifests, resolved against the already-downloaded
-/// `klib_by_name`. Deduped by lock-entry name.
-fn project_maven_klibs(
-    subtree: &[&Manifest],
-    lockfile: &Lockfile,
-    klib_by_name: &HashMap<&str, LibraryInput>,
-) -> Vec<LibraryInput> {
-    use std::collections::BTreeSet;
-    let mut names: BTreeSet<String> = BTreeSet::new();
-    for manifest in subtree {
-        for entry in project_maven_closure(manifest, lockfile) {
-            names.insert(entry.name.clone());
-        }
+/// The content identity of a Maven artifact: `(groupId:artifactId, version,
+/// classifier)`. Used to key downloaded klibs so two coordinates declared under
+/// the same konvoy key across projects never collapse (a name-keyed map would
+/// drop one).
+type MavenCoordKey = (String, String, Option<String>);
+
+/// The coordinate key of a Maven lock entry, or `None` for a path entry.
+fn maven_coord_key(dep: &DependencyLock) -> Option<MavenCoordKey> {
+    match &dep.source {
+        DepSource::Maven {
+            maven,
+            version,
+            classifier,
+            ..
+        } => Some((maven.clone(), version.clone(), classifier.clone())),
+        DepSource::Path { .. } => None,
     }
-    names
+}
+
+/// A project's own direct+transitive Maven closure as coordinate keys (see
+/// [`project_maven_closure`]). Computed once per project and unioned across a
+/// subtree to assemble compile inputs.
+fn project_maven_closure_coords(manifest: &Manifest, lockfile: &Lockfile) -> Vec<MavenCoordKey> {
+    project_maven_closure(manifest, lockfile)
         .iter()
-        .filter_map(|n| klib_by_name.get(n.as_str()).cloned())
+        .filter_map(|d| maven_coord_key(d))
         .collect()
 }
 
@@ -1326,14 +1403,13 @@ fn manifest_maven_deps_resolved(
     manifest: &Manifest,
     lockfile: &Lockfile,
 ) -> Result<(), EngineError> {
-    for spec in manifest.dependencies.values() {
-        if let Some((maven, version)) = spec.as_maven_coord() {
-            if !lockfile.has_maven_coord(maven, version) {
-                return Err(EngineError::LockfileUpdateRequired);
-            }
-        }
+    // Same predicate as `first_unresolved_maven_dep`, surfaced as a staleness
+    // error — share the one implementation so the two can't disagree about what
+    // "resolved" means.
+    match first_unresolved_maven_dep(manifest, lockfile) {
+        Some(_) => Err(EngineError::LockfileUpdateRequired),
+        None => Ok(()),
     }
-    Ok(())
 }
 
 /// Graph-wide staleness: the full root check plus, for every path-dependency,

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -4615,6 +4615,163 @@ mod tests {
     }
 
     #[test]
+    fn predicted_dependency_locks_empty_graph_and_lockfile_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        assert!(predicted_dependency_locks(&Lockfile::default(), &graph, tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn predicted_dependency_locks_preserves_path_source_hash_and_maven_verbatim() {
+        // The path dep carries its source_hash; the Maven entry is preserved
+        // byte-for-byte (build never edits Maven locks — only `konvoy update` does).
+        let tmp = tempfile::tempdir().unwrap();
+        let mut dep = resolved_dep("models", &[]);
+        dep.project_root = tmp.path().join("models");
+        dep.source_hash = "src-hash-123".to_owned();
+        let graph = crate::resolve::ResolvedGraph { order: vec![dep] };
+        let maven = maven_lock(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+            &["x"],
+        );
+        let mut lockfile = Lockfile::default();
+        lockfile.dependencies.push(maven.clone());
+
+        let locks = predicted_dependency_locks(&lockfile, &graph, tmp.path());
+        // The path dep keeps its source hash and a Path source.
+        let models = locks.iter().find(|d| d.name == "models").unwrap();
+        assert_eq!(models.source_hash, "src-hash-123");
+        assert!(matches!(&models.source, DepSource::Path { .. }));
+        // The Maven entry is carried over identically.
+        let cor = locks.iter().find(|d| d.name == "coroutines").unwrap();
+        assert_eq!(cor, &maven);
+    }
+
+    #[test]
+    fn predicted_dependency_locks_only_maven_no_path_deps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        let mut lockfile = Lockfile::default();
+        lockfile
+            .dependencies
+            .push(maven_lock("b", "g:b", "1.0", &[]));
+        lockfile
+            .dependencies
+            .push(maven_lock("a", "g:a", "1.0", &[]));
+
+        let locks = predicted_dependency_locks(&lockfile, &graph, tmp.path());
+        let names: Vec<&str> = locks.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["a", "b"],
+            "Maven entries are sorted by name too"
+        );
+    }
+
+    #[test]
+    fn maven_coord_key_distinguishes_classifiers() {
+        let main = DependencyLock {
+            name: "atomicfu".to_owned(),
+            source: DepSource::Maven {
+                version: "0.23.1".to_owned(),
+                maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: Vec::new(),
+                classifier: None,
+            },
+            source_hash: "h".to_owned(),
+        };
+        let mut cinterop = main.clone();
+        if let DepSource::Maven { classifier, .. } = &mut cinterop.source {
+            *classifier = Some("cinterop-interop".to_owned());
+        }
+        // Same coordinate + version, different classifier → distinct keys, so
+        // both klibs survive in the coord-keyed map.
+        assert_ne!(maven_coord_key(&main), maven_coord_key(&cinterop));
+    }
+
+    #[test]
+    fn project_maven_closure_includes_cinterop_via_required_by() {
+        // A cinterop entry (classifier set) is required_by its parent; when the
+        // parent is in a project's closure, the cinterop klib must be too.
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\natomicfu = { maven = \"org.jetbrains.kotlinx:atomicfu\", version = \"0.23.1\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        lockfile.dependencies = vec![
+            maven_lock("atomicfu", "org.jetbrains.kotlinx:atomicfu", "0.23.1", &[]),
+            // cinterop sibling, pulled in by atomicfu
+            DependencyLock {
+                name: "atomicfu-cinterop-interop".to_owned(),
+                source: DepSource::Maven {
+                    version: "0.23.1".to_owned(),
+                    maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                    targets: std::collections::BTreeMap::new(),
+                    required_by: vec!["atomicfu".to_owned()],
+                    classifier: Some("cinterop-interop".to_owned()),
+                },
+                source_hash: "h".to_owned(),
+            },
+        ];
+        assert_eq!(
+            closure_names(&manifest, &lockfile),
+            vec![
+                "atomicfu".to_owned(),
+                "atomicfu-cinterop-interop".to_owned()
+            ],
+            "the cinterop klib must ride along with its parent"
+        );
+    }
+
+    #[test]
+    fn project_maven_closure_walks_deep_chain_and_merges_multiple_requirers() {
+        // p declares a; a→b→c (3 levels), and c is ALSO required by a second
+        // direct dep d. Closure of {a, d} = {a, b, c, d}.
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\na = { maven = \"g:a\", version = \"1.0\" }\nd = { maven = \"g:d\", version = \"1.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.2.0");
+        lockfile.dependencies = vec![
+            maven_lock("a", "g:a", "1.0", &[]),
+            maven_lock("b", "g:b", "1.0", &["a"]),
+            maven_lock("c", "g:c", "1.0", &["b", "d"]), // required by both b and d
+            maven_lock("d", "g:d", "1.0", &[]),
+        ];
+        assert_eq!(
+            closure_names(&manifest, &lockfile),
+            vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_descendant_deps_skips_unknown_names_and_survives_cycles() {
+        // a -> {b, ghost}; b -> a (cycle). `ghost` isn't in by_name → skipped;
+        // the cycle must terminate via the `seen` set.
+        let a = resolved_dep("a", &["b", "ghost"]);
+        let b = resolved_dep("b", &["a"]);
+        let by_name: HashMap<&str, &ResolvedDep> = [("a", &a), ("b", &b)].into_iter().collect();
+
+        let mut names: Vec<&str> = collect_descendant_deps(&["a".to_owned()], &by_name)
+            .iter()
+            .map(|d| d.name.as_str())
+            .collect();
+        names.sort();
+        // `a` and `b` (the cycle), no panic, no `ghost`.
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
     fn collect_descendant_deps_walks_transitively_and_dedupes_diamond() {
         // Graph: parent -> {child, sibling}; child -> grandchild; sibling -> grandchild
         // (a diamond). parent's transitive descendants are child, sibling, and

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -463,7 +463,10 @@ pub(crate) fn resolve_build_context(
     //    the same key across projects must not collapse.
     let all_maven_entries: Vec<&DependencyLock> = effective_lockfile.dependencies.iter().collect();
     let all_maven_klibs = resolve_maven_klibs(&all_maven_entries, &target, resolver)?;
-    let klib_by_coord: HashMap<MavenCoordKey, LibraryInput> = effective_lockfile
+    // A `BTreeMap` so `.values()` is coord-sorted + deduped — the exact set the
+    // root links (its subtree is the whole graph), in a deterministic order so
+    // the root's cache key is stable.
+    let klib_by_coord: std::collections::BTreeMap<MavenCoordKey, LibraryInput> = effective_lockfile
         .dependencies
         .iter()
         .filter_map(maven_coord_key)
@@ -598,18 +601,11 @@ pub(crate) fn resolve_build_context(
         .map(LibraryInput::unhashed)
         .collect();
 
-    // The root links every path-dep klib (above) plus the Maven closure of its
-    // OWN subtree, which IS the whole graph — same mechanism as every path-dep,
-    // no special case. With the union pinned exactly (no stale entries) this
-    // equals the full union the root linked before.
-    let mut root_coords: BTreeSet<MavenCoordKey> =
-        project_maven_closure_coords(&manifest, &effective_lockfile)
-            .into_iter()
-            .collect();
-    for coords in own_closure.values() {
-        root_coords.extend(coords.iter().cloned());
-    }
-    library_inputs.extend(coords_to_klibs(root_coords));
+    // The root links every path-dep klib (above) plus the WHOLE Maven union: its
+    // subtree is the entire graph, so its closure is exactly the pinned set,
+    // which `klib_by_coord.values()` already holds coord-deduped and sorted — no
+    // need to re-run the closure fixpoint over the whole graph just to rebuild it.
+    library_inputs.extend(klib_by_coord.values().cloned());
 
     let store = ArtifactStore::new(project_root);
 
@@ -1051,6 +1047,10 @@ struct PreparedKlib<'a> {
 /// entry's `name`: the union dedups by coordinate and may keep another project's
 /// konvoy key for a shared dep, so a name match would miss it. Transitive
 /// expansion follows the lockfile's `required_by` (which lists requirer *names*).
+/// This assumes `required_by` is complete, which `konvoy update` guarantees; a
+/// lockfile written by a pre-#293 konvoy may have gaps, so a `--locked` build
+/// against such a stale lock could under-resolve — re-running `konvoy update`
+/// (or any non-locked build) regenerates a complete lock.
 ///
 /// This is the `[dependencies]` analogue of deriving each project's own
 /// `-Xplugin` set (#293): a path-dep is compiled against exactly the klibs it

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -475,25 +475,32 @@ pub(crate) fn resolve_build_context(
     let mut completed: HashMap<String, PathBuf> = HashMap::new();
 
     for level in &levels {
-        // Path-deps don't carry a pre-computed hash through the build pipeline,
-        // so the cache-key code rehashes them as needed.
-        let completed_path_klibs: Vec<LibraryInput> = completed
-            .values()
-            .cloned()
-            .map(LibraryInput::unhashed)
-            .collect();
+        // Snapshot of path-dep klibs built in PRIOR levels, keyed by dep name so
+        // each dep can select only its OWN transitive path-dep descendants.
+        // (Same-level deps are independent and not yet in `completed`, so they
+        // never see each other — taking the snapshot before the level enforces
+        // that.) Path-deps don't carry a pre-computed hash through the build
+        // pipeline, so the cache-key code rehashes them as needed.
+        let prior_klibs: HashMap<String, PathBuf> = completed.clone();
         let results: Vec<Result<(String, PathBuf, BuildOutcome), EngineError>> = level
             .par_iter()
             .map(|dep| {
-                // This dep links the path-dep klibs built so far plus the Maven
-                // closure of ITS OWN subtree — the `[dependencies]` analogue of
-                // deriving each project's own `-Xplugin` set (#293). A path-dep
-                // is thus compiled against exactly the klibs it (transitively)
-                // declares: identical to building it standalone (parity), and its
-                // cache key is not perturbed by unrelated deps elsewhere.
-                let mut lib_inputs = completed_path_klibs.clone();
-                let subtree =
-                    collect_subtree_manifests(&dep.manifest, &dep.dep_names, &dep_by_name);
+                // This dep is compiled against exactly its OWN subtree — its
+                // transitive path-dep descendants' klibs plus the Maven closure
+                // of that subtree — the `[dependencies]` analogue of deriving
+                // each project's own `-Xplugin` set (#293). So a path-dep builds
+                // identically standalone and as a dependency (parity): an
+                // undeclared cross-dep import fails here too, not only standalone,
+                // and the dep's cache key is not perturbed by unrelated deps.
+                let descendants = collect_descendant_deps(&dep.dep_names, &dep_by_name);
+                let mut lib_inputs: Vec<LibraryInput> = descendants
+                    .iter()
+                    .filter_map(|d| prior_klibs.get(&d.name).cloned())
+                    .map(LibraryInput::unhashed)
+                    .collect();
+                let subtree: Vec<&Manifest> = std::iter::once(&dep.manifest)
+                    .chain(descendants.iter().map(|d| &d.manifest))
+                    .collect();
                 lib_inputs.extend(project_maven_klibs(
                     &subtree,
                     &effective_lockfile,
@@ -1033,20 +1040,24 @@ pub(crate) fn project_maven_closure<'a>(
         .collect()
 }
 
-/// Collect the manifests in a project's path-dependency **subtree**: the project
-/// itself plus every path-dep transitively reachable through `dep_names`.
+/// Collect a project's transitive path-dependency **descendants**: every path-dep
+/// reachable through `start_dep_names` (deduped; diamonds collapse). Does NOT
+/// include the starting project itself.
 ///
-/// A project's compile must see the Maven closure of its whole subtree, not just
-/// its own direct deps: a path-dep whose public API exposes a Maven type forces
-/// every dependent's compile to also resolve that Maven klib (konanc rejects a
-/// klib reference whose transitive deps aren't on the library path).
-fn collect_subtree_manifests<'a>(
-    start_manifest: &'a Manifest,
+/// This is the single source of a project's subtree, used for BOTH the path-dep
+/// klibs it links and the Maven closure it compiles against, so a project is
+/// built against exactly what it (transitively) declares — standalone ==
+/// as-a-dependency (parity), and an undeclared cross-dep import fails in the
+/// workspace build, not only in a standalone one. (A project's compile also
+/// needs its descendants' Maven klibs: konanc rejects a klib reference whose
+/// transitive deps aren't on the library path — e.g. compiling against a klib
+/// whose API returns `Flow` requires `coroutines.klib`.)
+fn collect_descendant_deps<'a>(
     start_dep_names: &[String],
     by_name: &HashMap<&str, &'a ResolvedDep>,
-) -> Vec<&'a Manifest> {
+) -> Vec<&'a ResolvedDep> {
     use std::collections::BTreeSet;
-    let mut out = vec![start_manifest];
+    let mut out: Vec<&ResolvedDep> = Vec::new();
     let mut seen: BTreeSet<&str> = BTreeSet::new();
     let mut stack: Vec<&str> = start_dep_names.iter().map(String::as_str).collect();
     while let Some(name) = stack.pop() {
@@ -1054,7 +1065,7 @@ fn collect_subtree_manifests<'a>(
             continue;
         }
         if let Some(dep) = by_name.get(name) {
-            out.push(&dep.manifest);
+            out.push(dep);
             stack.extend(dep.dep_names.iter().map(String::as_str));
         }
     }
@@ -4426,6 +4437,49 @@ mod tests {
             .collect();
         names.sort();
         names
+    }
+
+    fn resolved_dep(name: &str, dep_names: &[&str]) -> ResolvedDep {
+        ResolvedDep {
+            name: name.to_owned(),
+            project_root: PathBuf::from(format!("/{name}")),
+            manifest: konvoy_config::manifest::Manifest::from_str(
+                "[package]\nname = \"x\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n",
+                "konvoy.toml",
+            )
+            .unwrap(),
+            dep_names: dep_names.iter().map(|s| (*s).to_owned()).collect(),
+            source_hash: "h".to_owned(),
+        }
+    }
+
+    #[test]
+    fn collect_descendant_deps_walks_transitively_and_dedupes_diamond() {
+        // Graph: parent -> {child, sibling}; child -> grandchild; sibling -> grandchild
+        // (a diamond). parent's transitive descendants are child, sibling, and
+        // grandchild — grandchild appears once despite two paths to it.
+        let child = resolved_dep("child", &["grandchild"]);
+        let sibling = resolved_dep("sibling", &["grandchild"]);
+        let grandchild = resolved_dep("grandchild", &[]);
+        let by_name: HashMap<&str, &ResolvedDep> = [
+            ("child", &child),
+            ("sibling", &sibling),
+            ("grandchild", &grandchild),
+        ]
+        .into_iter()
+        .collect();
+
+        let descendants =
+            collect_descendant_deps(&["child".to_owned(), "sibling".to_owned()], &by_name);
+        let mut names: Vec<&str> = descendants.iter().map(|d| d.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, vec!["child", "grandchild", "sibling"]);
+    }
+
+    #[test]
+    fn collect_descendant_deps_leaf_has_no_descendants() {
+        let by_name: HashMap<&str, &ResolvedDep> = HashMap::new();
+        assert!(collect_descendant_deps(&[], &by_name).is_empty());
     }
 
     #[test]

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -4530,6 +4530,91 @@ mod tests {
     }
 
     #[test]
+    fn maven_coord_key_extracts_coordinate_and_skips_path() {
+        // Maven entry → (coordinate, version, classifier).
+        let m = maven_lock("a", "g:a", "1.0", &[]);
+        assert_eq!(
+            maven_coord_key(&m),
+            Some(("g:a".to_owned(), "1.0".to_owned(), None))
+        );
+        // Classifier is carried through (cinterop entries).
+        let cinterop = DependencyLock {
+            name: "atomicfu-cinterop".to_owned(),
+            source: DepSource::Maven {
+                version: "0.23.1".to_owned(),
+                maven: "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: vec!["atomicfu".to_owned()],
+                classifier: Some("cinterop-interop".to_owned()),
+            },
+            source_hash: "h".to_owned(),
+        };
+        assert_eq!(
+            maven_coord_key(&cinterop),
+            Some((
+                "org.jetbrains.kotlinx:atomicfu".to_owned(),
+                "0.23.1".to_owned(),
+                Some("cinterop-interop".to_owned())
+            ))
+        );
+        // Path entry → None.
+        let p = DependencyLock {
+            name: "lib".to_owned(),
+            source: DepSource::Path {
+                path: "../lib".to_owned(),
+            },
+            source_hash: "h".to_owned(),
+        };
+        assert_eq!(maven_coord_key(&p), None);
+    }
+
+    #[test]
+    fn predicted_dependency_locks_sorts_by_name_and_keeps_maven() {
+        // Path deps in NON-alphabetical graph order + a Maven lock entry. The
+        // output must be sorted by name (byte-for-byte what `konvoy update`
+        // writes) so `update` then `build --locked` doesn't see an ordering diff.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut zdep = resolved_dep("zlib", &[]);
+        zdep.project_root = tmp.path().join("zlib");
+        let mut adep = resolved_dep("alib", &[]);
+        adep.project_root = tmp.path().join("alib");
+        let graph = crate::resolve::ResolvedGraph {
+            order: vec![zdep, adep],
+        };
+        let mut lockfile = Lockfile::default();
+        lockfile
+            .dependencies
+            .push(maven_lock("mlib", "g:m", "1.0", &[]));
+
+        let locks = predicted_dependency_locks(&lockfile, &graph, tmp.path());
+        let names: Vec<&str> = locks.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["alib", "mlib", "zlib"],
+            "deps must be sorted by name, with the Maven entry preserved"
+        );
+    }
+
+    #[test]
+    fn predicted_dependency_locks_drops_deps_with_empty_source_hash() {
+        // A dep whose source hasn't been hashed (empty source_hash) is omitted —
+        // it can't be pinned yet.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut hashed = resolved_dep("hashed", &[]);
+        hashed.project_root = tmp.path().join("hashed");
+        let mut unhashed = resolved_dep("unhashed", &[]);
+        unhashed.project_root = tmp.path().join("unhashed");
+        unhashed.source_hash = String::new();
+        let graph = crate::resolve::ResolvedGraph {
+            order: vec![hashed, unhashed],
+        };
+
+        let locks = predicted_dependency_locks(&Lockfile::default(), &graph, tmp.path());
+        let names: Vec<&str> = locks.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["hashed"]);
+    }
+
+    #[test]
     fn collect_descendant_deps_walks_transitively_and_dedupes_diamond() {
         // Graph: parent -> {child, sibling}; child -> grandchild; sibling -> grandchild
         // (a diamond). parent's transitive descendants are child, sibling, and

--- a/crates/konvoy-engine/src/build.rs
+++ b/crates/konvoy-engine/src/build.rs
@@ -143,9 +143,12 @@ pub(crate) struct ResolvedBuildContext {
     /// Library inputs (path + optional pre-computed hash) from built path-deps
     /// and downloaded Maven klibs.
     pub library_inputs: Vec<LibraryInput>,
-    /// Paths to downloaded compiler plugin JARs.
+    /// The ROOT project's compiler plugin JAR paths (used by the test build,
+    /// which compiles the root's test sources). `build_single` derives each
+    /// project's own set from its manifest.
     pub plugin_jars: Vec<PathBuf>,
-    /// Lockfile entries for resolved plugins (used by `update_lockfile_if_needed`).
+    /// Resolved plugin lockfile pins — the deduped union across the root and
+    /// all path-deps (persisted to the root lock by `update_lockfile_if_needed`).
     pub plugin_locks: Vec<konvoy_config::lockfile::PluginLock>,
     /// Resolved path-dependency graph in topological order.
     pub dep_graph: ResolvedGraph,
@@ -169,11 +172,13 @@ pub(crate) struct LockfileWriteInputs {
 ///
 /// - In `--locked` mode the on-disk lockfile is authoritative and returned
 ///   unchanged (the user explicitly forbids any modification; it already
-///   contains the plugin entries, enforced by the staleness check).
+///   contains the plugin entries — the root's enforced by the staleness check,
+///   dep-contributed ones by the graph-wide ensure's pin gate).
 /// - Otherwise the toolchain section is stabilized to the detected konanc
-///   version (predicting the post-build write), existing dependencies are
-///   preserved, and the predicted `[[plugins]]` entries (`plugin_locks`,
-///   resolved before the cache key is computed) are folded in.
+///   version (predicting the post-build write), and the predicted `[[plugins]]`
+///   entries (`plugin_locks`, resolved before the cache key is computed) and
+///   `[[dependencies]]` entries (path-dep locks derived from `dep_graph`, Maven
+///   locks preserved) are folded in.
 ///
 /// Folding the plugin entries in BOTH the version-matches branch and the
 /// stabilized branch is what fixes the spurious one-time recompile of projects
@@ -182,12 +187,15 @@ pub(crate) struct LockfileWriteInputs {
 /// the two builds produce different `lockfile_content` and therefore different
 /// cache keys. Plugins genuinely affect compilation, so they must stay in the
 /// cache key — folding the predicted entries in is what keeps it stable.
+#[allow(clippy::too_many_arguments)]
 fn predicted_effective_lockfile(
     lockfile: &Lockfile,
     konanc_version: &str,
     konanc_tarball_sha256: Option<&str>,
     jre_tarball_sha256: Option<&str>,
     plugin_locks: &[PluginLock],
+    dep_graph: &ResolvedGraph,
+    project_root: &Path,
     resolver: crate::common::ArtifactResolver<'_>,
 ) -> Lockfile {
     resolver.cache_key_artifact_state(lockfile, || {
@@ -197,15 +205,14 @@ fn predicted_effective_lockfile(
             Some(tc) if tc.konanc_version == konanc_version => lockfile.clone(),
             // Lockfile is missing or has a different version. Build the same
             // lockfile that will eventually be written so the cache key is stable
-            // from the first build. Preserve existing dependencies (e.g. Maven deps
-            // written by `konvoy update`).
+            // from the first build. (Dependencies are folded in below, for both
+            // branches.)
             _ => {
                 let mut stabilized = Lockfile::with_managed_toolchain(
                     konanc_version,
                     konanc_tarball_sha256,
                     jre_tarball_sha256,
                 );
-                stabilized.dependencies = lockfile.dependencies.clone();
                 // Mirror the detekt carry-forward that `update_lockfile_if_needed`
                 // applies to the WRITTEN lockfile, or the predicted cache-key
                 // lockfile would drop detekt and diverge from what gets written
@@ -220,8 +227,58 @@ fn predicted_effective_lockfile(
         // (`updated.plugins = plugin_locks`). This keeps the cache key identical
         // across the first and second builds of a project with plugins.
         effective.plugins = plugin_locks.to_vec();
+        // Same reasoning for the [[dependencies]] entries: path-dep locks are
+        // written only at the END of the build, so predict them here (the shared
+        // helper keeps the prediction and the write in lockstep) — otherwise a
+        // project with path-deps recompiles its whole graph once after the
+        // first build (issue #133 class).
+        effective.dependencies = predicted_dependency_locks(lockfile, dep_graph, project_root);
         effective
     })
+}
+
+/// Build the dependency lock entries the build will write for the current
+/// graph: path-dep entries derived from `dep_graph` (portable relative paths
+/// plus source hashes), with the lockfile's existing Maven entries preserved
+/// (`konvoy update` owns those; `konvoy build` never edits them).
+///
+/// Single authority shared by `predicted_effective_lockfile` (the cache-key
+/// prediction) and `update_lockfile_if_needed` (the write) so the two cannot
+/// drift — if they did, the first build would key on different lockfile content
+/// than the second build reads back from disk (issue #133 class).
+fn predicted_dependency_locks(
+    lockfile: &Lockfile,
+    dep_graph: &ResolvedGraph,
+    project_root: &Path,
+) -> Vec<DependencyLock> {
+    // Dep roots come back canonicalized (absolute) from `resolve_dep_path`;
+    // canonicalize the project root too so the relative computation is between
+    // like paths even when the cwd contains symlinks (e.g. /tmp on macOS).
+    let canonical_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let mut new_deps: Vec<DependencyLock> = dep_graph
+        .order
+        .iter()
+        .filter(|dep| !dep.source_hash.is_empty())
+        .map(|dep| {
+            let rel_path = portable_dep_path(&canonical_root, &dep.project_root);
+            DependencyLock {
+                name: dep.name.clone(),
+                source: DepSource::Path { path: rel_path },
+                source_hash: dep.source_hash.clone(),
+            }
+        })
+        .collect();
+
+    // Preserve existing Maven dep locks from the current lockfile.
+    // Maven dep locks are only modified by `konvoy update`, not by `konvoy build`.
+    for dep_lock in &lockfile.dependencies {
+        if matches!(&dep_lock.source, DepSource::Maven { .. }) {
+            new_deps.push(dep_lock.clone());
+        }
+    }
+    new_deps
 }
 
 /// Resolve the common build pipeline state (steps 1–7a).
@@ -232,11 +289,12 @@ fn predicted_effective_lockfile(
 /// 3. Check lockfile staleness in `--locked` mode
 /// 4. Resolve target and profile
 /// 5. Resolve managed konanc toolchain
-/// 6. Resolve plugin artifacts, then pre-stabilize the lockfile for cache-key
+/// 6. Resolve the dependency graph, then ensure the graph-wide plugin union
+///    (root + every path-dep) and pre-stabilize the lockfile for cache-key
 ///    consistency (the predicted `[[plugins]]` entries are folded in so the
 ///    cache key is stable from the first build)
-/// 7. Resolve + build path dependencies in topological order, then download
-///    Maven dependency klibs
+/// 7. Build path dependencies in topological order, then download Maven
+///    dependency klibs
 pub(crate) fn resolve_build_context(
     project_root: &Path,
     options: &BuildOptions,
@@ -315,8 +373,16 @@ pub(crate) fn resolve_build_context(
         )?;
     }
 
-    // 6. Resolve plugin artifacts, then pre-stabilize the lockfile for
-    //    cache-key consistency (issue #133).
+    // 6. Resolve the dependency graph up front. Plugin pinning spans the WHOLE
+    //    graph (root + path-deps), so every dependency's manifest must be known
+    //    before plugins are resolved and the lockfile is predicted.
+    //    `resolve_dependencies` only reads dep manifests + source hashes (no
+    //    toolchain/plugin state), so running it here — earlier than the build
+    //    loop below — is safe.
+    let dep_graph = resolve_dependencies(project_root, &manifest)?;
+
+    // 6a. Resolve + ensure plugin artifacts graph-wide, then pre-stabilize the
+    //     lockfile for cache-key consistency (issue #133).
     //
     // When `konvoy.lock` does not exist (first build) or the toolchain version
     // has changed, the lockfile read at step 2 will differ from what
@@ -331,20 +397,28 @@ pub(crate) fn resolve_build_context(
     // the effective lockfile. Otherwise a project with a `[plugins]` section
     // recompiles once unnecessarily after its first build (issue #133 class).
     //
+    // The pin set is the deduped UNION of every plugin across the root and all
+    // path-deps (issue #293): a path-dep's `[plugins]` must be downloaded and
+    // pinned just like the root's, because the dep's own compile step applies
+    // them (see `build_single`). The union is recorded in the root
+    // `konvoy.lock`, exactly as the root lock aggregates the graph's Maven
+    // deps; no dependency checkout is written to.
+    //
     // Hash lookup uses the on-disk `lockfile` (its `[[plugins]]` entries, if
     // any), which is exactly what the effective lockfile carried before folding.
     // On a warm cache the artifacts are already present and pinned, so
     // `ensure_plugin_artifacts` only re-verifies hashes — it does not download.
-    let (plugin_jars, plugin_locks) = if !manifest.plugins.is_empty() {
-        let resolved_artifacts = crate::plugin::resolve_plugin_artifacts(&manifest)?;
-        let results =
-            crate::plugin::ensure_plugin_artifacts(&resolved_artifacts, &lockfile, resolver)?;
-        let locks = crate::plugin::build_plugin_locks(&results);
-        let jars: Vec<PathBuf> = results.iter().map(|r| r.path.clone()).collect();
-        (jars, locks)
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    let graph_plugin_artifacts = crate::plugin::resolve_graph_plugin_artifacts(
+        std::iter::once(&manifest).chain(dep_graph.order.iter().map(|dep| &dep.manifest)),
+    )?;
+    let plugin_results =
+        crate::plugin::ensure_plugin_artifacts(&graph_plugin_artifacts, &lockfile, resolver)?;
+    let plugin_locks = crate::plugin::build_plugin_locks(&plugin_results);
+
+    // The ROOT project's own -Xplugin set, for the test build (`build_tests`
+    // compiles the root's test sources). Regular compilation derives each
+    // project's set from its own manifest inside `build_single`.
+    let plugin_jars = crate::plugin::plugin_jar_paths(&manifest)?;
 
     // We predict the lockfile content that will eventually be written, so the
     // cache key is the same in the first and second builds. In `--locked` mode
@@ -355,11 +429,12 @@ pub(crate) fn resolve_build_context(
         konanc_tarball_sha256.as_deref(),
         jre_tarball_sha256.as_deref(),
         &plugin_locks,
+        &dep_graph,
+        project_root,
         resolver,
     );
 
-    // 7. Resolve dependencies and build them in topological order.
-    let dep_graph = resolve_dependencies(project_root, &manifest)?;
+    // 7. Build path dependencies in topological order.
     let lockfile_content = lockfile_toml_content(&effective_lockfile)?;
 
     let levels = parallel_levels(&dep_graph);
@@ -382,7 +457,6 @@ pub(crate) fn resolve_build_context(
                     target: &target,
                     options,
                     library_inputs: &lib_inputs,
-                    plugin_jars: &[],
                 };
                 let (output, outcome) = build_single(
                     &dep.project_root,
@@ -469,7 +543,6 @@ pub fn build(
         target: &ctx.target,
         options,
         library_inputs: &ctx.library_inputs,
-        plugin_jars: &ctx.plugin_jars,
     };
     let (output_path, outcome) = build_single(
         project_root,
@@ -518,9 +591,10 @@ pub(crate) struct CompileContext<'a> {
     /// Dependency `.klib` inputs (path + optional pre-computed hash).
     ///
     /// The compiler only consumes the paths; the hashes feed the cache key.
+    /// Plugin JARs are NOT part of this context: each project's `-Xplugin` set
+    /// is derived from its own manifest inside `build_single`, so the same
+    /// context serves the root and every path-dep.
     pub library_inputs: &'a [LibraryInput],
-    /// Compiler plugin JAR paths to pass as `-Xplugin` args.
-    pub plugin_jars: &'a [PathBuf],
 }
 
 /// Build a single project (either root or a dependency).
@@ -548,6 +622,15 @@ pub(crate) fn build_single(
     }
 
     let is_lib = manifest.package.kind == PackageKind::Lib;
+
+    // This project's compiler plugins, from its OWN manifest — the root and
+    // every path-dep are treated identically, so a dep's `[plugins]` are applied
+    // to the dep's compilation exactly as when it is built standalone (#293).
+    // The JARs were already downloaded + SHA-pinned graph-wide in
+    // `resolve_build_context`; this is pure path derivation. The cache key
+    // covers plugins through `manifest_content` (the `[plugins]` config) and
+    // `lockfile_content` (the graph-wide pin union, version + sha256).
+    let plugin_jars = crate::plugin::plugin_jar_paths(manifest)?;
 
     // Compute cache key.
     let manifest_content = manifest.to_toml()?;
@@ -609,7 +692,7 @@ pub(crate) fn build_single(
     } else {
         ProduceKind::Program
     };
-    let compile_output = compile(cc, &sources, &output_path, produce)?;
+    let compile_output = compile(cc, &sources, &output_path, produce, &plugin_jars)?;
 
     // Store artifact in cache.
     let metadata = BuildMetadata {
@@ -665,6 +748,7 @@ fn compile_two_step(
     cc: &CompileContext<'_>,
     sources: &[PathBuf],
     output_path: &Path,
+    plugin_jars: &[PathBuf],
 ) -> Result<PathBuf, EngineError> {
     // Step 1: compile sources → temporary klib (with plugins active).
     let klib_path = output_path.with_extension("klib");
@@ -679,7 +763,7 @@ fn compile_two_step(
         .release(cc.options.is_release())
         .produce(ProduceKind::Library)
         .libraries(&lib_paths)
-        .plugins(cc.plugin_jars);
+        .plugins(plugin_jars);
 
     if let Some(jh) = cc.jre_home {
         compile_cmd = compile_cmd.java_home(jh);
@@ -735,6 +819,7 @@ fn compile_single_step(
     sources: &[PathBuf],
     output_path: &Path,
     produce: ProduceKind,
+    plugin_jars: &[PathBuf],
 ) -> Result<PathBuf, EngineError> {
     let lib_paths = library_paths_of(cc.library_inputs);
 
@@ -745,7 +830,7 @@ fn compile_single_step(
         .release(cc.options.is_release())
         .produce(produce)
         .libraries(&lib_paths)
-        .plugins(cc.plugin_jars);
+        .plugins(plugin_jars);
 
     if let Some(jh) = cc.jre_home {
         cmd = cmd.java_home(jh);
@@ -776,16 +861,17 @@ fn compile(
     sources: &[PathBuf],
     output_path: &Path,
     produce: ProduceKind,
+    plugin_jars: &[PathBuf],
 ) -> Result<PathBuf, EngineError> {
     // Ensure the output directory exists.
     if let Some(parent) = output_path.parent() {
         konvoy_util::fs::ensure_dir(parent)?;
     }
 
-    if needs_two_step_compilation(produce, cc.plugin_jars) {
-        compile_two_step(cc, sources, output_path)
+    if needs_two_step_compilation(produce, plugin_jars) {
+        compile_two_step(cc, sources, output_path, plugin_jars)
     } else {
-        compile_single_step(cc, sources, output_path, produce)
+        compile_single_step(cc, sources, output_path, produce, plugin_jars)
     }
 }
 
@@ -1008,12 +1094,13 @@ pub(crate) fn check_lockfile_staleness(
         }
     }
 
-    // Each declared plugin must have a *pinned* lockfile entry. Use the same
-    // `find_lockfile_hash` the resolver gate uses, so this fast-fail and the
-    // per-artifact gate agree that an empty `sha256` is "no pin" — otherwise a
+    // Each declared plugin must have a *pinned* lockfile entry for its resolved
+    // `(name, maven, version)` identity. Use the same lookup the resolver gate
+    // uses, so this fast-fail and the per-artifact gate agree on what "pinned"
+    // means (identity match, empty `sha256` is "no pin") — otherwise a stale or
     // malformed entry would slip past this check only to fail deeper in.
-    for plugin_name in manifest.plugins.keys() {
-        if crate::plugin::find_lockfile_hash(lockfile, plugin_name).is_none() {
+    for artifact in &crate::plugin::resolve_plugin_artifacts(manifest)? {
+        if crate::plugin::find_artifact_lockfile_hash(lockfile, artifact).is_none() {
             return Err(EngineError::LockfileUpdateRequired);
         }
     }
@@ -1066,34 +1153,10 @@ fn update_lockfile_if_needed(
         }
     }
 
-    // Build new dependency lock entries from path deps in the dep graph.
-    // Dep roots come back canonicalized (absolute) from `resolve_dep_path`;
-    // canonicalize the project root too so the relative computation is between
-    // like paths even when the cwd contains symlinks (e.g. /tmp on macOS).
-    let canonical_root = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.to_path_buf());
-    let mut new_deps: Vec<DependencyLock> = dep_graph
-        .order
-        .iter()
-        .filter(|dep| !dep.source_hash.is_empty())
-        .map(|dep| {
-            let rel_path = portable_dep_path(&canonical_root, &dep.project_root);
-            DependencyLock {
-                name: dep.name.clone(),
-                source: DepSource::Path { path: rel_path },
-                source_hash: dep.source_hash.clone(),
-            }
-        })
-        .collect();
-
-    // Preserve existing Maven dep locks from the current lockfile.
-    // Maven dep locks are only modified by `konvoy update`, not by `konvoy build`.
-    for dep_lock in &lockfile.dependencies {
-        if matches!(&dep_lock.source, DepSource::Maven { .. }) {
-            new_deps.push(dep_lock.clone());
-        }
-    }
+    // Build new dependency lock entries from path deps in the dep graph,
+    // preserving existing Maven dep locks (shared with the cache-key prediction
+    // in `predicted_effective_lockfile` so the two stay in lockstep).
+    let new_deps = predicted_dependency_locks(lockfile, dep_graph, project_root);
 
     let toolchain_changed = match &lockfile.toolchain {
         Some(tc) => tc.konanc_version != konanc.version,
@@ -1882,7 +1945,6 @@ mod tests {
             target: &target,
             options: &options,
             library_inputs: &[],
-            plugin_jars: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -1968,7 +2030,6 @@ mod tests {
             target: &target,
             options: &options,
             library_inputs: &[],
-            plugin_jars: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -2079,7 +2140,6 @@ mod tests {
             target: &target,
             options: &options,
             library_inputs: &[],
-            plugin_jars: &[],
         };
         let (output_path, outcome) =
             build_single(&project, &manifest, &cc, profile, &lockfile_content).unwrap();
@@ -3005,6 +3065,8 @@ mod tests {
             Some("new1"),
             Some("new2"),
             &[],
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
             crate::common::test_resolver(false, false),
         );
 
@@ -3091,7 +3153,6 @@ mod tests {
             target: &target,
             options: &options_no_force,
             library_inputs: &[],
-            plugin_jars: &[],
         };
         let (_, outcome) = build_single(
             &project,
@@ -3118,7 +3179,6 @@ mod tests {
             target: &target,
             options: &options_force,
             library_inputs: &[],
-            plugin_jars: &[],
         };
         let result = build_single(&project, &manifest, &cc_force, profile, &lockfile_content);
 
@@ -3224,6 +3284,8 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
             crate::common::test_resolver(false, false),
         );
 
@@ -3240,6 +3302,8 @@ mod tests {
             None,
             None,
             &plugin_locks,
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
             crate::common::test_resolver(false, false),
         );
 
@@ -3254,6 +3318,249 @@ mod tests {
             content_first.contains("kotlin-serialization"),
             "predicted plugin entries must be folded into the cache-key lockfile content"
         );
+    }
+
+    /// Pre-stabilization parity for a DEP-contributed plugin in the graph-wide
+    /// union (issue #293): the union resolved on the first build (root's plugin
+    /// + a path-dep's plugin, including a second version of the same plugin
+    /// name) must produce the same cache-key lockfile content as the second
+    /// build, which reads those pins back from disk. Otherwise a project with
+    /// plugin-using deps spuriously recompiles once after its first build
+    /// (issue #133 class).
+    #[test]
+    fn pre_stabilized_lockfile_matches_post_update_lockfile_with_dep_plugin_union() {
+        let konanc_version = "2.1.0";
+
+        // The graph-wide union: the root's serialization plugin plus a path-dep's
+        // plugins — one of them the same plugin name at a DIFFERENT version
+        // (allowed as a distinct pin, not a conflict).
+        let plugin_locks = vec![
+            PluginLock {
+                name: "kotlin-serialization".to_owned(),
+                maven: "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin".to_owned(),
+                version: konanc_version.to_owned(),
+                sha256: "root-plugin-sha".to_owned(),
+                url: "https://repo.maven.apache.org/ser.jar".to_owned(),
+            },
+            PluginLock {
+                name: "my-plugin".to_owned(),
+                maven: "com.example:my-plugin".to_owned(),
+                version: "1.0.0".to_owned(),
+                sha256: "dep-plugin-sha-v1".to_owned(),
+                url: "https://repo.maven.apache.org/my-plugin-1.0.0.jar".to_owned(),
+            },
+            PluginLock {
+                name: "my-plugin".to_owned(),
+                maven: "com.example:my-plugin".to_owned(),
+                version: "2.0.0".to_owned(),
+                sha256: "dep-plugin-sha-v2".to_owned(),
+                url: "https://repo.maven.apache.org/my-plugin-2.0.0.jar".to_owned(),
+            },
+        ];
+
+        // First build: no lockfile on disk.
+        let first_on_disk = Lockfile::default();
+        let effective_first = predicted_effective_lockfile(
+            &first_on_disk,
+            konanc_version,
+            None,
+            None,
+            &plugin_locks,
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
+            crate::common::test_resolver(false, false),
+        );
+
+        // After the first build, `update_lockfile_if_needed` writes the union.
+        let mut written = Lockfile::with_managed_toolchain(konanc_version, None, None);
+        written.plugins = plugin_locks.clone();
+
+        // Second build reads `written` from disk and resolves the same union.
+        let effective_second = predicted_effective_lockfile(
+            &written,
+            konanc_version,
+            None,
+            None,
+            &plugin_locks,
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
+            crate::common::test_resolver(false, false),
+        );
+
+        let content_first = lockfile_toml_content(&effective_first).unwrap();
+        let content_second = lockfile_toml_content(&effective_second).unwrap();
+        assert_eq!(
+            content_first, content_second,
+            "cache key lockfile content must be identical between the first and second \
+             builds when path-deps contribute plugins to the union"
+        );
+        for needle in ["root-plugin-sha", "dep-plugin-sha-v1", "dep-plugin-sha-v2"] {
+            assert!(
+                content_first.contains(needle),
+                "the dep-contributed union pins must be folded into the cache-key \
+                 lockfile content (missing {needle})"
+            );
+        }
+    }
+
+    /// Pre-stabilization parity for PATH-DEP `[[dependencies]]` entries: the
+    /// first build's predicted lockfile must already contain the dep entries
+    /// that `update_lockfile_if_needed` writes after the build, or the second
+    /// build reads them back from disk, computes a different `lockfile_content`,
+    /// and recompiles the whole graph once for nothing (issue #133 class — the
+    /// path-dep analogue of the plugin fold above).
+    #[test]
+    fn pre_stabilized_lockfile_matches_post_update_lockfile_with_path_deps() {
+        let konanc_version = "2.1.0";
+        let root_dir = tempfile::tempdir().unwrap();
+        let dep_dir = tempfile::tempdir().unwrap();
+
+        let dep_manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"models\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let graph = crate::resolve::ResolvedGraph {
+            order: vec![crate::resolve::ResolvedDep {
+                name: "models".to_owned(),
+                project_root: dep_dir.path().canonicalize().unwrap(),
+                manifest: dep_manifest,
+                dep_names: Vec::new(),
+                source_hash: "dep-source-hash".to_owned(),
+            }],
+        };
+
+        // First build: no lockfile on disk.
+        let first_on_disk = Lockfile::default();
+        let effective_first = predicted_effective_lockfile(
+            &first_on_disk,
+            konanc_version,
+            None,
+            None,
+            &[],
+            &graph,
+            root_dir.path(),
+            crate::common::test_resolver(false, false),
+        );
+
+        // After the first build, `update_lockfile_if_needed` writes the dep
+        // entries. Use the real write path so the prediction is compared with
+        // what actually lands on disk.
+        let lockfile_path = root_dir.path().join("konvoy.lock");
+        let konanc = KonancInfo {
+            path: PathBuf::from("/fake/konanc"),
+            version: konanc_version.to_owned(),
+            fingerprint: "fp".to_owned(),
+        };
+        update_lockfile_if_needed(
+            &first_on_disk,
+            &konanc,
+            None,
+            None,
+            &graph,
+            &[],
+            root_dir.path(),
+            &lockfile_path,
+            false,
+            crate::common::test_resolver(false, false),
+        )
+        .unwrap();
+        let written = Lockfile::from_path(&lockfile_path).unwrap();
+
+        // Second build reads `written` from disk and resolves the same graph.
+        let effective_second = predicted_effective_lockfile(
+            &written,
+            konanc_version,
+            None,
+            None,
+            &[],
+            &graph,
+            root_dir.path(),
+            crate::common::test_resolver(false, false),
+        );
+
+        let content_first = lockfile_toml_content(&effective_first).unwrap();
+        let content_second = lockfile_toml_content(&effective_second).unwrap();
+        assert_eq!(
+            content_first, content_second,
+            "cache key lockfile content must be identical between the first and \
+             second builds of a project with path-deps"
+        );
+        assert!(
+            content_first.contains("dep-source-hash"),
+            "the predicted dep entries must be folded into the cache-key lockfile content"
+        );
+    }
+
+    /// `update_lockfile_if_needed` persists the graph-wide plugin union,
+    /// including the same plugin name at multiple versions (distinct pins, not
+    /// a conflict), and a second write with the unchanged union is a no-op.
+    #[test]
+    fn update_lockfile_writes_multi_version_plugin_union_and_no_ops_when_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let lockfile_path = dir.path().join("konvoy.lock");
+        let lockfile = Lockfile::default();
+        let konanc = KonancInfo {
+            path: PathBuf::from("/fake/konanc"),
+            version: "2.1.0".to_owned(),
+            fingerprint: "fp".to_owned(),
+        };
+        let plugin_locks = vec![
+            PluginLock {
+                name: "my-plugin".to_owned(),
+                maven: "com.example:my-plugin".to_owned(),
+                version: "1.0.0".to_owned(),
+                sha256: "sha-v1".to_owned(),
+                url: "https://example.com/my-plugin-1.0.0.jar".to_owned(),
+            },
+            PluginLock {
+                name: "my-plugin".to_owned(),
+                maven: "com.example:my-plugin".to_owned(),
+                version: "2.0.0".to_owned(),
+                sha256: "sha-v2".to_owned(),
+                url: "https://example.com/my-plugin-2.0.0.jar".to_owned(),
+            },
+        ];
+
+        let empty_graph = crate::resolve::ResolvedGraph { order: Vec::new() };
+        update_lockfile_if_needed(
+            &lockfile,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &plugin_locks,
+            dir.path(),
+            &lockfile_path,
+            false,
+            crate::common::test_resolver(false, false),
+        )
+        .unwrap();
+
+        let written = Lockfile::from_path(&lockfile_path).unwrap();
+        assert_eq!(
+            written.plugins, plugin_locks,
+            "both versions of the plugin must be recorded as distinct pins"
+        );
+
+        // Re-running with the unchanged union must not error and must leave the
+        // lockfile identical (it would be rejected under --locked otherwise).
+        let before = fs::read_to_string(&lockfile_path).unwrap();
+        update_lockfile_if_needed(
+            &written,
+            &konanc,
+            None,
+            None,
+            &empty_graph,
+            &plugin_locks,
+            dir.path(),
+            &lockfile_path,
+            false,
+            crate::common::test_resolver(false, true),
+        )
+        .unwrap();
+        let after = fs::read_to_string(&lockfile_path).unwrap();
+        assert_eq!(before, after, "an unchanged union must be a no-op write");
     }
 
     /// The pre-stabilized lockfile should NOT change the content when the
@@ -3330,6 +3637,8 @@ mod tests {
             None,
             None,
             &[],
+            &crate::resolve::ResolvedGraph { order: Vec::new() },
+            Path::new("/tmp"),
             crate::common::test_resolver(false, true),
         );
 
@@ -3483,6 +3792,59 @@ mod tests {
         assert!(
             err.contains("lockfile is out of date"),
             "expected staleness error for missing plugin entries, got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_lockfile_staleness_plugin_version_drift_errors() {
+        // Manifest pins the plugin at a literal version; the lockfile entry has
+        // the same name but a DIFFERENT version. The pin lookup must be
+        // version-aware: a name-only match would wrongly treat the stale pin as
+        // valid (and the graph-wide union allows the same plugin name at several
+        // versions, which a name-only lookup cannot distinguish).
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"myapp\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n\n[plugins]\nmy-plugin = { maven = \"com.example:my-plugin\", version = \"1.1.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile.plugins.push(konvoy_config::lockfile::PluginLock {
+            name: "my-plugin".to_owned(),
+            maven: "com.example:my-plugin".to_owned(),
+            version: "1.0.0".to_owned(),
+            sha256: "abc123".to_owned(),
+            url: "https://example.com/my-plugin-1.0.0.jar".to_owned(),
+        });
+
+        let result = check_lockfile_staleness(&manifest, &lockfile);
+        assert!(
+            result.is_err(),
+            "a pin at a different version must be drift, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn check_lockfile_staleness_plugin_maven_drift_errors() {
+        // Same plugin name and version, but the manifest now points at a
+        // different Maven coordinate — the old pin is for a different artifact.
+        let manifest = konvoy_config::manifest::Manifest::from_str(
+            "[package]\nname = \"myapp\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n\n[plugins]\nmy-plugin = { maven = \"com.example:new-coord\", version = \"1.0.0\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile.plugins.push(konvoy_config::lockfile::PluginLock {
+            name: "my-plugin".to_owned(),
+            maven: "com.example:old-coord".to_owned(),
+            version: "1.0.0".to_owned(),
+            sha256: "abc123".to_owned(),
+            url: "https://example.com/old-coord-1.0.0.jar".to_owned(),
+        });
+
+        let result = check_lockfile_staleness(&manifest, &lockfile);
+        assert!(
+            result.is_err(),
+            "a pin for a different maven coordinate must be drift, got: {result:?}"
         );
     }
 

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -132,7 +132,7 @@ impl<'a> ArtifactResolver<'a> {
         lockfile: &Lockfile,
         bar: Option<&konvoy_util::progress::DownloadBar>,
     ) -> Result<crate::plugin::PluginArtifactResult, EngineError> {
-        let expected_sha256 = crate::plugin::find_lockfile_hash(lockfile, &artifact.plugin_name);
+        let expected_sha256 = crate::plugin::find_artifact_lockfile_hash(lockfile, artifact);
         self.resolve_artifact(
             || Ok(expected_sha256.is_some()),
             artifact.cache_path.exists(),
@@ -170,7 +170,7 @@ impl<'a> ArtifactResolver<'a> {
         let present: Vec<bool> = artifacts.iter().map(|a| a.cache_path.exists()).collect();
         for (artifact, is_present) in artifacts.iter().zip(present.iter().copied()) {
             self.resolve_artifact(
-                || Ok(crate::plugin::find_lockfile_hash(lockfile, &artifact.plugin_name).is_some()),
+                || Ok(crate::plugin::find_artifact_lockfile_hash(lockfile, artifact).is_some()),
                 is_present,
                 || EngineError::PluginOffline {
                     name: artifact.plugin_name.clone(),

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -214,13 +214,17 @@ impl<'a> ArtifactResolver<'a> {
     pub(crate) fn resolve_missing_maven_dependencies(
         self,
         project_root: &std::path::Path,
+        manifest: &Manifest,
+        dep_graph: &crate::resolve::ResolvedGraph,
         lockfile_path: &std::path::Path,
         name: String,
     ) -> Result<Lockfile, EngineError> {
         self.lockfiles.require_update_allowed()?;
         self.require_available(false, || EngineError::MissingLockfileEntry { name })?;
         eprintln!("  Maven dependencies not resolved - running update automatically...");
-        crate::update::update(project_root, self)?;
+        // Reuse the already-resolved graph so we don't re-walk + re-hash every
+        // path-dep's source tree a second time on this cold build.
+        crate::update::update_with_graph(project_root, manifest, dep_graph, self)?;
         Ok(Lockfile::from_path(lockfile_path)?)
     }
 

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -225,7 +225,8 @@ impl<'a> ArtifactResolver<'a> {
     }
 
     /// Require the manifest's managed artifacts to be resolvable under the
-    /// command's policy.
+    /// command's policy (root-only — used by `lint`, which does not build the
+    /// dependency graph).
     pub(crate) fn require_manifest_artifacts_resolvable(
         self,
         manifest: &Manifest,
@@ -233,6 +234,20 @@ impl<'a> ArtifactResolver<'a> {
     ) -> Result<(), EngineError> {
         self.lockfiles
             .verify_current_lockfile(|| crate::build::check_lockfile_staleness(manifest, lockfile))
+    }
+
+    /// Require the build graph's managed artifacts to be resolvable under the
+    /// command's policy: the root's full staleness check plus, for every
+    /// path-dependency, that its Maven deps are pinned in the (shared) root lock.
+    pub(crate) fn require_graph_artifacts_resolvable<'m>(
+        self,
+        manifest: &Manifest,
+        dep_manifests: impl IntoIterator<Item = &'m Manifest>,
+        lockfile: &Lockfile,
+    ) -> Result<(), EngineError> {
+        self.lockfiles.verify_current_lockfile(|| {
+            crate::build::check_graph_lockfile_staleness(manifest, dep_manifests, lockfile)
+        })
     }
 
     /// Resolve a changed path dependency source under the command's policy.

--- a/crates/konvoy-engine/src/plugin.rs
+++ b/crates/konvoy-engine/src/plugin.rs
@@ -4,6 +4,7 @@
 //! as dependencies. Any Maven-published compiler plugin JAR can be used without
 //! needing a built-in descriptor.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use konvoy_config::lockfile::{Lockfile, PluginLock};
@@ -116,24 +117,119 @@ pub fn resolve_plugin_artifacts(
     Ok(artifacts)
 }
 
+/// The given artifacts, deduplicated by their full `(name, maven, version)`
+/// identity and in stable sorted order.
+///
+/// A build graph (root + path-dependencies) may declare the same plugin several
+/// times. Identical declarations collapse to one entry — the JAR is
+/// content-addressed under `~/.konvoy/cache/maven`, so it is downloaded,
+/// verified, and pinned once. The same plugin name at a different version (or
+/// coordinate) stays a distinct entry: compiler plugins are applied
+/// per-compilation, not linked into a shared artifact classpath, so multiple
+/// versions across the graph are benign — unlike linked Maven *library* version
+/// conflicts, which Konvoy intentionally surfaces. Sorting keeps the resulting
+/// lockfile pins deterministic regardless of the order projects were discovered.
+fn unique_plugin_artifacts(artifacts: Vec<ResolvedPluginArtifact>) -> Vec<ResolvedPluginArtifact> {
+    let mut unique: BTreeMap<(String, String, String), ResolvedPluginArtifact> = BTreeMap::new();
+    for artifact in artifacts {
+        unique
+            .entry((
+                artifact.plugin_name.clone(),
+                artifact.maven_coord.group_artifact(),
+                artifact.maven_coord.version.clone(),
+            ))
+            .or_insert(artifact);
+    }
+    unique.into_values().collect()
+}
+
+/// Resolve the deduped union of plugin artifacts across a build graph's
+/// manifests (the root plus every path-dependency).
+///
+/// This is the graph-wide ensure's input: each manifest's plugins are resolved
+/// against its own `[toolchain]` (for the `{kotlin}` placeholder — path-deps are
+/// required to match the root's Kotlin version), then deduplicated and sorted by
+/// [`unique_plugin_artifacts`]. The resulting pins are recorded in the **root**
+/// `konvoy.lock`, exactly as the root lock already aggregates the graph's Maven
+/// dependencies; no dependency checkout is written to.
+///
+/// # Errors
+/// Returns an error if any manifest's plugin config is invalid (missing `maven`
+/// or `version`, malformed coordinate) or the cache root cannot be determined.
+pub fn resolve_graph_plugin_artifacts<'a>(
+    manifests: impl IntoIterator<Item = &'a Manifest>,
+) -> Result<Vec<ResolvedPluginArtifact>, EngineError> {
+    let mut all = Vec::new();
+    for manifest in manifests {
+        all.extend(resolve_plugin_artifacts(manifest)?);
+    }
+    Ok(unique_plugin_artifacts(all))
+}
+
+/// This project's compiler-plugin JAR paths, derived from its own manifest.
+///
+/// Pure path computation — no download. The JARs are downloaded and SHA-verified
+/// up front by the graph-wide ensure in `resolve_build_context`; each project's
+/// compile step (root or path-dep) then derives its own `-Xplugin` set here, so
+/// a project is compiled with the plugins *it* declares whether it is built
+/// standalone or as a dependency.
+///
+/// # Errors
+/// Returns an error if the plugin config is invalid or the cache root cannot be
+/// determined.
+pub fn plugin_jar_paths(manifest: &Manifest) -> Result<Vec<PathBuf>, EngineError> {
+    Ok(resolve_plugin_artifacts(manifest)?
+        .into_iter()
+        .map(|artifact| artifact.cache_path)
+        .collect())
+}
+
 // ---------------------------------------------------------------------------
 // Download / verification
 // ---------------------------------------------------------------------------
 
 /// Look up the pinned SHA-256 for a plugin from the lockfile.
 ///
+/// Pins are matched by their full identity — `(name, maven, version)` — not by
+/// name alone: the lockfile aggregates plugins across the whole build graph
+/// (root + path-deps), which may legitimately pin the same plugin name at
+/// several versions. A name-only match would return whichever pin happens to
+/// come first and verify a different artifact against it; an identity miss
+/// (e.g. after a version bump) is "no pin", falling back to download-and-record.
+///
 /// An empty string is treated as "no pin", so a malformed or half-written entry
 /// falls back to download-and-record instead of being verified against an empty
-/// hash. Shared by the resolver's pin gate (`prepare_plugin_artifacts`) and its
-/// hash lookup (`resolve_plugin_artifact`) so the two agree on what "pinned"
-/// means.
-pub(crate) fn find_lockfile_hash<'a>(lockfile: &'a Lockfile, plugin_name: &str) -> Option<&'a str> {
+/// hash. Shared by the resolver's pin gate (`prepare_plugin_artifacts`), its
+/// hash lookup (`resolve_plugin_artifact`), and the `--locked` staleness check
+/// (`check_lockfile_staleness`) so all three agree on what "pinned" means.
+pub(crate) fn find_lockfile_hash<'a>(
+    lockfile: &'a Lockfile,
+    plugin_name: &str,
+    maven: &str,
+    version: &str,
+) -> Option<&'a str> {
     lockfile
         .plugins
         .iter()
-        .find(|p| p.name == plugin_name)
+        .find(|p| p.name == plugin_name && p.maven == maven && p.version == version)
         .map(|p| p.sha256.as_str())
         .filter(|s| !s.is_empty())
+}
+
+/// Look up the pinned SHA-256 for a resolved plugin artifact.
+///
+/// Convenience over [`find_lockfile_hash`] using the artifact's resolved
+/// `(name, maven, version)` identity.
+pub(crate) fn find_artifact_lockfile_hash<'a>(
+    lockfile: &'a Lockfile,
+    artifact: &ResolvedPluginArtifact,
+) -> Option<&'a str> {
+    find_lockfile_hash(
+        lockfile,
+        &artifact.plugin_name,
+        &artifact.maven_coord.group_artifact(),
+        &artifact.maven_coord.version,
+    )
 }
 
 /// Map a `UtilError` from a plugin download into the matching `EngineError`.
@@ -234,7 +330,7 @@ pub fn build_plugin_locks(results: &[PluginArtifactResult]) -> Vec<PluginLock> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+    use std::path::Path;
 
     #[test]
     fn resolve_plugin_artifacts_basic() {
@@ -361,14 +457,68 @@ mod tests {
             ..Lockfile::default()
         };
 
-        let hash = find_lockfile_hash(&lockfile, "kotlin-serialization");
+        let hash = find_lockfile_hash(
+            &lockfile,
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "2.1.0",
+        );
         assert_eq!(hash, Some("abc123"));
+    }
+
+    #[test]
+    fn find_lockfile_hash_distinguishes_versions_and_coordinates() {
+        // The graph-wide union records distinct pins for the same plugin name at
+        // different versions, so the lookup must match the full identity
+        // (name, maven, version) — a name-only match would return whichever pin
+        // happens to come first and verify the wrong artifact against it.
+        let lockfile = Lockfile {
+            plugins: vec![
+                PluginLock {
+                    name: "ser".to_owned(),
+                    maven: "org.example:ser".to_owned(),
+                    version: "1.0.0".to_owned(),
+                    sha256: "sha-v1".to_owned(),
+                    url: "https://example.com/ser-1.0.0.jar".to_owned(),
+                },
+                PluginLock {
+                    name: "ser".to_owned(),
+                    maven: "org.example:ser".to_owned(),
+                    version: "2.0.0".to_owned(),
+                    sha256: "sha-v2".to_owned(),
+                    url: "https://example.com/ser-2.0.0.jar".to_owned(),
+                },
+            ],
+            ..Lockfile::default()
+        };
+
+        assert_eq!(
+            find_lockfile_hash(&lockfile, "ser", "org.example:ser", "1.0.0"),
+            Some("sha-v1")
+        );
+        assert_eq!(
+            find_lockfile_hash(&lockfile, "ser", "org.example:ser", "2.0.0"),
+            Some("sha-v2")
+        );
+        assert!(
+            find_lockfile_hash(&lockfile, "ser", "org.example:ser", "3.0.0").is_none(),
+            "a version with no pin must not match another version's pin"
+        );
+        assert!(
+            find_lockfile_hash(&lockfile, "ser", "org.other:ser", "1.0.0").is_none(),
+            "a different maven coordinate must not match"
+        );
     }
 
     #[test]
     fn find_lockfile_hash_absent() {
         let lockfile = Lockfile::default();
-        let hash = find_lockfile_hash(&lockfile, "kotlin-serialization");
+        let hash = find_lockfile_hash(
+            &lockfile,
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "2.1.0",
+        );
         assert!(hash.is_none());
     }
 
@@ -388,8 +538,119 @@ mod tests {
             ..Lockfile::default()
         };
 
-        let hash = find_lockfile_hash(&lockfile, "kotlin-serialization");
+        let hash = find_lockfile_hash(
+            &lockfile,
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "2.1.0",
+        );
         assert!(hash.is_none(), "empty sha256 must not count as a pin");
+    }
+
+    #[test]
+    fn unique_plugin_artifacts_dedupes_by_identity_and_sorts() {
+        let make = |name: &str, group: &str, artifact: &str, version: &str| {
+            let coord = MavenCoordinate::new(group, artifact, version);
+            ResolvedPluginArtifact {
+                plugin_name: name.to_owned(),
+                url: coord.to_url(MAVEN_CENTRAL),
+                cache_path: coord.cache_path(Path::new("/cache/maven")),
+                maven_coord: coord,
+            }
+        };
+
+        let artifacts = vec![
+            make("z-plugin", "com.example", "z-plugin", "1.0.0"),
+            make("a-plugin", "com.example", "a-plugin", "2.0.0"),
+            // Exact duplicate of z-plugin (e.g. root and a dep declare it
+            // identically) — collapses to one entry.
+            make("z-plugin", "com.example", "z-plugin", "1.0.0"),
+            // Same name at a DIFFERENT version (a dep pins an older release) —
+            // kept as a distinct entry, not a conflict.
+            make("z-plugin", "com.example", "z-plugin", "0.9.0"),
+        ];
+
+        let unique = unique_plugin_artifacts(artifacts);
+        let identities: Vec<(String, String)> = unique
+            .iter()
+            .map(|a| (a.plugin_name.clone(), a.maven_coord.version.clone()))
+            .collect();
+        assert_eq!(
+            identities,
+            vec![
+                ("a-plugin".to_owned(), "2.0.0".to_owned()),
+                ("z-plugin".to_owned(), "0.9.0".to_owned()),
+                ("z-plugin".to_owned(), "1.0.0".to_owned()),
+            ],
+            "union must be deduped by (name, maven, version) and sorted deterministically"
+        );
+    }
+
+    #[test]
+    fn resolve_graph_plugin_artifacts_unions_root_and_deps() {
+        // Root and one dep declare the same plugin (same resolved version via
+        // {kotlin}); other deps contribute their own plugins, one of them a
+        // second version of a plugin name the graph already has.
+        let root = make_manifest_with_plugin(
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "{kotlin}",
+        );
+        let dep_same = make_manifest_with_plugin(
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "{kotlin}",
+        );
+        let dep_other = make_manifest_with_plugin("my-plugin", "com.example:my-plugin", "1.0.0");
+        let dep_other_version =
+            make_manifest_with_plugin("my-plugin", "com.example:my-plugin", "2.0.0");
+
+        let union = resolve_graph_plugin_artifacts(
+            [&root, &dep_same, &dep_other, &dep_other_version].map(|m| m as &Manifest),
+        )
+        .unwrap();
+
+        let identities: Vec<(String, String)> = union
+            .iter()
+            .map(|a| (a.plugin_name.clone(), a.maven_coord.version.clone()))
+            .collect();
+        assert_eq!(
+            identities,
+            vec![
+                ("kotlin-serialization".to_owned(), "2.1.0".to_owned()),
+                ("my-plugin".to_owned(), "1.0.0".to_owned()),
+                ("my-plugin".to_owned(), "2.0.0".to_owned()),
+            ],
+            "graph union must collapse identical declarations and keep distinct versions"
+        );
+    }
+
+    #[test]
+    fn plugin_jar_paths_derive_from_own_manifest() {
+        // The per-project compile step derives its -Xplugin jars from the
+        // project's OWN manifest; the paths must be exactly the cache paths the
+        // graph-wide ensure downloaded to.
+        let manifest = make_manifest_with_plugin(
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "{kotlin}",
+        );
+        let paths = plugin_jar_paths(&manifest).unwrap();
+        let expected: Vec<PathBuf> = resolve_plugin_artifacts(&manifest)
+            .unwrap()
+            .into_iter()
+            .map(|a| a.cache_path)
+            .collect();
+        assert_eq!(paths, expected);
+        assert_eq!(paths.len(), 1);
+        assert!(
+            paths[0]
+                .display()
+                .to_string()
+                .ends_with("kotlin-serialization-compiler-plugin-2.1.0.jar"),
+            "jar path must be the resolved cache path: {}",
+            paths[0].display()
+        );
     }
 
     #[test]
@@ -566,14 +827,26 @@ mod tests {
             ..Lockfile::default()
         };
         assert_eq!(
-            find_lockfile_hash(&lockfile, "kotlin-serialization"),
+            find_lockfile_hash(
+                &lockfile,
+                "kotlin-serialization",
+                "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+                "2.1.0",
+            ),
             Some("hash-ser")
         );
         assert_eq!(
-            find_lockfile_hash(&lockfile, "kotlin-allopen"),
+            find_lockfile_hash(
+                &lockfile,
+                "kotlin-allopen",
+                "org.jetbrains.kotlin:kotlin-allopen-compiler-plugin",
+                "2.1.0",
+            ),
             Some("hash-open")
         );
-        assert!(find_lockfile_hash(&lockfile, "nonexistent").is_none());
+        assert!(
+            find_lockfile_hash(&lockfile, "nonexistent", "org.example:nope", "1.0.0").is_none()
+        );
     }
 
     #[test]
@@ -773,7 +1046,12 @@ mod tests {
                 source_hash: "abcdef".to_owned(),
             });
         // Same name as a dep but should not be found as a plugin.
-        let hash = find_lockfile_hash(&lockfile, "kotlin-serialization");
+        let hash = find_lockfile_hash(
+            &lockfile,
+            "kotlin-serialization",
+            "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin",
+            "2.1.0",
+        );
         assert!(
             hash.is_none(),
             "plugin lookup should not match dependency entries"

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -1877,6 +1877,17 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
             child_requirer_name(&None, "com.example", "missing", &resolved),
             "unknown"
         );
+        // requirer Some takes PRECEDENCE over the resolved-name fallback, even
+        // when they differ.
+        assert_eq!(
+            child_requirer_name(
+                &Some("explicit".to_owned()),
+                "org.jetbrains.kotlinx",
+                "kotlinx-coroutines-core",
+                &resolved,
+            ),
+            "explicit"
+        );
     }
 
     #[test]
@@ -1915,6 +1926,128 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
             compare_maven_versions("2.0.0-beta", "1.0.0"),
             Ordering::Greater
         );
+    }
+
+    #[test]
+    fn compare_maven_versions_reflexive_and_antisymmetric() {
+        use std::cmp::Ordering;
+        for v in ["1.0.0", "1.2", "0.6.1", "1.0.0-beta", "2.0"] {
+            assert_eq!(compare_maven_versions(v, v), Ordering::Equal);
+        }
+        // a < b  <=>  b > a, across mixed numeric/suffix cases.
+        for (a, b) in [
+            ("1.9.0", "1.10.0"),
+            ("1.0.0-beta", "1.0.0"),
+            ("0.6.0", "0.6.1"),
+        ] {
+            assert_eq!(compare_maven_versions(a, b), Ordering::Less);
+            assert_eq!(compare_maven_versions(b, a), Ordering::Greater);
+        }
+    }
+
+    #[test]
+    fn compare_maven_versions_non_numeric_segment_falls_back_lexically() {
+        use std::cmp::Ordering;
+        // A non-numeric core segment can't be parsed → byte comparison for that
+        // segment (best effort; the function is hint-only).
+        assert_eq!(compare_maven_versions("1.x.0", "1.y.0"), Ordering::Less);
+        // Trailing zeros don't change ordering.
+        assert_eq!(compare_maven_versions("1", "1.0.0.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn maven_version_conflict_munges_hint_name_and_picks_existing_when_higher() {
+        // hint_name turns dots into dashes (the konvoy.toml key convention); when
+        // the existing pin is the higher version, it's the suggested one.
+        let err = maven_version_conflict(
+            "org.jetbrains.kotlinx:atomicfu",
+            "org.jetbrains.kotlinx.atomicfu",
+            "konvoy.toml",
+            "0.24.0",
+            "models",
+            "0.23.1",
+        );
+        match err {
+            EngineError::MavenVersionConflict {
+                maven,
+                hint_name,
+                hint_version,
+                details,
+            } => {
+                assert_eq!(maven, "org.jetbrains.kotlinx:atomicfu");
+                assert_eq!(hint_name, "org-jetbrains-kotlinx-atomicfu");
+                assert_eq!(hint_version, "0.24.0", "existing is higher → suggested");
+                assert!(details.contains("konvoy.toml requires 0.24.0"));
+                assert!(details.contains("models requires 0.23.1"));
+            }
+            other => panic!("expected MavenVersionConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_required_by_accumulates_and_sorts_multiple_requirers() {
+        // A transitive dep pulled in by two parents records BOTH, sorted (the
+        // map is a BTreeSet, so order is deterministic).
+        let dep = ResolvedMavenDep {
+            name: "shared".to_owned(),
+            group_id: "g".to_owned(),
+            artifact_id: "shared".to_owned(),
+            version: "1.0".to_owned(),
+            required_by: Vec::new(),
+            classifier: None,
+        };
+        let mut resolved = HashMap::new();
+        resolved.insert(dep.key(), dep.clone());
+        let mut required_by_map: HashMap<String, BTreeSet<String>> = HashMap::new();
+        required_by_map.insert(
+            dep.key(),
+            BTreeSet::from(["zed".to_owned(), "alpha".to_owned()]),
+        );
+
+        finalize_required_by(&mut resolved, &required_by_map);
+        assert_eq!(
+            resolved.get(&dep.key()).unwrap().required_by,
+            vec!["alpha".to_owned(), "zed".to_owned()],
+            "requirers are deterministic (sorted)"
+        );
+    }
+
+    #[test]
+    fn collect_graph_direct_maven_deps_three_projects_dedup_keeps_first_declarer() {
+        // root, libA, libB. root and libA declare coroutines under DIFFERENT
+        // konvoy keys (same coord+version) — dedup keeps the FIRST declarer's
+        // name (root). libB adds a distinct dep.
+        let root = manifest_with_deps(&[(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+        )]);
+        let lib_a = manifest_with_deps(&[(
+            "my-coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+        )]);
+        let lib_b = manifest_with_deps(&[(
+            "datetime",
+            "org.jetbrains.kotlinx:kotlinx-datetime",
+            "0.6.0",
+        )]);
+
+        let union = collect_graph_direct_maven_deps([
+            ("konvoy.toml", &root),
+            ("libA", &lib_a),
+            ("libB", &lib_b),
+        ])
+        .unwrap();
+        let by_key: std::collections::BTreeMap<String, &str> =
+            union.iter().map(|d| (d.key(), d.name.as_str())).collect();
+        assert_eq!(union.len(), 2, "the shared coordinate dedups to one entry");
+        assert_eq!(
+            by_key.get("org.jetbrains.kotlinx:kotlinx-coroutines-core"),
+            Some(&"coroutines"),
+            "the first declarer's (root's) konvoy key wins"
+        );
+        assert!(by_key.contains_key("org.jetbrains.kotlinx:kotlinx-datetime"));
     }
 
     #[test]

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -1838,6 +1838,48 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
     }
 
     #[test]
+    fn child_requirer_name_prefers_requirer_then_resolved_then_unknown() {
+        let mut resolved: HashMap<String, ResolvedMavenDep> = HashMap::new();
+        resolved.insert(
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core".to_owned(),
+            ResolvedMavenDep {
+                name: "coroutines".to_owned(),
+                group_id: "org.jetbrains.kotlinx".to_owned(),
+                artifact_id: "kotlinx-coroutines-core".to_owned(),
+                version: "1.8.0".to_owned(),
+                required_by: Vec::new(),
+                classifier: None,
+            },
+        );
+
+        // requirer is Some → used directly (the cached processing-dep name).
+        assert_eq!(
+            child_requirer_name(
+                &Some("coroutines".to_owned()),
+                "org.jetbrains.kotlinx",
+                "kotlinx-coroutines-core",
+                &resolved,
+            ),
+            "coroutines"
+        );
+        // requirer None (a seed/direct dep) → fall back to the resolved entry's name.
+        assert_eq!(
+            child_requirer_name(
+                &None,
+                "org.jetbrains.kotlinx",
+                "kotlinx-coroutines-core",
+                &resolved,
+            ),
+            "coroutines"
+        );
+        // requirer None and the processing dep isn't resolved → "unknown".
+        assert_eq!(
+            child_requirer_name(&None, "com.example", "missing", &resolved),
+            "unknown"
+        );
+    }
+
+    #[test]
     fn compare_maven_versions_is_numeric_not_lexicographic() {
         use std::cmp::Ordering;
         // The bug this guards: a string compare makes "1.10.0" < "1.9.0".

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -197,31 +197,27 @@ pub fn update(
         });
     }
 
-    // 2. Collect Maven deps (those with `maven` + `version` set).
-    let maven_deps: Vec<(&String, &str, &str)> = manifest
-        .dependencies
-        .iter()
-        .filter_map(|(name, spec)| spec.as_maven_coord().map(|(m, v)| (name, m, v)))
-        .collect();
+    // 2. Collect the DIRECT Maven deps as the deduped union across the whole
+    //    build graph — the root plus every path-dependency. A path-dep's
+    //    `[dependencies]` must be resolved and pinned in the root lock too,
+    //    because the dep's own compile links the klibs it declares (the
+    //    `[dependencies]` analogue of the path-dep `[plugins]` fix, #293).
+    //    `resolve_dependencies` only reads dep manifests + source hashes, so it
+    //    is safe to run here; it also enforces the shared Kotlin version. Cross-
+    //    project version clashes are surfaced (libraries are linked).
+    let dep_graph = crate::resolve::resolve_dependencies(project_root, &manifest)?;
+    let mut projects: Vec<(&str, &Manifest)> = vec![("konvoy.toml", &manifest)];
+    projects.extend(
+        dep_graph
+            .order
+            .iter()
+            .map(|dep| (dep.name.as_str(), &dep.manifest)),
+    );
+    let direct_deps = collect_graph_direct_maven_deps(projects)?;
 
-    if maven_deps.is_empty() {
+    if direct_deps.is_empty() {
         lockfile.write_to(&lockfile_path)?;
         return Ok(UpdateResult { updated_count: 0 });
-    }
-
-    // 3. Build the set of direct deps with their maven coordinates.
-    let mut direct_deps: Vec<ResolvedMavenDep> = Vec::new();
-    for (dep_name, maven, version) in &maven_deps {
-        let (group_id, artifact_id) = crate::common::split_maven_coordinate(maven)?;
-
-        direct_deps.push(ResolvedMavenDep {
-            name: (*dep_name).clone(),
-            group_id: group_id.to_owned(),
-            artifact_id: artifact_id.to_owned(),
-            version: (*version).to_owned(),
-            required_by: Vec::new(),
-            classifier: None,
-        });
     }
 
     // 4. Resolve transitive dependencies via BFS on POM files.
@@ -419,6 +415,76 @@ struct BfsState {
     metadata_cache: HashMap<String, ArtifactMetadata>,
     required_by_map: HashMap<String, BTreeSet<String>>,
     queue: VecDeque<BfsEntry>,
+}
+
+/// Collect the deduped union of **direct** Maven dependencies across the build
+/// graph — the root manifest plus every path-dependency — surfacing a version
+/// conflict when two projects declare the same `group:artifact` at different
+/// versions.
+///
+/// Each `(label, manifest)` pair is a project; `label` names it in conflict
+/// messages (e.g. `"konvoy.toml"` for the root, or a path-dep's name). A
+/// path-dep's `[dependencies]` must be resolved and pinned just like the root's,
+/// because each project's own compile links the klibs it declares — the
+/// `[dependencies]` analogue of the path-dep `[plugins]` fix (#293).
+///
+/// Unlike compiler plugins (applied per-compilation, so multiple versions are
+/// benign), Maven libraries are linked into a shared artifact graph, so a
+/// cross-graph version clash is a hard error here — consistent with how the
+/// transitive resolver already surfaces conflicts rather than auto-picking.
+///
+/// # Errors
+/// Returns [`EngineError::MavenVersionConflict`] on a cross-project version
+/// clash, or a coordinate-parse error for a malformed `maven` value.
+fn collect_graph_direct_maven_deps<'a>(
+    projects: impl IntoIterator<Item = (&'a str, &'a Manifest)>,
+) -> Result<Vec<ResolvedMavenDep>, EngineError> {
+    // Keyed by `group:artifact` (the dedup/conflict key), value carries the dep
+    // plus the label of the project that first declared it (for the message).
+    let mut by_key: BTreeMap<String, (ResolvedMavenDep, String)> = BTreeMap::new();
+
+    for (label, manifest) in projects {
+        for (dep_name, spec) in &manifest.dependencies {
+            let Some((maven, version)) = spec.as_maven_coord() else {
+                continue; // path dep or incomplete — not a Maven dep
+            };
+            let (group_id, artifact_id) = crate::common::split_maven_coordinate(maven)?;
+            let dep = ResolvedMavenDep {
+                name: dep_name.clone(),
+                group_id: group_id.to_owned(),
+                artifact_id: artifact_id.to_owned(),
+                version: version.to_owned(),
+                required_by: Vec::new(),
+                classifier: None,
+            };
+            let key = dep.key();
+
+            match by_key.get(&key) {
+                Some((existing, existing_label)) if existing.version != dep.version => {
+                    let hint_version = if dep.version.as_str() > existing.version.as_str() {
+                        dep.version.clone()
+                    } else {
+                        existing.version.clone()
+                    };
+                    return Err(EngineError::MavenVersionConflict {
+                        maven: key,
+                        details: format!(
+                            "  {existing_label} requires {}\n  {label} requires {}",
+                            existing.version, dep.version
+                        ),
+                        hint_name: artifact_id.replace('.', "-"),
+                        hint_version,
+                    });
+                }
+                Some(_) => { /* identical declaration — dedup */ }
+                None => {
+                    by_key.insert(key, (dep, label.to_owned()));
+                }
+            }
+        }
+    }
+
+    Ok(by_key.into_values().map(|(dep, _)| dep).collect())
 }
 
 /// Check for a version conflict between a newly resolved dep and one already seen.
@@ -840,6 +906,20 @@ mod tests {
         tmp
     }
 
+    /// Create a nested `lib` path-dependency under `project/<name>` so
+    /// `update` (which now resolves the whole graph) can find it. Nested rather
+    /// than a `/tmp` sibling so parallel tests don't collide on a shared path.
+    fn add_nested_lib_dep(project: &std::path::Path, name: &str, kotlin: &str) {
+        let dep = project.join(name);
+        fs::create_dir_all(dep.join("src")).unwrap();
+        fs::write(
+            dep.join("konvoy.toml"),
+            format!("[package]\nname = \"{name}\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"{kotlin}\"\n"),
+        )
+        .unwrap();
+        fs::write(dep.join("src/lib.kt"), "package dep\nfun f() = 1\n").unwrap();
+    }
+
     #[test]
     fn update_no_maven_deps_is_noop() {
         let project = make_project(
@@ -851,15 +931,16 @@ name = "my-app"
 kotlin = "2.1.0"
 
 [dependencies]
-my-utils = { path = "../my-utils" }
+my-utils = { path = "my-utils" }
 "#,
         );
+        add_nested_lib_dep(project.path(), "my-utils", "2.1.0");
         // Write an initial lockfile with a path dep.
         let mut lockfile = Lockfile::with_toolchain("2.1.0");
         lockfile.dependencies.push(DependencyLock {
             name: "my-utils".to_owned(),
             source: DepSource::Path {
-                path: "../my-utils".to_owned(),
+                path: "my-utils".to_owned(),
             },
             source_hash: "abcdef".to_owned(),
         });
@@ -887,15 +968,16 @@ name = "my-app"
 kotlin = "2.1.0"
 
 [dependencies]
-my-utils = { path = "../my-utils" }
+my-utils = { path = "my-utils" }
 "#,
         );
+        add_nested_lib_dep(project.path(), "my-utils", "2.1.0");
         // Pre-populate lockfile with a path dep.
         let mut lockfile = Lockfile::with_toolchain("2.1.0");
         lockfile.dependencies.push(DependencyLock {
             name: "my-utils".to_owned(),
             source: DepSource::Path {
-                path: "../my-utils".to_owned(),
+                path: "my-utils".to_owned(),
             },
             source_hash: "path-hash".to_owned(),
         });
@@ -911,7 +993,7 @@ my-utils = { path = "../my-utils" }
         let dep = &reparsed.dependencies[0];
         assert_eq!(dep.name, "my-utils");
         match &dep.source {
-            DepSource::Path { path } => assert_eq!(path, "../my-utils"),
+            DepSource::Path { path } => assert_eq!(path, "my-utils"),
             other => panic!("expected Path source, got: {other:?}"),
         }
     }
@@ -1579,5 +1661,94 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
             DepSource::Maven { classifier, .. } => assert!(classifier.is_none()),
             other => panic!("expected Maven source, got: {other:?}"),
         }
+    }
+
+    // -- graph-wide direct Maven dep collection (#293 analogue for [dependencies]) --
+
+    fn manifest_with_deps(deps: &[(&str, &str, &str)]) -> Manifest {
+        let mut toml = String::from(
+            "[package]\nname = \"p\"\nkind = \"lib\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\n",
+        );
+        for (name, maven, version) in deps {
+            toml.push_str(&format!(
+                "{name} = {{ maven = \"{maven}\", version = \"{version}\" }}\n"
+            ));
+        }
+        Manifest::from_str(&toml, "konvoy.toml").unwrap()
+    }
+
+    #[test]
+    fn collect_graph_direct_maven_deps_unions_and_dedupes() {
+        // The root and a path-dep both declare coroutines (identical → dedup); the
+        // dep also declares datetime. The union has both, exactly once each.
+        let root = manifest_with_deps(&[(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+        )]);
+        let dep = manifest_with_deps(&[
+            (
+                "coroutines",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "1.8.0",
+            ),
+            (
+                "datetime",
+                "org.jetbrains.kotlinx:kotlinx-datetime",
+                "0.6.0",
+            ),
+        ]);
+
+        let union =
+            collect_graph_direct_maven_deps([("konvoy.toml", &root), ("models", &dep)]).unwrap();
+        let ids: Vec<String> = union
+            .iter()
+            .map(|d| format!("{}:{}", d.key(), d.version))
+            .collect();
+        assert_eq!(union.len(), 2, "identical declarations must dedup to one");
+        assert!(ids.contains(&"org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0".to_owned()));
+        assert!(ids.contains(&"org.jetbrains.kotlinx:kotlinx-datetime:0.6.0".to_owned()));
+    }
+
+    #[test]
+    fn collect_graph_direct_maven_deps_surfaces_cross_project_conflict() {
+        // Libraries are linked, so the same artifact at two versions across the
+        // graph is a conflict to surface — not distinct pins (unlike plugins).
+        let root = manifest_with_deps(&[(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.8.0",
+        )]);
+        let dep = manifest_with_deps(&[(
+            "coroutines",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "1.7.3",
+        )]);
+
+        let err = collect_graph_direct_maven_deps([("konvoy.toml", &root), ("models", &dep)])
+            .unwrap_err();
+        match err {
+            EngineError::MavenVersionConflict { details, maven, .. } => {
+                assert_eq!(maven, "org.jetbrains.kotlinx:kotlinx-coroutines-core");
+                assert!(details.contains("1.8.0"), "details: {details}");
+                assert!(
+                    details.contains("models requires 1.7.3"),
+                    "conflict must name the declaring project: {details}"
+                );
+            }
+            other => panic!("expected MavenVersionConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn collect_graph_direct_maven_deps_ignores_path_deps() {
+        // A path-dep entry in a manifest is not a Maven dep and must be skipped.
+        let root = Manifest::from_str(
+            "[package]\nname = \"p\"\nkind = \"bin\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n[dependencies]\nmodels = { path = \"../models\" }\n",
+            "konvoy.toml",
+        )
+        .unwrap();
+        let union = collect_graph_direct_maven_deps([("konvoy.toml", &root)]).unwrap();
+        assert!(union.is_empty(), "path deps are not Maven deps");
     }
 }

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -178,10 +178,24 @@ pub fn update(
     project_root: &Path,
     resolver: crate::common::ArtifactResolver<'_>,
 ) -> Result<UpdateResult, EngineError> {
-    // 1. Read konvoy.toml and konvoy.lock.
-    let manifest_path = project_root.join("konvoy.toml");
-    let manifest = Manifest::from_path(&manifest_path)?;
+    let manifest = Manifest::from_path(&project_root.join("konvoy.toml"))?;
+    // Resolve the path-dependency graph once; the Maven union spans it.
+    let dep_graph = crate::resolve::resolve_dependencies(project_root, &manifest)?;
+    update_with_graph(project_root, &manifest, &dep_graph, resolver)
+}
 
+/// [`update`] with the path-dependency graph already resolved.
+///
+/// The build's auto-update path has already resolved (and source-hashed) the
+/// graph at `resolve_build_context`, so it calls this directly to avoid walking
+/// and hashing every path-dep's source tree a second time on a cold build.
+pub(crate) fn update_with_graph(
+    project_root: &Path,
+    manifest: &Manifest,
+    dep_graph: &crate::resolve::ResolvedGraph,
+    resolver: crate::common::ArtifactResolver<'_>,
+) -> Result<UpdateResult, EngineError> {
+    // 1. Read konvoy.lock.
     let lockfile_path = project_root.join("konvoy.lock");
     let mut lockfile = Lockfile::from_path(&lockfile_path)?;
 
@@ -202,11 +216,8 @@ pub fn update(
     //    `[dependencies]` must be resolved and pinned in the root lock too,
     //    because the dep's own compile links the klibs it declares (the
     //    `[dependencies]` analogue of the path-dep `[plugins]` fix, #293).
-    //    `resolve_dependencies` only reads dep manifests + source hashes, so it
-    //    is safe to run here; it also enforces the shared Kotlin version. Cross-
-    //    project version clashes are surfaced (libraries are linked).
-    let dep_graph = crate::resolve::resolve_dependencies(project_root, &manifest)?;
-    let mut projects: Vec<(&str, &Manifest)> = vec![("konvoy.toml", &manifest)];
+    //    Cross-project version clashes are surfaced (libraries are linked).
+    let mut projects: Vec<(&str, &Manifest)> = vec![("konvoy.toml", manifest)];
     projects.extend(
         dep_graph
             .order
@@ -216,6 +227,13 @@ pub fn update(
     let direct_deps = collect_graph_direct_maven_deps(projects)?;
 
     if direct_deps.is_empty() {
+        // No Maven deps anywhere in the graph — prune any stale Maven pins (the
+        // last Maven dep may have just been removed) while preserving path-dep
+        // locks, then write. Without this, a removed Maven dep's pin would
+        // linger and still be linked/enforced under `--locked`.
+        lockfile
+            .dependencies
+            .retain(|d| matches!(&d.source, DepSource::Path { .. }));
         lockfile.write_to(&lockfile_path)?;
         return Ok(UpdateResult { updated_count: 0 });
     }
@@ -461,20 +479,14 @@ fn collect_graph_direct_maven_deps<'a>(
 
             match by_key.get(&key) {
                 Some((existing, existing_label)) if existing.version != dep.version => {
-                    let hint_version = if dep.version.as_str() > existing.version.as_str() {
-                        dep.version.clone()
-                    } else {
-                        existing.version.clone()
-                    };
-                    return Err(EngineError::MavenVersionConflict {
-                        maven: key,
-                        details: format!(
-                            "  {existing_label} requires {}\n  {label} requires {}",
-                            existing.version, dep.version
-                        ),
-                        hint_name: artifact_id.replace('.', "-"),
-                        hint_version,
-                    });
+                    return Err(maven_version_conflict(
+                        &key,
+                        artifact_id,
+                        existing_label,
+                        &existing.version,
+                        label,
+                        &dep.version,
+                    ));
                 }
                 Some(_) => { /* identical declaration — dedup */ }
                 None => {
@@ -485,6 +497,64 @@ fn collect_graph_direct_maven_deps<'a>(
     }
 
     Ok(by_key.into_values().map(|(dep, _)| dep).collect())
+}
+
+/// Order two Maven version strings by dotted-numeric segments, so `1.10.0`
+/// sorts above `1.9.0` (a plain string compare gets this wrong). Non-numeric
+/// segments (e.g. `-beta` suffixes) fall back to lexicographic order, and a
+/// longer numeric run is treated as newer (`1.0.1` > `1.0`). This is a hint
+/// heuristic, not a full semver implementation.
+fn compare_maven_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut a_parts = a.split('.');
+    let mut b_parts = b.split('.');
+    loop {
+        match (a_parts.next(), b_parts.next()) {
+            (None, None) => return Ordering::Equal,
+            (Some(_), None) => return Ordering::Greater,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(x), Some(y)) => {
+                let ord = match (x.parse::<u64>(), y.parse::<u64>()) {
+                    (Ok(nx), Ok(ny)) => nx.cmp(&ny),
+                    _ => x.cmp(y),
+                };
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+        }
+    }
+}
+
+/// Build a [`EngineError::MavenVersionConflict`] naming the two clashing
+/// requirers and suggesting the higher version to pin.
+///
+/// Single source of the conflict message format + hint policy, shared by the
+/// graph-direct collector ([`collect_graph_direct_maven_deps`]) and the
+/// transitive resolver ([`check_version_conflict`]) so they can't drift.
+fn maven_version_conflict(
+    dep_key: &str,
+    base_artifact_id: &str,
+    existing_requirer: &str,
+    existing_version: &str,
+    current_requirer: &str,
+    current_version: &str,
+) -> EngineError {
+    let hint_version = if compare_maven_versions(current_version, existing_version)
+        == std::cmp::Ordering::Greater
+    {
+        current_version
+    } else {
+        existing_version
+    };
+    EngineError::MavenVersionConflict {
+        maven: dep_key.to_owned(),
+        details: format!(
+            "  {existing_requirer} requires {existing_version}\n  {current_requirer} requires {current_version}"
+        ),
+        hint_name: base_artifact_id.replace('.', "-"),
+        hint_version: hint_version.to_owned(),
+    }
 }
 
 /// Check for a version conflict between a newly resolved dep and one already seen.
@@ -513,23 +583,14 @@ fn check_version_conflict(
     };
     let current_requirer = requirer.unwrap_or("konvoy.toml (direct)");
 
-    let details = format!(
-        "  {existing_requirer} requires {}\n  {current_requirer} requires {resolved_version}",
-        existing.version
-    );
-    let hint_name = base_artifact_id.replace('.', "-");
-    let hint_version = if resolved_version > existing.version.as_str() {
-        resolved_version.to_owned()
-    } else {
-        existing.version.clone()
-    };
-
-    Err(EngineError::MavenVersionConflict {
-        maven: dep_key.to_owned(),
-        details,
-        hint_name,
-        hint_version,
-    })
+    Err(maven_version_conflict(
+        dep_key,
+        base_artifact_id,
+        existing_requirer,
+        &existing.version,
+        current_requirer,
+        resolved_version,
+    ))
 }
 
 /// Discover cinterop klibs from cached metadata and return them as separate deps.
@@ -580,16 +641,17 @@ fn discover_cinterop_deps(
 fn finalize_required_by(
     resolved: &mut HashMap<String, ResolvedMavenDep>,
     required_by_map: &HashMap<String, BTreeSet<String>>,
-    direct_deps: &[ResolvedMavenDep],
 ) {
+    // A dep's `required_by` must record EVERY transitive requirer, even when the
+    // dep is ALSO declared direct somewhere in the graph. The per-project Maven
+    // closure (`build::project_maven_closure`) reconstructs a path-dep's
+    // transitive set SOLELY from `required_by`, so emptying it for graph-direct
+    // deps would make a transitive-that's-also-direct unreachable for a sibling
+    // path-dep that needs it — a standalone-vs-as-a-dependency parity break. A
+    // purely-direct dep simply has no `required_by_map` entry and stays empty.
     for (key, dep) in resolved.iter_mut() {
         if let Some(requirers) = required_by_map.get(key) {
-            let is_direct = direct_deps.iter().any(|d| d.key() == *key);
-            if is_direct {
-                dep.required_by = Vec::new();
-            } else {
-                dep.required_by = requirers.iter().cloned().collect();
-            }
+            dep.required_by = requirers.iter().cloned().collect();
         }
     }
 }
@@ -753,7 +815,13 @@ fn resolve_transitive(
                     .cloned()
                     .unwrap_or_else(|| meta_dep.version.clone());
 
-                // Already resolved — check for version conflict, then skip.
+                // Already resolved — check for version conflict, then record the
+                // requiring edge and skip re-queueing. The requirer is THIS entry
+                // (the dep whose metadata we're reading), not this entry's own
+                // requirer — matching the new-dep branch below. Recording it even
+                // for an already-resolved (e.g. direct-seeded) child is what lets
+                // `build::project_maven_closure` reach a transitive that is also
+                // declared direct somewhere in the graph.
                 if let Some(existing) = state.resolved.get(&dep_key) {
                     check_version_conflict(
                         existing,
@@ -762,13 +830,20 @@ fn resolve_transitive(
                         &base_artifact_id,
                         requirer.as_deref(),
                     )?;
-                    if let Some(req) = &requirer {
-                        state
-                            .required_by_map
-                            .entry(dep_key)
-                            .or_default()
-                            .insert(req.clone());
-                    }
+                    let parent_name = requirer
+                        .clone()
+                        .or_else(|| {
+                            state
+                                .resolved
+                                .get(&format!("{group_id}:{artifact_id}"))
+                                .map(|d| d.name.clone())
+                        })
+                        .unwrap_or_else(|| "unknown".to_owned());
+                    state
+                        .required_by_map
+                        .entry(dep_key)
+                        .or_default()
+                        .insert(parent_name);
                     continue;
                 }
 
@@ -819,7 +894,7 @@ fn resolve_transitive(
         }
     }
 
-    finalize_required_by(&mut state.resolved, &state.required_by_map, direct_deps);
+    finalize_required_by(&mut state.resolved, &state.required_by_map);
 
     let cinterop_deps =
         discover_cinterop_deps(&state.resolved, &state.metadata_cache, maven_suffix);
@@ -1380,20 +1455,12 @@ kotlin = "2.1.0"
     }
 
     #[test]
-    fn finalize_required_by_clears_direct_deps_and_fills_transitive() {
-        // Build a minimal graph: one direct dep `kotlinx-coroutines-core`
-        // that pulls in transitive `atomicfu`. `finalize_required_by` should
-        // clear required_by on the direct dep and populate it on the
-        // transitive one.
-        let direct = ResolvedMavenDep {
-            name: "kotlinx-coroutines".to_owned(),
-            group_id: "org.jetbrains.kotlinx".to_owned(),
-            artifact_id: "kotlinx-coroutines-core".to_owned(),
-            version: "1.8.0".to_owned(),
-            required_by: vec!["leftover".to_owned()], // must be cleared
-            classifier: None,
-        };
-        let transitive = ResolvedMavenDep {
+    fn finalize_required_by_records_every_transitive_requirer() {
+        // A transitive dep that is ALSO declared direct must STILL record its
+        // transitive requirers — the per-project Maven closure relies on
+        // `required_by` to reach it (emptying it broke standalone-vs-as-dep
+        // parity; see the comment in `finalize_required_by`).
+        let direct_and_transitive = ResolvedMavenDep {
             name: "atomicfu".to_owned(),
             group_id: "org.jetbrains.kotlinx".to_owned(),
             artifact_id: "atomicfu".to_owned(),
@@ -1403,37 +1470,24 @@ kotlin = "2.1.0"
         };
 
         let mut resolved = HashMap::new();
-        resolved.insert(direct.key(), direct.clone());
-        resolved.insert(transitive.key(), transitive.clone());
+        resolved.insert(direct_and_transitive.key(), direct_and_transitive.clone());
 
         let mut required_by_map: HashMap<String, BTreeSet<String>> = HashMap::new();
+        // atomicfu is pulled in by coroutines AND declared direct by the root.
         required_by_map.insert(
-            direct.key(),
-            BTreeSet::from(["self-ref-ignored".to_owned()]),
-        );
-        required_by_map.insert(
-            transitive.key(),
+            direct_and_transitive.key(),
             BTreeSet::from(["kotlinx-coroutines-core".to_owned()]),
         );
 
-        finalize_required_by(&mut resolved, &required_by_map, &[direct.clone()]);
+        finalize_required_by(&mut resolved, &required_by_map);
 
-        // Direct dep: required_by must be cleared even though the map has an entry.
-        assert!(
-            resolved
-                .get(&direct.key())
-                .expect("direct still present")
-                .required_by
-                .is_empty(),
-            "direct dep should have empty required_by"
-        );
-        // Transitive dep: required_by must reflect the map.
         assert_eq!(
             resolved
-                .get(&transitive.key())
-                .expect("transitive still present")
+                .get(&direct_and_transitive.key())
+                .expect("dep still present")
                 .required_by,
-            vec!["kotlinx-coroutines-core".to_owned()]
+            vec!["kotlinx-coroutines-core".to_owned()],
+            "a direct-AND-transitive dep must keep its transitive requirer so the closure can reach it"
         );
     }
 
@@ -1452,7 +1506,7 @@ kotlin = "2.1.0"
         resolved.insert(dep.key(), dep.clone());
         let required_by_map: HashMap<String, BTreeSet<String>> = HashMap::new();
 
-        finalize_required_by(&mut resolved, &required_by_map, &[]);
+        finalize_required_by(&mut resolved, &required_by_map);
 
         assert_eq!(
             resolved
@@ -1738,6 +1792,87 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
             }
             other => panic!("expected MavenVersionConflict, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn compare_maven_versions_is_numeric_not_lexicographic() {
+        use std::cmp::Ordering;
+        // The bug this guards: a string compare makes "1.10.0" < "1.9.0".
+        assert_eq!(compare_maven_versions("1.10.0", "1.9.0"), Ordering::Greater);
+        assert_eq!(compare_maven_versions("1.9.0", "1.10.0"), Ordering::Less);
+        assert_eq!(compare_maven_versions("2.0.0", "2.0.0"), Ordering::Equal);
+        assert_eq!(compare_maven_versions("1.0.1", "1.0"), Ordering::Greater);
+        assert_eq!(compare_maven_versions("0.6.1", "0.6.0"), Ordering::Greater);
+    }
+
+    #[test]
+    fn maven_version_conflict_hint_suggests_the_higher_version() {
+        let err = maven_version_conflict(
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+            "kotlinx-coroutines-core",
+            "konvoy.toml",
+            "1.9.0",
+            "models",
+            "1.10.0",
+        );
+        match err {
+            EngineError::MavenVersionConflict {
+                hint_version,
+                details,
+                ..
+            } => {
+                assert_eq!(
+                    hint_version, "1.10.0",
+                    "hint must suggest the higher version"
+                );
+                assert!(details.contains("konvoy.toml requires 1.9.0"));
+                assert!(details.contains("models requires 1.10.0"));
+            }
+            other => panic!("expected MavenVersionConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_prunes_stale_maven_when_graph_has_none() {
+        // A lockfile pins a Maven dep that the manifest no longer declares (and
+        // there are no Maven deps anywhere). update() must drop the stale pin
+        // while keeping path-dep locks.
+        let project = make_project(
+            "[package]\nname = \"app\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n\n[dependencies]\nmy-utils = { path = \"my-utils\" }\n",
+        );
+        add_nested_lib_dep(project.path(), "my-utils", "2.1.0");
+        let mut lockfile = Lockfile::with_toolchain("2.1.0");
+        lockfile.dependencies.push(DependencyLock {
+            name: "my-utils".to_owned(),
+            source: DepSource::Path {
+                path: "my-utils".to_owned(),
+            },
+            source_hash: "h".to_owned(),
+        });
+        lockfile.dependencies.push(DependencyLock {
+            name: "kotlinx-datetime".to_owned(),
+            source: DepSource::Maven {
+                version: "0.6.0".to_owned(),
+                maven: "org.jetbrains.kotlinx:kotlinx-datetime".to_owned(),
+                targets: std::collections::BTreeMap::new(),
+                required_by: Vec::new(),
+                classifier: None,
+            },
+            source_hash: "stale".to_owned(),
+        });
+        lockfile
+            .write_to(&project.path().join("konvoy.lock"))
+            .unwrap();
+
+        update(project.path(), crate::common::test_resolver(false, false)).unwrap();
+
+        let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
+        assert!(
+            reparsed.has_maven_entry("kotlinx-datetime") == false,
+            "stale Maven pin must be pruned"
+        );
+        assert_eq!(reparsed.dependencies.len(), 1, "the path dep must be kept");
+        assert_eq!(reparsed.dependencies[0].name, "my-utils");
     }
 
     #[test]

--- a/crates/konvoy-engine/src/update.rs
+++ b/crates/konvoy-engine/src/update.rs
@@ -499,21 +499,38 @@ fn collect_graph_direct_maven_deps<'a>(
     Ok(by_key.into_values().map(|(dep, _)| dep).collect())
 }
 
-/// Order two Maven version strings by dotted-numeric segments, so `1.10.0`
-/// sorts above `1.9.0` (a plain string compare gets this wrong). Non-numeric
-/// segments (e.g. `-beta` suffixes) fall back to lexicographic order, and a
-/// longer numeric run is treated as newer (`1.0.1` > `1.0`). This is a hint
-/// heuristic, not a full semver implementation.
+/// Order two Maven version strings well enough to pick the higher one for a
+/// conflict hint. Compares the dotted-numeric core (`1.10.0` > `1.9.0`, and a
+/// missing trailing segment counts as `0` so `1.0` == `1.0.0`); a version with a
+/// pre-release suffix sorts BELOW the same core (`1.0.0-beta` < `1.0.0`), and two
+/// suffixes compare lexicographically. Not a full semver implementation — it
+/// only has to tolerate arbitrary Maven version strings and produce a sensible
+/// hint.
 fn compare_maven_versions(a: &str, b: &str) -> std::cmp::Ordering {
     use std::cmp::Ordering;
-    let mut a_parts = a.split('.');
-    let mut b_parts = b.split('.');
+
+    // Split a version into its numeric core (segments before the first `-`) and
+    // an optional pre-release suffix.
+    fn split_core(v: &str) -> (&str, Option<&str>) {
+        match v.split_once('-') {
+            Some((core, pre)) => (core, Some(pre)),
+            None => (v, None),
+        }
+    }
+
+    let (a_core, a_pre) = split_core(a);
+    let (b_core, b_pre) = split_core(b);
+
+    let mut a_parts = a_core.split('.');
+    let mut b_parts = b_core.split('.');
     loop {
         match (a_parts.next(), b_parts.next()) {
-            (None, None) => return Ordering::Equal,
-            (Some(_), None) => return Ordering::Greater,
-            (None, Some(_)) => return Ordering::Less,
-            (Some(x), Some(y)) => {
+            (None, None) => break,
+            // Pad a missing segment with 0 so `1.0` and `1.0.0` compare equal,
+            // and `1.0.1` > `1.0`.
+            (a_seg, b_seg) => {
+                let x = a_seg.unwrap_or("0");
+                let y = b_seg.unwrap_or("0");
                 let ord = match (x.parse::<u64>(), y.parse::<u64>()) {
                     (Ok(nx), Ok(ny)) => nx.cmp(&ny),
                     _ => x.cmp(y),
@@ -523,6 +540,15 @@ fn compare_maven_versions(a: &str, b: &str) -> std::cmp::Ordering {
                 }
             }
         }
+    }
+
+    // Equal numeric core: a pre-release suffix is LESS than no suffix; two
+    // suffixes compare lexicographically.
+    match (a_pre, b_pre) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(x), Some(y)) => x.cmp(y),
     }
 }
 
@@ -555,6 +581,29 @@ fn maven_version_conflict(
         hint_name: base_artifact_id.replace('.', "-"),
         hint_version: hint_version.to_owned(),
     }
+}
+
+/// The name of the dep that requires the child currently being recorded.
+///
+/// A queue entry's `requirer` field carries the processing dep's OWN name (set
+/// when it was enqueued); for the seed (direct) deps it is `None`, so we fall
+/// back to looking the processing dep up in `resolved` by its `group:artifact`,
+/// and finally to `"unknown"`. Shared by both the already-resolved and new-dep
+/// branches so they attribute `required_by` identically.
+fn child_requirer_name(
+    requirer: &Option<String>,
+    group_id: &str,
+    artifact_id: &str,
+    resolved: &HashMap<String, ResolvedMavenDep>,
+) -> String {
+    requirer
+        .clone()
+        .or_else(|| {
+            resolved
+                .get(&format!("{group_id}:{artifact_id}"))
+                .map(|d| d.name.clone())
+        })
+        .unwrap_or_else(|| "unknown".to_owned())
 }
 
 /// Check for a version conflict between a newly resolved dep and one already seen.
@@ -636,8 +685,10 @@ fn discover_cinterop_deps(
     cinterop_deps
 }
 
-/// Finalize the `required_by` fields: direct deps get empty, transitive deps
-/// get the accumulated requirer set.
+/// Finalize the `required_by` fields: every dep with recorded requirers gets the
+/// accumulated set (including a dep that is BOTH declared direct and pulled
+/// transitively — see the body). A purely-direct dep has no recorded requirers
+/// and stays empty.
 fn finalize_required_by(
     resolved: &mut HashMap<String, ResolvedMavenDep>,
     required_by_map: &HashMap<String, BTreeSet<String>>,
@@ -830,33 +881,25 @@ fn resolve_transitive(
                         &base_artifact_id,
                         requirer.as_deref(),
                     )?;
-                    let parent_name = requirer
-                        .clone()
-                        .or_else(|| {
-                            state
-                                .resolved
-                                .get(&format!("{group_id}:{artifact_id}"))
-                                .map(|d| d.name.clone())
-                        })
-                        .unwrap_or_else(|| "unknown".to_owned());
-                    state
-                        .required_by_map
-                        .entry(dep_key)
-                        .or_default()
-                        .insert(parent_name);
+                    let existing_name = existing.name.clone();
+                    let parent_name =
+                        child_requirer_name(&requirer, &group_id, &artifact_id, &state.resolved);
+                    // Skip a self-reference (a dep whose POM lists itself): this
+                    // branch has no cycle check, and `A required_by [A]` is a
+                    // confusing lockfile entry that the old wipe used to hide.
+                    if parent_name != existing_name {
+                        state
+                            .required_by_map
+                            .entry(dep_key)
+                            .or_default()
+                            .insert(parent_name);
+                    }
                     continue;
                 }
 
                 let dep_name = base_artifact_id.clone();
-                let parent_name = requirer
-                    .clone()
-                    .or_else(|| {
-                        state
-                            .resolved
-                            .get(&format!("{group_id}:{artifact_id}"))
-                            .map(|d| d.name.clone())
-                    })
-                    .unwrap_or_else(|| "unknown".to_owned());
+                let parent_name =
+                    child_requirer_name(&requirer, &group_id, &artifact_id, &state.resolved);
 
                 state
                     .required_by_map
@@ -1806,6 +1849,33 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
     }
 
     #[test]
+    fn compare_maven_versions_handles_segments_and_prerelease() {
+        use std::cmp::Ordering;
+        // Missing trailing segments count as 0.
+        assert_eq!(compare_maven_versions("1.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_maven_versions("1.0.0", "1.0"), Ordering::Equal);
+        // A pre-release suffix sorts BELOW the same numeric core (the bug the
+        // old lexicographic fallback got backwards: "1.0.0-beta" > "1.0.0").
+        assert_eq!(
+            compare_maven_versions("1.0.0-beta", "1.0.0"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_maven_versions("1.0.0", "1.0.0-RC1"),
+            Ordering::Greater
+        );
+        // Two suffixes compare lexicographically; numeric core still dominates.
+        assert_eq!(
+            compare_maven_versions("1.0.0-rc1", "1.0.0-rc2"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_maven_versions("2.0.0-beta", "1.0.0"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
     fn maven_version_conflict_hint_suggests_the_higher_version() {
         let err = maven_version_conflict(
             "org.jetbrains.kotlinx:kotlinx-coroutines-core",
@@ -1868,7 +1938,7 @@ atomicfu = { maven = "org.jetbrains.kotlinx:atomicfu", version = "0.23.1" }
 
         let reparsed = Lockfile::from_path(&project.path().join("konvoy.lock")).unwrap();
         assert!(
-            reparsed.has_maven_entry("kotlinx-datetime") == false,
+            !reparsed.has_maven_entry("kotlinx-datetime"),
             "stale Maven pin must be pruned"
         );
         assert_eq!(reparsed.dependencies.len(), 1, "the path dep must be kept");

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1241,6 +1241,181 @@ KOTLIN
     assert_file_contains konvoy.lock "maven ="
 }
 
+test_path_dep_maven_dep_build_lifecycle() {
+    # A path-dep that declares its OWN Maven dependency must be compiled WITH that
+    # dep's klib — the [dependencies] analogue of the path-dep [plugins] fix. The
+    # union (incl. transitives) is resolved into the ROOT lock; the dep checkout
+    # is never written to. Before this change the dep compiled with no Maven
+    # klibs and failed with "unresolved reference".
+    konvoy init --name md-lib --lib >/dev/null 2>&1
+    konvoy init --name md-app >/dev/null 2>&1
+    cat >> md-lib/konvoy.toml << 'TOML'
+
+[dependencies]
+kotlinx-datetime = { maven = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.0" }
+TOML
+    # The lib's source USES its Maven dep — this only compiles if the dep's klib
+    # is on the lib's compile path.
+    cat > md-lib/src/lib.kt << 'KOTLIN'
+package mdlib
+
+import kotlinx.datetime.Clock
+
+fun stampLen(): Int = Clock.System.now().toString().length
+KOTLIN
+    cat >> md-app/konvoy.toml << 'TOML'
+
+[dependencies]
+md-lib = { path = "../md-lib" }
+TOML
+    cat > md-app/src/main.kt << 'KOTLIN'
+import mdlib.stampLen
+
+fun main() {
+    println("stamp-len=" + stampLen())
+}
+KOTLIN
+    cd md-app
+
+    # First build auto-resolves the graph-wide Maven union (the dep's datetime +
+    # its transitive) into the root lock, then compiles the dep WITH its klib.
+    local out1
+    out1=$(konvoy build 2>&1)
+    assert_contains "$out1" "Compiling md-lib"
+    assert_contains "$out1" "Compiling md-app"
+
+    # The binary links + runs end-to-end (proves the dep's Maven klib was both
+    # compiled against AND linked into the final binary).
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "stamp-len="
+
+    # The dep's Maven dep (and its transitive) are pinned in the ROOT lock; the
+    # dep checkout is never written to.
+    assert_file_contains konvoy.lock "kotlinx-datetime"
+    assert_file_contains konvoy.lock "maven ="
+    if [ -f ../md-lib/konvoy.lock ]; then
+        echo "    root build must not write a lockfile into the dep checkout" >&2
+        return 1
+    fi
+
+    # Second build is fully cached (the union is folded into the cache key).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked is satisfied by the path-dep's pinned Maven dep (matched by
+    # coordinate, even though the lock aggregates it in the root lock).
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+}
+
+test_path_dep_maven_version_conflict_surfaced() {
+    # Two path-deps require DIFFERENT versions of the same Maven artifact. Maven
+    # libraries are linked, so this is a hard error to surface (not distinct
+    # pins) — consistent with how the transitive resolver already surfaces
+    # conflicts. The error names both requirers and gives an actionable hint.
+    konvoy init --name cf-liba --lib >/dev/null 2>&1
+    konvoy init --name cf-libb --lib >/dev/null 2>&1
+    konvoy init --name cf-app >/dev/null 2>&1
+    cat >> cf-liba/konvoy.toml << 'TOML'
+
+[dependencies]
+coroutines = { maven = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.8.0" }
+TOML
+    cat >> cf-libb/konvoy.toml << 'TOML'
+
+[dependencies]
+coroutines = { maven = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
+TOML
+    cat >> cf-app/konvoy.toml << 'TOML'
+
+[dependencies]
+cf-liba = { path = "../cf-liba" }
+cf-libb = { path = "../cf-libb" }
+TOML
+    cd cf-app
+    local output
+    if output=$(konvoy build 2>&1); then
+        echo "    expected a version conflict across the two path-deps" >&2
+        return 1
+    fi
+    assert_contains "$output" "version conflict"
+    assert_contains "$output" "kotlinx-coroutines-core"
+    assert_contains "$output" "1.8.0"
+    assert_contains "$output" "1.7.3"
+}
+
+test_path_dep_serialization_roundtrip() {
+    # End-to-end gold test: a path-dep uses BOTH the serialization compiler plugin
+    # AND its serialization runtime Maven deps, defines a @Serializable type, and
+    # round-trips it. The app links the dep and runs it. This exercises the whole
+    # stack the PR fixes at once — the dep's [plugins] are applied to its compile
+    # (#293) and the dep's [dependencies] (Maven) flow into the dep's compile and
+    # the final link. Impossible before this PR (the dep got neither).
+    konvoy init --name ser-models --lib >/dev/null 2>&1
+    konvoy init --name ser-app >/dev/null 2>&1
+    cat >> ser-models/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
+
+[dependencies]
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+kotlinx-serialization-json = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+TOML
+    cat > ser-models/src/lib.kt << 'KOTLIN'
+package sermodels
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+
+@Serializable
+data class User(val name: String, val age: Int)
+
+fun roundTrip(): String {
+    val json = Json.encodeToString(User("Alice", 30))
+    val back = Json.decodeFromString<User>(json)
+    return "name=${back.name} age=${back.age}"
+}
+KOTLIN
+    cat >> ser-app/konvoy.toml << 'TOML'
+
+[dependencies]
+ser-models = { path = "../ser-models" }
+TOML
+    cat > ser-app/src/main.kt << 'KOTLIN'
+import sermodels.roundTrip
+
+fun main() {
+    println(roundTrip())
+}
+KOTLIN
+    cd ser-app
+
+    konvoy build 2>&1
+
+    # The round-trip executes through the dep — proving the dep's serializers were
+    # generated (plugin applied) and its serialization runtime was linked.
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "name=Alice age=30"
+
+    # The dep's plugin and Maven deps are all pinned in the ROOT lock.
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
+    assert_file_contains konvoy.lock "kotlinx-serialization-core"
+    assert_file_contains konvoy.lock "kotlinx-serialization-json"
+
+    # Second build is fully cached across the whole stack.
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+}
+
 test_doctor_maven_dep_checks() {
     # Doctor should check Maven deps and lockfile entries.
     konvoy init --name doc-maven >/dev/null 2>&1
@@ -2470,6 +2645,9 @@ run_test test_build_maven_dep_without_update_succeeds
 run_test test_build_maven_dep_locked_without_update_fails
 run_test test_maven_dep_build_lifecycle
 run_test test_maven_dep_mixed_with_path_dep_build
+run_test test_path_dep_maven_dep_build_lifecycle
+run_test test_path_dep_maven_version_conflict_surfaced
+run_test test_path_dep_serialization_roundtrip
 run_test test_doctor_maven_dep_checks
 run_test test_doctor_missing_lockfile_entry_warns
 run_test test_doctor_no_lockfile_warns

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -562,13 +562,17 @@ KOTLIN
 
 test_path_dep_plugin_build_lifecycle() {
     # Path-dep [plugins] are applied to the dep's own compile and pinned in the
-    # ROOT lockfile (#293; the root here declares no plugins of its own).
+    # ROOT lockfile (#293; the root here declares no plugins of its own). Uses
+    # the canonical serialization plugin coordinate, same as the rest of the
+    # suite (the -embeddable variant was reverted in #245 as "not the real fix";
+    # the real #239 fix was two-step program compilation, #243 — and library
+    # path-deps compile single-step with -Xplugin regardless).
     konvoy init --name plug-dep-lib --lib >/dev/null 2>&1
     konvoy init --name plug-dep-app >/dev/null 2>&1
     cat >> plug-dep-lib/konvoy.toml << 'TOML'
 
 [plugins]
-kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
 TOML
     cat >> plug-dep-app/konvoy.toml << 'TOML'
 
@@ -576,10 +580,14 @@ TOML
 plug-dep-lib = { path = "../plug-dep-lib" }
 TOML
 
-    # Probe source: the serialization plugin matches @Serializable by FQ name
-    # and errors because the runtime library is absent — a failing dep compile
-    # is positive proof the dep was built with its -Xplugin. Before #293 the
-    # dep compiled with no plugins, so this build SUCCEEDED (silently wrong).
+    # Application probe: a @Serializable class (matched by FQ name) gives the
+    # serialization plugin something to act on. With the runtime library absent
+    # the dep's compile then FAILS — a failure localized to the dep's own
+    # compilation is positive, platform-independent proof the dep was built with
+    # its -Xplugin. Before #293 the dep compiled with no plugins, so this build
+    # SUCCEEDED (silently wrong). PART 2 below flips the result by removing only
+    # the @Serializable usage (plugin still declared) and the build succeeds —
+    # confirming the failure was the plugin engaging, not the annotation itself.
     cat > plug-dep-lib/src/lib.kt << 'KOTLIN'
 package kotlinx.serialization
 
@@ -596,7 +604,11 @@ KOTLIN
         echo "    expected the dep compile to fail under the serialization plugin (was -Xplugin applied to the dep?)" >&2
         return 1
     fi
-    assert_contains "$probe" "serializer has not been found"
+    # The failure must be in the DEP's compilation (the dep got the plugin), so
+    # the dep's compile line printed but the root's never did.
+    assert_contains "$probe" "Compiling plug-dep-lib"
+    assert_contains "$probe" "compilation failed"
+    assert_not_contains "$probe" "Compiling plug-dep-app"
 
     # Standalone parity: the dep must fail the same way built on its own.
     local standalone
@@ -604,11 +616,13 @@ KOTLIN
         echo "    expected the standalone dep build to fail under the serialization plugin" >&2
         return 1
     fi
-    assert_contains "$standalone" "serializer has not been found"
+    assert_contains "$standalone" "compilation failed"
     rm -rf ../plug-dep-lib/.konvoy ../plug-dep-lib/konvoy.lock
 
-    # Make the dep's plugin a no-op (plain source) and verify the pinning +
-    # caching lifecycle.
+    # PART 2 — control + pinning/caching lifecycle. Same plugin still declared,
+    # but the source no longer uses @Serializable, so the plugin is a clean
+    # no-op and the build succeeds. That this now compiles (vs. PART 1's failure)
+    # is the control proving the plugin was genuinely engaging in PART 1.
     cat > ../plug-dep-lib/src/lib.kt << 'KOTLIN'
 package models
 
@@ -622,7 +636,7 @@ KOTLIN
     # The dep's plugin pin lands in the ROOT lockfile; the dep checkout is
     # never written to by the root build.
     assert_file_contains konvoy.lock "[[plugins]]"
-    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
     assert_file_contains konvoy.lock "sha256"
     if [ -f ../plug-dep-lib/konvoy.lock ]; then
         echo "    root build must not write a lockfile into the dep checkout" >&2
@@ -658,7 +672,7 @@ test_path_dep_plugin_union_dedup() {
     # root lock — not duplicated, not a conflict (#293).
     konvoy init --name dedup-lib --lib >/dev/null 2>&1
     konvoy init --name dedup-app >/dev/null 2>&1
-    local ser='kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }'
+    local ser='kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }'
     printf '\n[plugins]\n%s\n' "$ser" >> dedup-lib/konvoy.toml
     printf '\n[plugins]\n%s\n\n[dependencies]\ndedup-lib = { path = "../dedup-lib" }\n' "$ser" >> dedup-app/konvoy.toml
     # No @Serializable anywhere — the plugin is a clean no-op, so both compiles
@@ -679,7 +693,7 @@ test_path_dep_plugin_union_dedup() {
         cat konvoy.lock >&2
         return 1
     fi
-    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
 
     # Second build is fully cached (the deduped pin is folded into the key).
     local out2
@@ -699,12 +713,12 @@ test_graph_plugin_union_different_plugins() {
     cat >> union-lib/konvoy.toml << 'TOML'
 
 [plugins]
-allopen = { maven = "org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable", version = "{kotlin}" }
+allopen = { maven = "org.jetbrains.kotlin:kotlin-allopen-compiler-plugin", version = "{kotlin}" }
 TOML
     cat >> union-app/konvoy.toml << 'TOML'
 
 [plugins]
-kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
 
 [dependencies]
 union-lib = { path = "../union-lib" }
@@ -725,8 +739,8 @@ TOML
         cat konvoy.lock >&2
         return 1
     fi
-    assert_file_contains konvoy.lock "kotlin-allopen-compiler-plugin-embeddable"
-    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "kotlin-allopen-compiler-plugin"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
 
     # The dep contributed a pin to the root lock but its own checkout is never
     # written to.
@@ -752,7 +766,7 @@ test_transitive_dep_plugin_applied_and_pinned() {
     cat >> gc-lib/konvoy.toml << 'TOML'
 
 [plugins]
-kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
 TOML
     cat >> child-lib/konvoy.toml << 'TOML'
 
@@ -765,10 +779,12 @@ TOML
 child-lib = { path = "../child-lib" }
 TOML
 
-    # Probe: a fake @Serializable in the GRANDCHILD makes its plugin fire and
-    # error (the runtime serializers are absent). A failing grandchild compile
-    # is positive proof the plugin reached depth 2 of the graph. Before #293 the
-    # grandchild compiled with no -Xplugin, so the build SUCCEEDED (silently wrong).
+    # Probe: a @Serializable class in the GRANDCHILD gives its plugin something
+    # to act on; with the runtime absent the grandchild's compile then FAILS. A
+    # failure localized to the grandchild's own compilation is positive proof the
+    # plugin reached depth 2 of the graph. Before #293 the grandchild compiled
+    # with no -Xplugin, so the build SUCCEEDED (silently wrong). The no-op rebuild
+    # below (plugin still declared) flips it to success — the control.
     cat > gc-lib/src/lib.kt << 'KOTLIN'
 package kotlinx.serialization
 
@@ -785,8 +801,11 @@ KOTLIN
         echo "    expected the grandchild compile to fail under the serialization plugin (did the union reach depth 2?)" >&2
         return 1
     fi
-    assert_contains "$probe" "serializer has not been found"
+    # Failure is in the grandchild's compile (it got the plugin); the build never
+    # reached the child or the root.
     assert_contains "$probe" "Compiling gc-lib"
+    assert_contains "$probe" "compilation failed"
+    assert_not_contains "$probe" "Compiling app-root"
 
     # Make the grandchild's plugin a no-op and verify the full pin lifecycle.
     cat > ../gc-lib/src/lib.kt << 'KOTLIN'
@@ -803,7 +822,7 @@ KOTLIN
     # The grandchild's plugin pin lands in the ROOT (app) lockfile; neither
     # intermediate checkout is written to.
     assert_file_contains konvoy.lock "[[plugins]]"
-    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
     if [ -f ../gc-lib/konvoy.lock ] || [ -f ../child-lib/konvoy.lock ]; then
         echo "    root build must not write lockfiles into dep checkouts" >&2
         return 1
@@ -2416,7 +2435,8 @@ run_test test_graph_plugin_union_different_plugins
 run_test test_transitive_dep_plugin_applied_and_pinned
 run_test test_plugin_kotlin_placeholder_resolves
 
-# Issue #239: serialization plugin must use embeddable JAR
+# Issue #239: serialization plugin downloaded but not applied (fixed by two-step
+# program compilation, #243 — the embeddable-JAR mapping was reverted in #245).
 run_test test_issue_239_serialization_plugin_applied
 
 # Maven dependencies

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -651,6 +651,180 @@ KOTLIN
     assert_contains "$out4" "lockfile"
 }
 
+test_path_dep_plugin_union_dedup() {
+    # The root AND a path-dep declare the SAME plugin (same coordinate + version
+    # via {kotlin}). The graph-wide union is content-addressed by
+    # (name, maven, version), so the shared plugin is pinned exactly ONCE in the
+    # root lock — not duplicated, not a conflict (#293).
+    konvoy init --name dedup-lib --lib >/dev/null 2>&1
+    konvoy init --name dedup-app >/dev/null 2>&1
+    local ser='kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }'
+    printf '\n[plugins]\n%s\n' "$ser" >> dedup-lib/konvoy.toml
+    printf '\n[plugins]\n%s\n\n[dependencies]\ndedup-lib = { path = "../dedup-lib" }\n' "$ser" >> dedup-app/konvoy.toml
+    # No @Serializable anywhere — the plugin is a clean no-op, so both compiles
+    # succeed and the lockfile is written.
+    printf 'package dedup\nfun helper(): Int = 1\n' > dedup-lib/src/lib.kt
+    cd dedup-app
+
+    local out
+    out=$(konvoy build 2>&1)
+    assert_contains "$out" "Compiling dedup-lib"
+    assert_contains "$out" "Compiling dedup-app"
+
+    # Exactly one [[plugins]] entry despite the plugin being declared twice.
+    local count
+    count=$(grep -c '^\[\[plugins\]\]' konvoy.lock)
+    if [ "$count" != "1" ]; then
+        echo "    expected exactly 1 deduped plugin pin, got $count" >&2
+        cat konvoy.lock >&2
+        return 1
+    fi
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+
+    # Second build is fully cached (the deduped pin is folded into the key).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+}
+
+test_graph_plugin_union_different_plugins() {
+    # The root declares one plugin and a path-dep declares a DIFFERENT one. The
+    # root lock records the deduped UNION of both — each pinned once, sorted by
+    # name — and no dependency checkout is written to (#293).
+    konvoy init --name union-lib --lib >/dev/null 2>&1
+    konvoy init --name union-app >/dev/null 2>&1
+    # Dep uses allopen; root uses serialization. Both are no-ops on plain source
+    # (no annotations / no @Serializable), so both projects compile cleanly.
+    cat >> union-lib/konvoy.toml << 'TOML'
+
+[plugins]
+allopen = { maven = "org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable", version = "{kotlin}" }
+TOML
+    cat >> union-app/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+
+[dependencies]
+union-lib = { path = "../union-lib" }
+TOML
+    printf 'package unionlib\nfun helper(): Int = 1\n' > union-lib/src/lib.kt
+    cd union-app
+
+    local out
+    out=$(konvoy build 2>&1)
+    assert_contains "$out" "Compiling union-lib"
+    assert_contains "$out" "Compiling union-app"
+
+    # Both plugins pinned in the ROOT lock — two distinct entries.
+    local count
+    count=$(grep -c '^\[\[plugins\]\]' konvoy.lock)
+    if [ "$count" != "2" ]; then
+        echo "    expected 2 plugin pins in the union, got $count" >&2
+        cat konvoy.lock >&2
+        return 1
+    fi
+    assert_file_contains konvoy.lock "kotlin-allopen-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+
+    # The dep contributed a pin to the root lock but its own checkout is never
+    # written to.
+    if [ -f ../union-lib/konvoy.lock ]; then
+        echo "    root build must not write a lockfile into the dep checkout" >&2
+        return 1
+    fi
+
+    # Cache-key stability with a multi-plugin union: second build is cached.
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+}
+
+test_transitive_dep_plugin_applied_and_pinned() {
+    # A grandchild (depth-2) path-dep declares a plugin: app -> child -> gc.
+    # The graph-wide union must reach the grandchild, apply its plugin to the
+    # grandchild's OWN compile, and pin it in the ROOT (app) lockfile (#293).
+    konvoy init --name gc-lib --lib >/dev/null 2>&1
+    konvoy init --name child-lib --lib >/dev/null 2>&1
+    konvoy init --name app-root >/dev/null 2>&1
+    cat >> gc-lib/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+TOML
+    cat >> child-lib/konvoy.toml << 'TOML'
+
+[dependencies]
+gc-lib = { path = "../gc-lib" }
+TOML
+    cat >> app-root/konvoy.toml << 'TOML'
+
+[dependencies]
+child-lib = { path = "../child-lib" }
+TOML
+
+    # Probe: a fake @Serializable in the GRANDCHILD makes its plugin fire and
+    # error (the runtime serializers are absent). A failing grandchild compile
+    # is positive proof the plugin reached depth 2 of the graph. Before #293 the
+    # grandchild compiled with no -Xplugin, so the build SUCCEEDED (silently wrong).
+    cat > gc-lib/src/lib.kt << 'KOTLIN'
+package kotlinx.serialization
+
+@Target(AnnotationTarget.CLASS)
+annotation class Serializable
+
+@Serializable
+data class User(val name: String, val age: Int)
+KOTLIN
+
+    cd app-root
+    local probe
+    if probe=$(konvoy build 2>&1); then
+        echo "    expected the grandchild compile to fail under the serialization plugin (did the union reach depth 2?)" >&2
+        return 1
+    fi
+    assert_contains "$probe" "serializer has not been found"
+    assert_contains "$probe" "Compiling gc-lib"
+
+    # Make the grandchild's plugin a no-op and verify the full pin lifecycle.
+    cat > ../gc-lib/src/lib.kt << 'KOTLIN'
+package gclib
+
+fun greet(): String = "hello from grandchild"
+KOTLIN
+    local out1
+    out1=$(konvoy build 2>&1)
+    assert_contains "$out1" "Compiling gc-lib"
+    assert_contains "$out1" "Compiling child-lib"
+    assert_contains "$out1" "Compiling app-root"
+
+    # The grandchild's plugin pin lands in the ROOT (app) lockfile; neither
+    # intermediate checkout is written to.
+    assert_file_contains konvoy.lock "[[plugins]]"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    if [ -f ../gc-lib/konvoy.lock ] || [ -f ../child-lib/konvoy.lock ]; then
+        echo "    root build must not write lockfiles into dep checkouts" >&2
+        return 1
+    fi
+
+    # Second build fully cached across the whole 3-level graph.
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked fails actionably if the grandchild's pin is removed from the lock.
+    sed -i '/\[\[plugins\]\]/,$d' konvoy.lock
+    local out3
+    if out3=$(konvoy build --locked 2>&1); then
+        echo "    expected --locked to fail with the grandchild plugin pin missing" >&2
+        return 1
+    fi
+    assert_contains "$out3" "lockfile"
+}
+
 test_plugin_kotlin_placeholder_resolves() {
     # version = "{kotlin}" should resolve to the toolchain version in the lockfile.
     konvoy init --name plug-placeholder >/dev/null 2>&1
@@ -2237,6 +2411,9 @@ run_test test_plugin_with_path_fails
 run_test test_plugin_locked_no_entries_error
 run_test test_plugin_build_lifecycle
 run_test test_path_dep_plugin_build_lifecycle
+run_test test_path_dep_plugin_union_dedup
+run_test test_graph_plugin_union_different_plugins
+run_test test_transitive_dep_plugin_applied_and_pinned
 run_test test_plugin_kotlin_placeholder_resolves
 
 # Issue #239: serialization plugin must use embeddable JAR

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1416,6 +1416,74 @@ KOTLIN
     assert_not_contains "$out2" "Compiling"
 }
 
+test_path_dep_undeclared_sibling_fails() {
+    # Each path-dep is compiled against ONLY its own subtree (its transitive
+    # path-dep descendants), not every klib built so far. So an UNDECLARED
+    # cross-dep import fails in the workspace build — it isn't silently masked by
+    # a sibling that happens to be compiled earlier. Standalone == as-a-dependency
+    # parity for path-dep klibs, the same guarantee the Maven closure gives.
+    konvoy init --name us-child --lib >/dev/null 2>&1
+    konvoy init --name us-sibling --lib >/dev/null 2>&1
+    konvoy init --name us-parent --lib >/dev/null 2>&1
+    konvoy init --name us-app >/dev/null 2>&1
+    printf 'package uschild\nfun childFn(): Int = 1\n' > us-child/src/lib.kt
+    printf 'package ussibling\nfun siblingFn(): Int = 2\n' > us-sibling/src/lib.kt
+    # parent declares ONLY child, but its source uses BOTH child and sibling.
+    cat >> us-parent/konvoy.toml << 'TOML'
+
+[dependencies]
+us-child = { path = "../us-child" }
+TOML
+    cat > us-parent/src/lib.kt << 'KOTLIN'
+package usparent
+
+import uschild.childFn
+import ussibling.siblingFn
+
+fun total(): Int = childFn() + siblingFn()
+KOTLIN
+    # app pulls in parent AND sibling. sibling (a leaf) builds at level 0; parent
+    # builds at level 1 — the exact shape that USED to mask the undeclared use,
+    # because sibling's klib was in the "all completed klibs" set handed to parent.
+    cat >> us-app/konvoy.toml << 'TOML'
+
+[dependencies]
+us-parent = { path = "../us-parent" }
+us-sibling = { path = "../us-sibling" }
+TOML
+    cat > us-app/src/main.kt << 'KOTLIN'
+import usparent.total
+
+fun main() {
+    println("total=" + total())
+}
+KOTLIN
+    cd us-app
+
+    # parent uses `us-sibling` without declaring it → the workspace build must
+    # FAIL in parent's OWN compile (localized: parent compiled, app never did).
+    local out1
+    if out1=$(konvoy build 2>&1); then
+        echo "    expected the build to fail: parent uses an UNDECLARED sibling path-dep" >&2
+        return 1
+    fi
+    assert_contains "$out1" "Compiling us-parent"
+    assert_contains "$out1" "unresolved reference"
+    assert_not_contains "$out1" "Compiling us-app"
+
+    # Declaring the dependency fixes it (proving the failure was the missing
+    # declaration, not anything else): the build now succeeds and runs.
+    cat >> ../us-parent/konvoy.toml << 'TOML'
+us-sibling = { path = "../us-sibling" }
+TOML
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "Compiling us-app"
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "total=3"
+}
+
 test_doctor_maven_dep_checks() {
     # Doctor should check Maven deps and lockfile entries.
     konvoy init --name doc-maven >/dev/null 2>&1
@@ -2648,6 +2716,7 @@ run_test test_maven_dep_mixed_with_path_dep_build
 run_test test_path_dep_maven_dep_build_lifecycle
 run_test test_path_dep_maven_version_conflict_surfaced
 run_test test_path_dep_serialization_roundtrip
+run_test test_path_dep_undeclared_sibling_fails
 run_test test_doctor_maven_dep_checks
 run_test test_doctor_missing_lockfile_entry_warns
 run_test test_doctor_no_lockfile_warns

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -700,6 +700,15 @@ test_path_dep_plugin_union_dedup() {
     out2=$(konvoy build 2>&1)
     assert_contains "$out2" "(cached)"
     assert_not_contains "$out2" "Compiling"
+
+    # --locked is satisfied by the single deduped pin even though the plugin is
+    # declared by BOTH the root (checked via staleness) and the dep (gated by the
+    # graph-wide ensure). A name-only or per-project pin scheme would mis-handle
+    # this; the (name, maven, version) identity makes the one pin cover both.
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+    assert_not_contains "$out3" "Compiling"
 }
 
 test_graph_plugin_union_different_plugins() {
@@ -754,6 +763,14 @@ TOML
     out2=$(konvoy build 2>&1)
     assert_contains "$out2" "(cached)"
     assert_not_contains "$out2" "Compiling"
+
+    # --locked is satisfied by the union: the root's serialization pin (via the
+    # staleness check) and the dep's allopen pin (via the graph-wide ensure)
+    # must both be present, with no spurious version-conflict rejection.
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+    assert_not_contains "$out3" "Compiling"
 }
 
 test_transitive_dep_plugin_applied_and_pinned() {

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1284,12 +1284,6 @@ KOTLIN
     assert_contains "$out1" "Compiling md-lib"
     assert_contains "$out1" "Compiling md-app"
 
-    # The binary links + runs end-to-end (proves the dep's Maven klib was both
-    # compiled against AND linked into the final binary).
-    local run_out
-    run_out=$(konvoy run 2>&1)
-    assert_contains "$run_out" "stamp-len="
-
     # The dep's Maven dep (and its transitive) are pinned in the ROOT lock; the
     # dep checkout is never written to.
     assert_file_contains konvoy.lock "kotlinx-datetime"
@@ -1300,6 +1294,9 @@ KOTLIN
     fi
 
     # Second build is fully cached (the union is folded into the cache key).
+    # Asserted BEFORE any `konvoy run` — `run` itself builds, and the one-time
+    # issue-#133 recompile happens on the build right after the first, so a `run`
+    # in between would absorb it and hide a cache-key regression.
     local out2
     out2=$(konvoy build 2>&1)
     assert_contains "$out2" "(cached)"
@@ -1310,6 +1307,12 @@ KOTLIN
     local out3
     out3=$(konvoy build --locked 2>&1)
     assert_contains "$out3" "(cached)"
+
+    # Finally, the binary links + runs end-to-end (proves the dep's Maven klib
+    # was both compiled against AND linked into the final binary).
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "stamp-len="
 }
 
 test_path_dep_maven_version_conflict_surfaced() {
@@ -1398,22 +1401,24 @@ KOTLIN
 
     konvoy build 2>&1
 
-    # The round-trip executes through the dep — proving the dep's serializers were
-    # generated (plugin applied) and its serialization runtime was linked.
-    local run_out
-    run_out=$(konvoy run 2>&1)
-    assert_contains "$run_out" "name=Alice age=30"
-
     # The dep's plugin and Maven deps are all pinned in the ROOT lock.
     assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin"
     assert_file_contains konvoy.lock "kotlinx-serialization-core"
     assert_file_contains konvoy.lock "kotlinx-serialization-json"
 
-    # Second build is fully cached across the whole stack.
+    # Second build is fully cached across the whole stack. Asserted BEFORE the
+    # `konvoy run` below: `run` rebuilds, so it would absorb the one-time
+    # issue-#133 recompile and hide a cache-key regression.
     local out2
     out2=$(konvoy build 2>&1)
     assert_contains "$out2" "(cached)"
     assert_not_contains "$out2" "Compiling"
+
+    # The round-trip executes through the dep — proving the dep's serializers were
+    # generated (plugin applied) and its serialization runtime was linked.
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "name=Alice age=30"
 }
 
 test_path_dep_undeclared_sibling_fails() {

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -560,6 +560,97 @@ KOTLIN
     assert_not_contains "$out3" "Compiling"
 }
 
+test_path_dep_plugin_build_lifecycle() {
+    # Path-dep [plugins] are applied to the dep's own compile and pinned in the
+    # ROOT lockfile (#293; the root here declares no plugins of its own).
+    konvoy init --name plug-dep-lib --lib >/dev/null 2>&1
+    konvoy init --name plug-dep-app >/dev/null 2>&1
+    cat >> plug-dep-lib/konvoy.toml << 'TOML'
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version = "{kotlin}" }
+TOML
+    cat >> plug-dep-app/konvoy.toml << 'TOML'
+
+[dependencies]
+plug-dep-lib = { path = "../plug-dep-lib" }
+TOML
+
+    # Probe source: the serialization plugin matches @Serializable by FQ name
+    # and errors because the runtime library is absent — a failing dep compile
+    # is positive proof the dep was built with its -Xplugin. Before #293 the
+    # dep compiled with no plugins, so this build SUCCEEDED (silently wrong).
+    cat > plug-dep-lib/src/lib.kt << 'KOTLIN'
+package kotlinx.serialization
+
+@Target(AnnotationTarget.CLASS)
+annotation class Serializable
+
+@Serializable
+data class User(val name: String, val age: Int)
+KOTLIN
+
+    cd plug-dep-app
+    local probe
+    if probe=$(konvoy build 2>&1); then
+        echo "    expected the dep compile to fail under the serialization plugin (was -Xplugin applied to the dep?)" >&2
+        return 1
+    fi
+    assert_contains "$probe" "serializer has not been found"
+
+    # Standalone parity: the dep must fail the same way built on its own.
+    local standalone
+    if standalone=$(cd ../plug-dep-lib && konvoy build 2>&1); then
+        echo "    expected the standalone dep build to fail under the serialization plugin" >&2
+        return 1
+    fi
+    assert_contains "$standalone" "serializer has not been found"
+    rm -rf ../plug-dep-lib/.konvoy ../plug-dep-lib/konvoy.lock
+
+    # Make the dep's plugin a no-op (plain source) and verify the pinning +
+    # caching lifecycle.
+    cat > ../plug-dep-lib/src/lib.kt << 'KOTLIN'
+package models
+
+fun greet(): String = "hello"
+KOTLIN
+    local out1
+    out1=$(konvoy build 2>&1)
+    assert_contains "$out1" "Compiling plug-dep-lib"
+    assert_contains "$out1" "Compiling plug-dep-app"
+
+    # The dep's plugin pin lands in the ROOT lockfile; the dep checkout is
+    # never written to by the root build.
+    assert_file_contains konvoy.lock "[[plugins]]"
+    assert_file_contains konvoy.lock "kotlin-serialization-compiler-plugin-embeddable"
+    assert_file_contains konvoy.lock "sha256"
+    if [ -f ../plug-dep-lib/konvoy.lock ]; then
+        echo "    root build must not write a lockfile into the dep checkout" >&2
+        return 1
+    fi
+
+    # Second build: fully cached — the dep plugin pins and the path-dep entries
+    # are folded into the first build's cache key (issue #133 class).
+    local out2
+    out2=$(konvoy build 2>&1)
+    assert_contains "$out2" "(cached)"
+    assert_not_contains "$out2" "Compiling"
+
+    # --locked succeeds with the dep's pin present...
+    local out3
+    out3=$(konvoy build --locked 2>&1)
+    assert_contains "$out3" "(cached)"
+
+    # ...and fails actionably when the dep's pin is missing.
+    sed -i '/\[\[plugins\]\]/,$d' konvoy.lock
+    local out4
+    if out4=$(konvoy build --locked 2>&1); then
+        echo "    expected --locked to fail with the dep plugin pin missing" >&2
+        return 1
+    fi
+    assert_contains "$out4" "lockfile"
+}
+
 test_plugin_kotlin_placeholder_resolves() {
     # version = "{kotlin}" should resolve to the toolchain version in the lockfile.
     konvoy init --name plug-placeholder >/dev/null 2>&1
@@ -2145,6 +2236,7 @@ run_test test_plugin_without_maven_fails
 run_test test_plugin_with_path_fails
 run_test test_plugin_locked_no_entries_error
 run_test test_plugin_build_lifecycle
+run_test test_path_dep_plugin_build_lifecycle
 run_test test_plugin_kotlin_placeholder_resolves
 
 # Issue #239: serialization plugin must use embeddable JAR


### PR DESCRIPTION
Fixes #293, and closes the **same bug class for `[dependencies]`** discovered while testing the plugin fix.

A path-dependency's build-relevant config was silently dropped when the project was built **as a dependency**. This PR closes every instance of that class found by auditing where the build reads the *root* manifest/lockfile vs each dep's:

| Case | Status |
|---|---|
| path-dep `[plugins]` not applied | ✅ fixed |
| path-dep `[dependencies]` (Maven, direct + transitive) not applied | ✅ fixed |
| cinterop klibs (Maven classifier entries) | ✅ ride along on the Maven path |
| `[toolchain].kotlin` | already enforced equal across the graph |
| `[toolchain].detekt` | lint-only, per-project — not a build input |
| `[codegen]` | not wired into the build in `main` (separate PR stack) — N/A |

## Part 1 — path-dep `[plugins]` (graph-wide plugin pinning)

- **Graph-wide ensure + pin:** the deduped **union** of plugins across root + every path-dep is downloaded/SHA-pinned once and recorded in the **root** `konvoy.lock`; dep checkouts are never written to.
- **Per-project application:** each project derives its own `-Xplugin` set from its own manifest, so it compiles identically standalone and as a dependency. `plugin_jars` leaves `CompileContext`.
- **Identity-aware pins** `(name, maven, version)`: the union may hold the same plugin name at several versions (allowed — plugins are applied per-compilation, not linked). A root plugin version/coordinate bump is now caught as `--locked` drift.

## Part 2 — path-dep `[dependencies]` (Maven), same bug class

Before this PR, `konvoy update` collected Maven deps from the **root manifest only** and the build fed Maven klibs to the **root compile only** — so a path-dep declaring a Maven dep failed with `unresolved reference`, and a path-dep using a plugin that needs a runtime (e.g. kotlinx-serialization) couldn't work at all. Mirror the plugin design, **with the key difference that libraries are linked → conflicts are surfaced** (not allowed as distinct pins):

- **`update` graph-wide:** seed the transitive resolver with the deduped union of direct Maven deps across the root + every path-dep; cross-graph version clashes are surfaced (naming both declaring projects); the union is written to the **root** lock.
- **Per-project subtree scoping:** each project's compile links only its **own path-dep subtree** — its transitive path-dep descendants' klibs *and* the Maven closure of that subtree, not the whole graph/union — so a path-dep is compiled against exactly what it (transitively) declares (parity), and its cache key isn't perturbed by unrelated deps. *Empirically required for Maven:* a klib whose public API exposes a Maven type forces every dependent's compile to also resolve that klib (`compiling against a klib returning Flow needs coroutines.klib`), so per-project-own deps are insufficient. The same subtree walk (`collect_descendant_deps`) scopes the path-dep klibs, so an **undeclared** cross-path-dep import fails in the workspace build, not only standalone. The root's subtree is the whole graph, preserving prior root behavior.
- **Graph-wide gates:** `first_unresolved` + `check_lockfile_staleness` scan the whole graph; a path-dep's unresolved Maven dep triggers auto-update (or errors under `--locked`/`--offline` before network). All Maven matching is **by coordinate** (`has_maven_coord`), so a dep pinned in the union under another project's key is still recognized.

The dependency graph is now resolved **once, up front**, and reused by the gates, the plugin ensure, and the build loop.

## Verification

End-to-end on a real Kotlin/Native toolchain:
- ✅ A path-dep using its own Maven dep (`kotlinx-datetime`) builds and runs (was `unresolved reference`).
- ✅ **The gold test, impossible before:** a path-dep using the serialization plugin **and** its serialization runtime round-trips a `@Serializable` *through the dep* → `name=Alice age=30`.
- ✅ Cross-path-dep version conflict surfaced (`liba requires 1.8.0 / libb requires 1.7.3`, with hint).
- ✅ An **undeclared** cross-path-dep import now fails in the workspace build (localized to the offending dep), not only standalone — declaring it fixes it (`total=3`); legitimate diamond/chain graphs unaffected.

- ✅ Plugin application probe (fail-with-plugin / pass-as-no-op) + standalone≡as-dep parity, at depth 2 too.
- ✅ Deduped/union pins in the root lock; dep checkouts untouched; second builds fully cached; `--locked` satisfied by graph-wide pins.

`1062` workspace unit tests pass, `clippy -D warnings` clean, `fmt` clean.

## Tests

- **Unit:** plugin union dedup/identity + pre-stabilization parity (incl. dep-contributed, multi-version) + lockfile write; Maven graph collection + cross-project conflict; subtree/closure + transitive-descendant computation (incl. coordinate-not-name matching, diamond dedup); coordinate-based graph staleness / first-unresolved; path-dep `[[dependencies]]` cache-key parity.
- **Smoke** (`tests/smoke/tests.sh`): path-dep plugin lifecycle (probe + pin + cache + `--locked`), dedup, different-plugins union, transitive (depth-2) plugin; path-dep Maven lifecycle, cross-path-dep conflict, the end-to-end serialization round-trip through a path-dep, and undeclared cross-path-dep usage failing as-a-dependency.

The smoke tests use the canonical **non-embeddable** plugin coordinate, consistent with the rest of the suite (the embeddable mapping was reverted in #245 as "not the real fix"; #239 was fixed by two-step compilation in #243). The plugin-application probe is platform-independent (asserts the dep's compile *fails* with a `@Serializable` present but *succeeds* as a no-op with the plugin still declared — a result that flips on the plugin alone). All host-runnable smoke tests were verified locally against the real `konvoy` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


