### PR TITLE
codegen (4/5): `konvoy generate` command + `konvoy doctor` codegen status

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ hello/
 - `konvoy run [--target <triple|host>] [--release] [--force] [--locked] [--offline] [-- <args…>]` — build and run
 - `konvoy test [--target <triple|host>] [--release] [--verbose] [--force] [--locked] [--offline] [--filter <pattern>]` — build and run tests
 - `konvoy lint [--verbose] [--config <path>] [--locked] [--offline]` — run detekt static analysis on Kotlin sources
+- `konvoy generate [--verbose] [--locked] [--offline]` — run the configured code generators (e.g. OpenAPI/Fabrikt) without compiling
 - `konvoy update` — resolve Maven dependencies (including transitives via POM) and update `konvoy.lock`
 - `konvoy clean` — remove build artifacts
 - `konvoy doctor` — check environment, toolchain, and dependency setup

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -119,6 +119,20 @@ enum Command {
         #[arg(long)]
         offline: bool,
     },
+    /// Run code generators (e.g. OpenAPI/Fabrikt) without compiling
+    Generate {
+        /// Show raw generator output
+        #[arg(long, short = 'v')]
+        verbose: bool,
+        /// Assert that konvoy.lock is up to date and never modify it (pinned
+        /// codegen tools may still be downloaded; only lockfile drift is an error)
+        #[arg(long)]
+        locked: bool,
+        /// Run without network access: every codegen tool and the JRE must
+        /// already be present locally, or generation fails
+        #[arg(long)]
+        offline: bool,
+    },
     /// Resolve Maven dependencies and update konvoy.lock
     Update,
     /// Remove build artifacts
@@ -228,6 +242,11 @@ fn main() {
         } => with_resolver(offline, locked, |resolver| {
             cmd_lint(verbose, config, resolver)
         }),
+        Command::Generate {
+            verbose,
+            locked,
+            offline,
+        } => with_resolver(offline, locked, |resolver| cmd_generate(verbose, resolver)),
         // `konvoy update` is inherently online and never locked: it exists to
         // (re)resolve dependencies and rewrite konvoy.lock.
         Command::Update => with_resolver(false, false, cmd_update),
@@ -456,6 +475,22 @@ fn cmd_lint(
     Err(format!("lint found {} issue(s)", result.finding_count).into())
 }
 
+fn cmd_generate(verbose: bool, resolver: konvoy_engine::ArtifactResolver<'_>) -> CliResult {
+    let root = project_root()?;
+
+    let result = konvoy_engine::generate(&root, verbose, resolver)?;
+
+    for output in &result.outputs {
+        eprintln!(
+            "    Generated {} file(s) for {} \u{2192} {}",
+            output.file_count,
+            output.display_name,
+            output.output_dir.display()
+        );
+    }
+    Ok(())
+}
+
 fn cmd_update(resolver: konvoy_engine::ArtifactResolver<'_>) -> CliResult {
     let root = project_root()?;
     // `konvoy update` is inherently online — resolving fetches POMs/klibs.
@@ -558,6 +593,41 @@ fn check_detekt(manifest: &konvoy_config::Manifest) -> u32 {
     }
 }
 
+/// Report the install status of each configured codegen tool. A not-yet-downloaded
+/// tool is informational (`[--]`, 0 issues) — it downloads on first use, like
+/// detekt; only a failure to inspect it counts as an issue.
+fn check_codegen(manifest: &konvoy_config::Manifest) -> u32 {
+    let mut issues = 0u32;
+    for generator in konvoy_engine::codegen::active_generators(&manifest.codegen) {
+        let tool = generator.managed_tool();
+        let label = generator.display_name();
+        match tool.is_installed() {
+            Ok(true) => match tool.artifact_path() {
+                Ok(path) => eprintln!(
+                    "  [ok] {label} ({}): {} ({})",
+                    tool.id(),
+                    tool.version(),
+                    path.display()
+                ),
+                Err(e) => {
+                    eprintln!("  [!!] {label} ({}): {e}", tool.id());
+                    issues = issues.saturating_add(1);
+                }
+            },
+            Ok(false) => eprintln!(
+                "  [--] {label} ({}): {} not downloaded — will download on first `konvoy generate` or `konvoy build`",
+                tool.id(),
+                tool.version()
+            ),
+            Err(e) => {
+                eprintln!("  [!!] {label} ({}): {e}", tool.id());
+                issues = issues.saturating_add(1);
+            }
+        }
+    }
+    issues
+}
+
 fn check_maven_deps(manifest: &konvoy_config::Manifest, cwd: &std::path::Path) -> u32 {
     let maven_deps: Vec<_> = manifest
         .dependencies
@@ -638,6 +708,7 @@ fn cmd_doctor() -> CliResult {
                 eprintln!("  [ok] Project: {}", manifest.package.name);
                 issues = issues.saturating_add(check_toolchain(&manifest));
                 issues = issues.saturating_add(check_detekt(&manifest));
+                issues = issues.saturating_add(check_codegen(&manifest));
                 issues = issues.saturating_add(check_maven_deps(&manifest, &cwd));
             }
             Err(e) => {
@@ -1339,6 +1410,7 @@ mod tests {
             "run",
             "test",
             "lint",
+            "generate",
             "update",
             "clean",
             "doctor",
@@ -1447,6 +1519,58 @@ mod tests {
             }
             other => panic!("expected Lint, got {other:?}"),
         }
+    }
+
+    // ── Generate parsing ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_generate_defaults() {
+        let cli = Cli::try_parse_from(["konvoy", "generate"]).unwrap();
+        match cli.command {
+            Command::Generate {
+                verbose,
+                locked,
+                offline,
+            } => {
+                assert!(!verbose);
+                assert!(!locked);
+                assert!(!offline);
+            }
+            other => panic!("expected Generate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_generate_verbose_short() {
+        let cli = Cli::try_parse_from(["konvoy", "generate", "-v"]).unwrap();
+        match cli.command {
+            Command::Generate { verbose, .. } => assert!(verbose),
+            other => panic!("expected Generate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_generate_all_flags() {
+        let cli = Cli::try_parse_from(["konvoy", "generate", "--verbose", "--locked", "--offline"])
+            .unwrap();
+        match cli.command {
+            Command::Generate {
+                verbose,
+                locked,
+                offline,
+            } => {
+                assert!(verbose);
+                assert!(locked);
+                assert!(offline);
+            }
+            other => panic!("expected Generate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_flag_on_generate() {
+        let err = Cli::try_parse_from(["konvoy", "generate", "--help"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     }
 
     #[test]

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -601,20 +601,16 @@ fn check_codegen(manifest: &konvoy_config::Manifest) -> u32 {
     for generator in konvoy_engine::codegen::active_generators(&manifest.codegen) {
         let tool = generator.managed_tool();
         let label = generator.display_name();
-        match tool.is_installed() {
-            Ok(true) => match tool.artifact_path() {
-                Ok(path) => eprintln!(
-                    "  [ok] {label} ({}): {} ({})",
-                    tool.id(),
-                    tool.version(),
-                    path.display()
-                ),
-                Err(e) => {
-                    eprintln!("  [!!] {label} ({}): {e}", tool.id());
-                    issues = issues.saturating_add(1);
-                }
-            },
-            Ok(false) => eprintln!(
+        // `artifact_path()` is the same path `is_installed()` checks; compute it
+        // once and `.exists()` it, rather than resolving the path twice.
+        match tool.artifact_path() {
+            Ok(path) if path.exists() => eprintln!(
+                "  [ok] {label} ({}): {} ({})",
+                tool.id(),
+                tool.version(),
+                path.display()
+            ),
+            Ok(_) => eprintln!(
                 "  [--] {label} ({}): {} not downloaded — will download on first `konvoy generate` or `konvoy build`",
                 tool.id(),
                 tool.version()

--- a/crates/konvoy-cli/tests/locked_offline_smoke.rs
+++ b/crates/konvoy-cli/tests/locked_offline_smoke.rs
@@ -288,7 +288,7 @@ fn offline_lint_errors_when_detekt_jar_absent() {
 
 /// Regression guard: a `lint --offline` that fails at JRE resolution (detekt JAR
 /// is cached, but the toolchain providing the JRE is not) must report
-/// `DetektJreOffline` AND must NOT leave a rewritten konvoy.lock behind — the
+/// `ToolchainJreOffline` AND must NOT leave a rewritten konvoy.lock behind — the
 /// detekt-hash persist happens only after the JRE resolves successfully.
 #[test]
 fn offline_lint_jre_failure_leaves_lockfile_untouched() {

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -277,34 +277,34 @@ pub fn run_codegen(
 ) -> Result<Vec<PathBuf>, EngineError> {
     let mut generated = Vec::new();
     for generator in generators {
-        generated.extend(run_one_generator(
-            project_root,
-            generator.as_ref(),
-            jre_home,
-            verbose,
-        )?);
+        let (_, files) = run_one_generator(project_root, generator.as_ref(), jre_home, verbose)?;
+        generated.extend(files);
     }
     Ok(generated)
 }
 
-/// Run a single generator and return the `.kt` files it emitted.
+/// Run a single generator, returning its output directory and the `.kt` files it
+/// emitted.
 ///
 /// Generators may nest their output (e.g. Fabrikt writes under
 /// `<output_dir>/src/main/kotlin/`); a generator that legitimately produced no
-/// output directory (emitted nothing) yields an empty list rather than erroring.
+/// output directory (emitted nothing) yields an empty file list rather than
+/// erroring. The output directory is returned (rather than recomputed by callers)
+/// so `generate` can report it without re-deriving the path.
 fn run_one_generator(
     project_root: &Path,
     generator: &dyn CodeGenerator,
     jre_home: Option<&Path>,
     verbose: bool,
-) -> Result<Vec<PathBuf>, EngineError> {
+) -> Result<(PathBuf, Vec<PathBuf>), EngineError> {
     let output_dir = generator_output_dir(project_root, generator.name());
     generator.generate(project_root, &output_dir, jre_home, verbose)?;
-    if output_dir.is_dir() {
-        Ok(konvoy_util::fs::collect_files(&output_dir, "kt")?)
+    let files = if output_dir.is_dir() {
+        konvoy_util::fs::collect_files(&output_dir, "kt")?
     } else {
-        Ok(Vec::new())
-    }
+        Vec::new()
+    };
+    Ok((output_dir, files))
 }
 
 /// One generator's result from a [`generate`] run.
@@ -356,14 +356,11 @@ pub fn generate(
         return Err(EngineError::CodegenNotConfigured);
     }
 
-    // Validate every generator's declared inputs up front — the same input pass
-    // `konvoy build` runs while hashing them for the cache key. This makes a
-    // missing spec fail fast with an actionable `CodegenInputNotFound` (identical
-    // to `build`) *before* any toolchain/tool download, rather than letting the
-    // generator process fail later with an opaque tool error. The hashes
-    // themselves are not needed here (generate has no cache key), so they are
-    // discarded.
-    compute_codegen_hashes(root, &generators)?;
+    // Validate every generator's declared inputs up front, so a missing spec fails
+    // fast with an actionable `CodegenInputNotFound` (as `konvoy build` reports it)
+    // *before* any toolchain/tool download — rather than letting the generator
+    // process fail later with an opaque tool error.
+    validate_generator_inputs(root, &generators)?;
 
     let lockfile = konvoy_config::lockfile::Lockfile::from_path(&root.join("konvoy.lock"))?;
 
@@ -378,14 +375,46 @@ pub fn generate(
 
     let mut outputs = Vec::with_capacity(generators.len());
     for generator in &generators {
-        let files = run_one_generator(root, generator.as_ref(), Some(&jre_home), verbose)?;
+        let (output_dir, files) =
+            run_one_generator(root, generator.as_ref(), Some(&jre_home), verbose)?;
         outputs.push(GeneratedOutput {
             display_name: generator.display_name().to_owned(),
             file_count: files.len(),
-            output_dir: generator_output_dir(root, generator.name()),
+            output_dir,
         });
     }
     Ok(GenerateResult { outputs })
+}
+
+/// Validate that every generator's declared inputs exist, mapping a missing input
+/// to the actionable [`EngineError::CodegenInputNotFound`].
+///
+/// This is the cheap counterpart to [`compute_codegen_hashes`]: `konvoy build`
+/// validates inputs *while* reading and hashing them for the cache key, but
+/// `konvoy generate` has no cache key — it only needs to confirm the declared
+/// inputs are present (a `stat`, not a full content read) before doing any
+/// toolchain/tool work. (The cache-key portability checks in
+/// [`compute_generator_hash`] are likewise build-only and not repeated here.)
+///
+/// # Errors
+/// [`EngineError::CodegenInputNotFound`] if a declared input is missing, plus any
+/// error from enumerating a generator's inputs (e.g. a missing spec directory).
+fn validate_generator_inputs(
+    project_root: &Path,
+    generators: &[Box<dyn CodeGenerator>],
+) -> Result<(), EngineError> {
+    for generator in generators {
+        for input in generator.input_files(project_root)? {
+            let full_path = project_root.join(&input);
+            if !full_path.exists() {
+                return Err(EngineError::CodegenInputNotFound {
+                    name: generator.name().to_owned(),
+                    path: full_path.display().to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 fn compute_generator_hash(

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -277,16 +277,105 @@ pub fn run_codegen(
 ) -> Result<Vec<PathBuf>, EngineError> {
     let mut generated = Vec::new();
     for generator in generators {
-        let output_dir = generator_output_dir(project_root, generator.name());
-        generator.generate(project_root, &output_dir, jre_home, verbose)?;
-        // Collect the emitted `.kt` (generators may nest them, e.g. Fabrikt writes
-        // under `<output_dir>/src/main/kotlin/`), to feed into compilation. Tolerate
-        // a generator that legitimately produced no output dir (emitted nothing).
-        if output_dir.is_dir() {
-            generated.extend(konvoy_util::fs::collect_files(&output_dir, "kt")?);
-        }
+        generated.extend(run_one_generator(
+            project_root,
+            generator.as_ref(),
+            jre_home,
+            verbose,
+        )?);
     }
     Ok(generated)
+}
+
+/// Run a single generator and return the `.kt` files it emitted.
+///
+/// Generators may nest their output (e.g. Fabrikt writes under
+/// `<output_dir>/src/main/kotlin/`); a generator that legitimately produced no
+/// output directory (emitted nothing) yields an empty list rather than erroring.
+fn run_one_generator(
+    project_root: &Path,
+    generator: &dyn CodeGenerator,
+    jre_home: Option<&Path>,
+    verbose: bool,
+) -> Result<Vec<PathBuf>, EngineError> {
+    let output_dir = generator_output_dir(project_root, generator.name());
+    generator.generate(project_root, &output_dir, jre_home, verbose)?;
+    if output_dir.is_dir() {
+        Ok(konvoy_util::fs::collect_files(&output_dir, "kt")?)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+/// One generator's result from a [`generate`] run.
+#[derive(Debug, Clone)]
+pub struct GeneratedOutput {
+    /// Human-readable generator label (e.g. `"OpenAPI"`).
+    pub display_name: String,
+    /// Number of `.kt` files written.
+    pub file_count: usize,
+    /// Directory the sources were written to.
+    pub output_dir: PathBuf,
+}
+
+/// Result of [`generate`]: one entry per configured generator.
+#[derive(Debug, Clone)]
+pub struct GenerateResult {
+    /// Per-generator output, in stable generator order.
+    pub outputs: Vec<GeneratedOutput>,
+}
+
+/// Run every configured code generator for the project at `root`, materializing
+/// sources into each generator's `.konvoy/gen/<name>/` directory.
+///
+/// This is the standalone `konvoy generate` entry point — it generates without
+/// compiling. It is **root-scoped**: it generates this project's configured
+/// generators, not those of its path-dependencies (each dependency's sources are
+/// generated when it is built as part of `konvoy build`).
+///
+/// It does NOT modify `konvoy.lock`. The graph-wide `[[codegen_tools]]` pins are
+/// owned by `konvoy build`, which writes the de-duplicated union for the whole
+/// project graph; a root-scoped `generate` must not clobber a path-dependency's
+/// pin with a subset. Generation is therefore read-only w.r.t. the lockfile: under
+/// `--locked` a missing pin still surfaces as drift via the resolver, and a normal
+/// run downloads (without persisting) exactly what the next `build` will pin.
+///
+/// # Errors
+/// Returns [`EngineError::CodegenNotConfigured`] when no `[codegen]` is configured,
+/// or any error from staleness checking, JRE/tool resolution, or a generator
+/// process.
+pub fn generate(
+    root: &Path,
+    verbose: bool,
+    resolver: crate::common::ArtifactResolver<'_>,
+) -> Result<GenerateResult, EngineError> {
+    let manifest = konvoy_config::Manifest::from_path(&root.join("konvoy.toml"))?;
+    let generators = active_generators(&manifest.codegen);
+    if generators.is_empty() {
+        return Err(EngineError::CodegenNotConfigured);
+    }
+
+    let lockfile = konvoy_config::lockfile::Lockfile::from_path(&root.join("konvoy.lock"))?;
+
+    // Under --locked, fail for the same reasons `konvoy build` would (issue #295:
+    // every command is consistent about drift); a no-op when not locked.
+    resolver.require_manifest_artifacts_resolvable(&manifest, &lockfile)?;
+
+    // Fabrikt and other JVM generators run on the toolchain's bundled JRE; resolve
+    // it, then download/verify the codegen tools under the command's policy.
+    let jre_home = resolver.resolve_jre(&manifest.toolchain.kotlin, &lockfile)?;
+    ensure_codegen_tools(&generators, &lockfile.codegen_tools, resolver)?;
+
+    let mut outputs = Vec::with_capacity(generators.len());
+    for generator in &generators {
+        let files = run_one_generator(root, generator.as_ref(), Some(&jre_home), verbose)?;
+        outputs.push(GeneratedOutput {
+            display_name: generator.display_name().to_owned(),
+            file_count: files.len(),
+            output_dir: generator_output_dir(root, generator.name()),
+        });
+    }
+    Ok(GenerateResult { outputs })
 }
 
 fn compute_generator_hash(
@@ -1017,6 +1106,30 @@ mod tests {
         match run_codegen(tmp.path(), &gens, None, false) {
             Err(EngineError::CodegenFailed { name, .. }) => assert_eq!(name, "boom"),
             other => panic!("expected CodegenFailed, got {other:?}"),
+        }
+    }
+
+    // ---- generate (standalone `konvoy generate`) ----------------------------
+
+    #[test]
+    fn generate_without_codegen_is_codegen_not_configured() {
+        // A project with no `[codegen]` section: `konvoy generate` must fail fast
+        // with a clear "nothing configured" error, before any lockfile or network
+        // work — so the (unused) resolver policy is irrelevant here.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("konvoy.toml"),
+            "[package]\nname = \"demo\"\n\n[toolchain]\nkotlin = \"2.1.0\"\n",
+        )
+        .unwrap();
+
+        match generate(
+            tmp.path(),
+            false,
+            crate::common::test_resolver(false, false),
+        ) {
+            Err(EngineError::CodegenNotConfigured) => {}
+            other => panic!("expected CodegenNotConfigured, got {other:?}"),
         }
     }
 }

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -342,8 +342,9 @@ pub struct GenerateResult {
 ///
 /// # Errors
 /// Returns [`EngineError::CodegenNotConfigured`] when no `[codegen]` is configured,
-/// or any error from staleness checking, JRE/tool resolution, or a generator
-/// process.
+/// [`EngineError::CodegenInputNotFound`] when a declared input (e.g. the spec) is
+/// missing, or any error from staleness checking, JRE/tool resolution, or a
+/// generator process.
 pub fn generate(
     root: &Path,
     verbose: bool,
@@ -354,6 +355,15 @@ pub fn generate(
     if generators.is_empty() {
         return Err(EngineError::CodegenNotConfigured);
     }
+
+    // Validate every generator's declared inputs up front — the same input pass
+    // `konvoy build` runs while hashing them for the cache key. This makes a
+    // missing spec fail fast with an actionable `CodegenInputNotFound` (identical
+    // to `build`) *before* any toolchain/tool download, rather than letting the
+    // generator process fail later with an opaque tool error. The hashes
+    // themselves are not needed here (generate has no cache key), so they are
+    // discarded.
+    compute_codegen_hashes(root, &generators)?;
 
     let lockfile = konvoy_config::lockfile::Lockfile::from_path(&root.join("konvoy.lock"))?;
 
@@ -1130,6 +1140,30 @@ mod tests {
         ) {
             Err(EngineError::CodegenNotConfigured) => {}
             other => panic!("expected CodegenNotConfigured, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generate_with_missing_spec_is_codegen_input_not_found() {
+        // A configured spec that doesn't exist must fail fast with
+        // CodegenInputNotFound (the same input validation `build` does) BEFORE any
+        // toolchain/tool resolution — so the resolver policy is irrelevant here.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("konvoy.toml"),
+            "[package]\nname = \"demo\"\n\n[toolchain]\nkotlin = \"2.2.0\"\n\n\
+             [codegen.openapi]\nversion = \"20.0.0\"\nspec = \"specs/api.yaml\"\n\
+             base_package = \"com.example.gen\"\n",
+        )
+        .unwrap();
+
+        match generate(
+            tmp.path(),
+            false,
+            crate::common::test_resolver(false, false),
+        ) {
+            Err(EngineError::CodegenInputNotFound { name, .. }) => assert_eq!(name, "openapi"),
+            other => panic!("expected CodegenInputNotFound, got {other:?}"),
         }
     }
 }

--- a/crates/konvoy-engine/src/common.rs
+++ b/crates/konvoy-engine/src/common.rs
@@ -100,8 +100,15 @@ impl<'a> ArtifactResolver<'a> {
         Ok((!was_pinned).then_some(actual_sha256))
     }
 
-    /// Resolve the JRE used to run detekt.
-    pub(crate) fn resolve_detekt_jre(
+    /// Resolve the Kotlin/Native toolchain's bundled JRE, used to run managed JVM
+    /// tools (detekt and the JVM codegen generators).
+    ///
+    /// Only the JRE is needed here — not the `konanc` compiler — so this is lighter
+    /// than full toolchain resolution; it installs the toolchain solely to obtain
+    /// its bundled JRE when absent. The errors are tool-agnostic on purpose
+    /// (`ToolchainJreOffline` / `ToolchainNoJre`): both `lint` and `generate` share
+    /// this path.
+    pub(crate) fn resolve_jre(
         self,
         kotlin_version: &str,
         lockfile: &Lockfile,
@@ -110,7 +117,7 @@ impl<'a> ArtifactResolver<'a> {
             self.resolve_artifact(
                 || has_required_toolchain_artifact_pins(lockfile, kotlin_version),
                 false,
-                || EngineError::DetektJreOffline {
+                || EngineError::ToolchainJreOffline {
                     version: kotlin_version.to_owned(),
                 },
             )?;
@@ -120,7 +127,7 @@ impl<'a> ArtifactResolver<'a> {
 
         let jre_home = konvoy_konanc::toolchain::jre_home_path(kotlin_version)?;
         if !jre_home.join("bin").join("java").exists() {
-            return Err(EngineError::DetektNoJre);
+            return Err(EngineError::ToolchainNoJre);
         }
         Ok(jre_home)
     }
@@ -720,29 +727,29 @@ mod tests {
     }
 
     #[test]
-    fn resolve_detekt_jre_reports_locked_drift_when_toolchain_hashes_missing() {
-        let version = "0.0.0-resolver-detekt-jre-drift";
+    fn resolve_jre_reports_locked_drift_when_toolchain_hashes_missing() {
+        let version = "0.0.0-resolver-jre-drift";
         let lockfile = lockfile_with_toolchain(version, None, None);
 
         let result = with_resolver(false, true, |resolver| {
-            resolver.resolve_detekt_jre(version, &lockfile)
+            resolver.resolve_jre(version, &lockfile)
         });
 
         assert!(matches!(result, Err(EngineError::LockfileUpdateRequired)));
     }
 
     #[test]
-    fn resolve_detekt_jre_reports_offline_when_pinned_but_absent() {
-        let version = "0.0.0-resolver-detekt-jre-offline";
+    fn resolve_jre_reports_offline_when_pinned_but_absent() {
+        let version = "0.0.0-resolver-jre-offline";
         let lockfile = lockfile_with_toolchain(version, Some("konanc-sha"), Some("jre-sha"));
 
         let result = with_resolver(true, false, |resolver| {
-            resolver.resolve_detekt_jre(version, &lockfile)
+            resolver.resolve_jre(version, &lockfile)
         });
 
         assert!(matches!(
             result,
-            Err(EngineError::DetektJreOffline { version: got }) if got == version
+            Err(EngineError::ToolchainJreOffline { version: got }) if got == version
         ));
     }
 

--- a/crates/konvoy-engine/src/detekt.rs
+++ b/crates/konvoy-engine/src/detekt.rs
@@ -256,7 +256,7 @@ pub fn lint(
     // with the toolchain absent), and a failed lint must not leave a rewritten
     // konvoy.lock behind. This is also the last read of `lockfile`, so the
     // persist below can consume it without a clone.
-    let jre_home = resolver.resolve_detekt_jre(&manifest.toolchain.kotlin, &lockfile)?;
+    let jre_home = resolver.resolve_jre(&manifest.toolchain.kotlin, &lockfile)?;
 
     // Persist the freshly-resolved hash to the lockfile if it was not pinned.
     if let Some(actual_sha256) = detekt_hash_to_persist {
@@ -671,9 +671,9 @@ src/main.kt:3:5: Magic number. [MagicNumber]
         assert!(
             matches!(
                 result,
-                Err(crate::error::EngineError::DetektJreOffline { .. })
+                Err(crate::error::EngineError::ToolchainJreOffline { .. })
             ),
-            "expected DetektJreOffline, got: {result:?}"
+            "expected ToolchainJreOffline, got: {result:?}"
         );
         let err = result.unwrap_err().to_string();
         assert!(

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -116,13 +116,17 @@ pub enum EngineError {
     #[error("cannot run tool `{tool}`: {message}")]
     ToolExecFailed { tool: String, message: String },
 
-    /// No JRE available to run detekt.
-    #[error("jre not available for running detekt — run `konvoy toolchain install` first")]
-    DetektNoJre,
+    /// No JRE available in the Kotlin/Native toolchain (needed to run JVM tools
+    /// such as detekt and codegen generators).
+    #[error(
+        "no JRE available in the Kotlin/Native toolchain — run `konvoy toolchain install` first"
+    )]
+    ToolchainNoJre,
 
-    /// The toolchain providing detekt's JRE is missing and --offline prevents installing it.
-    #[error("Kotlin/Native toolchain {version} is not installed (detekt needs its JRE) and --offline prevents downloads — run `konvoy toolchain install` first, or drop --offline")]
-    DetektJreOffline { version: String },
+    /// The Kotlin/Native toolchain providing the bundled JRE is missing and
+    /// --offline prevents installing it.
+    #[error("Kotlin/Native toolchain {version} is not installed (its bundled JRE is needed to run JVM tools) and --offline prevents downloads — run `konvoy toolchain install` first, or drop --offline")]
+    ToolchainJreOffline { version: String },
 
     /// Detekt jar hash mismatch.
     #[error("detekt {version} jar hash mismatch — expected {expected}, got {actual}; this may indicate a tampered or corrupted download — delete ~/.konvoy/tools/detekt/{version}/ and re-run `konvoy lint` to re-download, or verify the hash at the detekt release page")]
@@ -135,6 +139,10 @@ pub enum EngineError {
     /// Lint not configured.
     #[error("detekt not configured — add `detekt = \"1.23.7\"` to [toolchain] in konvoy.toml")]
     LintNotConfigured,
+
+    /// `konvoy generate` invoked on a project with no codegen configured.
+    #[error("no codegen configured — add a `[codegen.openapi]` section to konvoy.toml")]
+    CodegenNotConfigured,
 
     /// A configured codegen input file is missing.
     #[error("codegen input for `{name}` not found at {path} — create the file, or fix the inputs configured in [codegen.{name}]")]

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -20,8 +20,9 @@ pub use artifact::{ArtifactStore, BuildMetadata};
 pub use build::{build, BuildOptions, BuildOutcome, BuildResult};
 pub use cache::{CacheInputs, CacheKey};
 pub use codegen::{
-    compute_codegen_hash_pairs, compute_codegen_hashes, generator_output_dir, generator_summaries,
-    managed_tools, CodeGenerator, GeneratorSummary,
+    compute_codegen_hash_pairs, compute_codegen_hashes, generate, generator_output_dir,
+    generator_summaries, managed_tools, CodeGenerator, GenerateResult, GeneratedOutput,
+    GeneratorSummary,
 };
 pub use common::{ArtifactResolver, LockfileManager};
 pub use detekt::{lint, DetektDiagnostic, LintOptions, LintResult};

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1384,6 +1384,150 @@ test_codegen_generate_command() {
     assert_contains "$out" "Generated"
 }
 
+# Expected: `konvoy generate --verbose` exercises the verbose plumbing end-to-end
+# (the generator runs with output shown) and still materializes sources.
+test_codegen_generate_verbose() {
+    konvoy init --name cg-gen-v --lib >/dev/null 2>&1
+    rm -rf cg-gen-v/src
+    _append_codegen_config cg-gen-v/konvoy.toml
+    _write_openapi_spec cg-gen-v/specs/api.yaml
+    cd cg-gen-v
+    local out
+    out=$(konvoy generate --verbose 2>&1)
+    assert_contains "$out" "Generated"
+    _assert_generated_kt .konvoy/gen/openapi
+}
+
+# Expected (generate -> build handoff): `generate` materializes sources WITHOUT a
+# pin; a subsequent `build` compiles them AND writes the [[codegen_tools]] pin (the
+# pin is owned by build, not generate). The binary then runs with the generated
+# model linked in.
+test_codegen_generate_then_build_handoff() {
+    konvoy init --name cg-gen-build >/dev/null 2>&1
+    _append_codegen_config cg-gen-build/konvoy.toml
+    _write_openapi_spec cg-gen-build/specs/api.yaml
+    cat > cg-gen-build/src/main.kt << 'KOTLIN'
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+
+@Serializable
+data class Cfg(val name: String)
+
+fun main() {
+    println("cfg=" + Json.encodeToString(Cfg("ok")))
+}
+KOTLIN
+    cd cg-gen-build
+
+    local gen_out
+    gen_out=$(konvoy generate 2>&1)
+    assert_contains "$gen_out" "Generated"
+    _assert_generated_kt .konvoy/gen/openapi
+    if [ -f konvoy.lock ] && grep -q '\[\[codegen_tools\]\]' konvoy.lock; then
+        echo "    generate must not pin the codegen tool" >&2
+        return 1
+    fi
+
+    local build_out
+    build_out=$(konvoy build 2>&1)
+    assert_contains "$build_out" "Compiling"
+    assert_file_contains konvoy.lock "[[codegen_tools]]"
+    assert_file_contains konvoy.lock "fabrikt"
+
+    local run_out
+    run_out=$(konvoy run 2>&1)
+    assert_contains "$run_out" "cfg="
+}
+
+# Expected (the post-build flag matrix, from a pinned + cached state): one build
+# pins the Fabrikt tool and caches the JAR; then `generate --locked` (pin present →
+# no drift), `generate --offline` (tool + JRE present), and `generate --locked
+# --offline` (frozen) all succeed.
+test_codegen_generate_locked_and_offline_after_build() {
+    konvoy init --name cg-gen-frozen --lib >/dev/null 2>&1
+    rm -rf cg-gen-frozen/src
+    _append_codegen_config cg-gen-frozen/konvoy.toml
+    _write_openapi_spec cg-gen-frozen/specs/api.yaml
+    cd cg-gen-frozen
+
+    konvoy build >/dev/null 2>&1
+    assert_file_contains konvoy.lock "[[codegen_tools]]"
+
+    local out_locked
+    out_locked=$(konvoy generate --locked 2>&1)
+    assert_contains "$out_locked" "Generated"
+    _assert_generated_kt .konvoy/gen/openapi
+
+    local out_offline
+    out_offline=$(konvoy generate --offline 2>&1)
+    assert_contains "$out_offline" "Generated"
+
+    local out_frozen
+    out_frozen=$(konvoy generate --locked --offline 2>&1)
+    assert_contains "$out_frozen" "Generated"
+}
+
+# Expected: `konvoy clean --all` removes .konvoy/ (including generated sources);
+# `generate` recreates them cleanly.
+test_codegen_generate_after_clean_regenerates() {
+    konvoy init --name cg-gen-clean --lib >/dev/null 2>&1
+    rm -rf cg-gen-clean/src
+    _append_codegen_config cg-gen-clean/konvoy.toml
+    _write_openapi_spec cg-gen-clean/specs/api.yaml
+    cd cg-gen-clean
+
+    konvoy generate >/dev/null 2>&1
+    _assert_generated_kt .konvoy/gen/openapi
+
+    konvoy clean --all >/dev/null 2>&1
+    if [ -d .konvoy/gen ]; then
+        echo "    konvoy clean --all should remove .konvoy/gen" >&2
+        return 1
+    fi
+
+    local out
+    out=$(konvoy generate 2>&1)
+    assert_contains "$out" "Generated"
+    _assert_generated_kt .konvoy/gen/openapi
+}
+
+# Expected (root-scoped): the root AND a path-dep BOTH declare codegen. `generate`
+# is root-scoped — it runs ONLY the root's generators and never touches the
+# dependency's checkout (the dep's sources are generated when it is built).
+test_codegen_generate_is_root_scoped() {
+    konvoy init --name cg-rs-dep --lib >/dev/null 2>&1
+    konvoy init --name cg-rs-root --lib >/dev/null 2>&1
+    rm -rf cg-rs-root/src
+    _append_codegen_config cg-rs-dep/konvoy.toml
+    _write_openapi_spec cg-rs-dep/specs/api.yaml
+    _write_openapi_spec cg-rs-root/specs/api.yaml
+    # Root needs no plugins/runtime deps (generate doesn't compile): a bare codegen
+    # section + the path dependency (one [dependencies] table) is enough.
+    cat >> cg-rs-root/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.root"
+
+[dependencies]
+cg-rs-dep = { path = "../cg-rs-dep" }
+TOML
+    cd cg-rs-root
+
+    local out
+    out=$(konvoy generate 2>&1)
+    assert_contains "$out" "Generated"
+    _assert_generated_kt .konvoy/gen/openapi
+
+    # The dependency's generators are NOT run by a root `generate`.
+    if [ -d ../cg-rs-dep/.konvoy/gen ]; then
+        echo "    konvoy generate must be root-scoped (dep .konvoy/gen was created)" >&2
+        return 1
+    fi
+}
+
 # Unexpected: `konvoy generate` on a project with no [codegen] fails fast with a
 # clear "not configured" message, before any network or JRE work.
 test_codegen_generate_no_codegen_fails() {
@@ -1395,6 +1539,126 @@ test_codegen_generate_no_codegen_fails() {
         return 1
     fi
     assert_contains "$output" "no codegen configured"
+}
+
+# Unexpected: `generate --locked` without a codegen pin is lockfile drift. (A spec
+# is present so input validation passes and the resolver's drift gate is reached.)
+test_codegen_generate_locked_no_pin_fails() {
+    konvoy init --name cg-gen-locked --lib >/dev/null 2>&1
+    cat >> cg-gen-locked/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    _write_openapi_spec cg-gen-locked/specs/api.yaml
+    cd cg-gen-locked
+    printf '[toolchain]\nkonanc_version = "2.2.0"\n' > konvoy.lock
+    local output
+    if output=$(konvoy generate --locked 2>&1); then
+        echo "    expected generate --locked to fail without a codegen pin" >&2
+        return 1
+    fi
+    assert_contains "$output" "lockfile"
+}
+
+# Unexpected: `generate --offline` with an uncached Fabrikt JAR is a hard error
+# naming the tool. The toolchain JRE IS present (pre-installed), so this reaches the
+# codegen-tool gate; a unique version guarantees the JAR is never cached (no race).
+test_codegen_generate_offline_tool_absent_fails() {
+    konvoy init --name cg-gen-offtool --lib >/dev/null 2>&1
+    cat >> cg-gen-offtool/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "97.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    _write_openapi_spec cg-gen-offtool/specs/api.yaml
+    cd cg-gen-offtool
+    local output
+    if output=$(konvoy generate --offline 2>&1); then
+        echo "    expected generate --offline to fail with an absent codegen tool" >&2
+        return 1
+    fi
+    assert_contains "$output" 'codegen tool `fabrikt`'
+    assert_contains "$output" "--offline prevents downloads"
+}
+
+# Unexpected: `generate --offline` when the toolchain (and thus its bundled JRE) is
+# absent fails at JRE resolution with the tool-agnostic toolchain error — NOT a
+# detekt-branded one. An uninstalled, never-cached toolchain version forces the gate.
+test_codegen_generate_offline_jre_absent_fails() {
+    konvoy init --name cg-gen-offjre --lib >/dev/null 2>&1
+    sed -i 's/^kotlin = .*/kotlin = "9.9.9"/' cg-gen-offjre/konvoy.toml
+    cat >> cg-gen-offjre/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    _write_openapi_spec cg-gen-offjre/specs/api.yaml
+    cd cg-gen-offjre
+    local output
+    if output=$(konvoy generate --offline 2>&1); then
+        echo "    expected generate --offline to fail with the toolchain JRE absent" >&2
+        return 1
+    fi
+    assert_contains "$output" "9.9.9"
+    assert_contains "$output" "--offline prevents downloads"
+}
+
+# Unexpected: a declared-but-missing spec fails fast with the same actionable
+# CodegenInputNotFound `konvoy build` gives — BEFORE any toolchain/tool work.
+test_codegen_generate_missing_spec_fails() {
+    konvoy init --name cg-gen-nospec --lib >/dev/null 2>&1
+    cat >> cg-gen-nospec/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-gen-nospec
+    local output
+    if output=$(konvoy generate 2>&1); then
+        echo "    expected generate to fail with a missing spec file" >&2
+        return 1
+    fi
+    assert_contains "$output" "codegen input for"
+    assert_contains "$output" "not found"
+}
+
+# Unexpected: `konvoy generate` outside a project (no konvoy.toml) errors clearly.
+test_codegen_generate_outside_project_fails() {
+    local output
+    if output=$(konvoy generate 2>&1); then
+        echo "    expected generate to fail outside a project" >&2
+        return 1
+    fi
+    assert_contains "$output" "no konvoy.toml"
+}
+
+# Unexpected: manifest validation (shared with build) also blocks generate — an
+# absolute spec path is rejected at parse time, before any work.
+test_codegen_generate_absolute_spec_rejected() {
+    konvoy init --name cg-gen-abs --lib >/dev/null 2>&1
+    cat >> cg-gen-abs/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "/etc/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-gen-abs
+    local output
+    if output=$(konvoy generate 2>&1); then
+        echo "    expected generate to reject an absolute spec path" >&2
+        return 1
+    fi
+    assert_contains "$output" "relative path inside the project"
 }
 
 # Expected (doctor, not-downloaded path): `konvoy doctor` reports each configured
@@ -3234,7 +3498,18 @@ run_test test_codegen_bad_spec_extension_rejected
 run_test test_codegen_old_fabrikt_version_rejected
 run_test test_codegen_unknown_tool_rejected
 run_test test_codegen_generate_command
+run_test test_codegen_generate_verbose
+run_test test_codegen_generate_then_build_handoff
+run_test test_codegen_generate_locked_and_offline_after_build
+run_test test_codegen_generate_after_clean_regenerates
+run_test test_codegen_generate_is_root_scoped
 run_test test_codegen_generate_no_codegen_fails
+run_test test_codegen_generate_locked_no_pin_fails
+run_test test_codegen_generate_offline_tool_absent_fails
+run_test test_codegen_generate_offline_jre_absent_fails
+run_test test_codegen_generate_missing_spec_fails
+run_test test_codegen_generate_outside_project_fails
+run_test test_codegen_generate_absolute_spec_rejected
 run_test test_codegen_doctor_reports_not_downloaded
 run_test test_codegen_doctor_reports_installed
 

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -1350,6 +1350,97 @@ TOML
     assert_contains "$output" "grpc"
 }
 
+# Expected: `konvoy generate` runs the configured generators WITHOUT compiling. It
+# materializes the .kt sources and prints a per-generator summary, but does not
+# produce a build artifact and is read-only w.r.t. konvoy.lock (the graph-wide
+# [[codegen_tools]] pins are owned by `konvoy build`). Re-running is idempotent.
+test_codegen_generate_command() {
+    konvoy init --name cg-gen --lib >/dev/null 2>&1
+    rm -rf cg-gen/src
+    _append_codegen_config cg-gen/konvoy.toml
+    _write_openapi_spec cg-gen/specs/api.yaml
+    cd cg-gen
+
+    local out
+    out=$(konvoy generate 2>&1)
+    assert_contains "$out" "Generated"
+    assert_contains "$out" "OpenAPI"
+    _assert_generated_kt .konvoy/gen/openapi
+
+    # generate must NOT compile.
+    if [ -d .konvoy/build ]; then
+        echo "    konvoy generate must not compile (.konvoy/build exists)" >&2
+        return 1
+    fi
+
+    # generate is read-only w.r.t. the lockfile: it writes no [[codegen_tools]] pin.
+    if [ -f konvoy.lock ] && grep -q '\[\[codegen_tools\]\]' konvoy.lock; then
+        echo "    konvoy generate must not write codegen pins to konvoy.lock" >&2
+        return 1
+    fi
+
+    # Re-running regenerates cleanly.
+    out=$(konvoy generate 2>&1)
+    assert_contains "$out" "Generated"
+}
+
+# Unexpected: `konvoy generate` on a project with no [codegen] fails fast with a
+# clear "not configured" message, before any network or JRE work.
+test_codegen_generate_no_codegen_fails() {
+    konvoy init --name cg-none >/dev/null 2>&1
+    cd cg-none
+    local output
+    if output=$(konvoy generate 2>&1); then
+        echo "    expected generate to fail when no codegen is configured" >&2
+        return 1
+    fi
+    assert_contains "$output" "no codegen configured"
+}
+
+# Expected (doctor, not-downloaded path): `konvoy doctor` reports each configured
+# codegen tool. A unique version (never in the shared ~/.konvoy cache) guarantees
+# the "not downloaded" line deterministically. Doctor exits non-zero here (the
+# toolchain isn't installed), so the status is ignored and only output is asserted;
+# doctor performs no downloads.
+test_codegen_doctor_reports_not_downloaded() {
+    konvoy init --name cg-doc-missing --lib >/dev/null 2>&1
+    cat >> cg-doc-missing/konvoy.toml << 'TOML'
+
+[codegen.openapi]
+version = "98.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.gen"
+TOML
+    cd cg-doc-missing
+    local out
+    out=$(konvoy doctor 2>&1 || true)
+    assert_contains "$out" "OpenAPI"
+    assert_contains "$out" "fabrikt"
+    assert_contains "$out" "98.0.0"
+    assert_contains "$out" "not downloaded"
+}
+
+# Expected (doctor, installed path): after a build downloads Fabrikt, `konvoy
+# doctor` reports the codegen tool as [ok] with its version and on-disk path.
+test_codegen_doctor_reports_installed() {
+    konvoy init --name cg-doc-ok --lib >/dev/null 2>&1
+    rm -rf cg-doc-ok/src
+    _append_codegen_config cg-doc-ok/konvoy.toml
+    _write_openapi_spec cg-doc-ok/specs/api.yaml
+    cd cg-doc-ok
+
+    konvoy build >/dev/null 2>&1
+
+    local out
+    out=$(konvoy doctor 2>&1 || true)
+    assert_contains "$out" "20.0.0"
+    # The fabrikt line is specifically [ok] (not [--]/[!!]).
+    if ! echo "$out" | grep -q '\[ok\].*fabrikt'; then
+        echo "    expected doctor to report fabrikt [ok] after a build: $out" >&2
+        return 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Tests: Maven dependencies
 # ---------------------------------------------------------------------------
@@ -3142,6 +3233,10 @@ run_test test_codegen_absolute_spec_rejected
 run_test test_codegen_bad_spec_extension_rejected
 run_test test_codegen_old_fabrikt_version_rejected
 run_test test_codegen_unknown_tool_rejected
+run_test test_codegen_generate_command
+run_test test_codegen_generate_no_codegen_fails
+run_test test_codegen_doctor_reports_not_downloaded
+run_test test_codegen_doctor_reports_installed
 
 # Maven dependencies
 run_test test_update_help


### PR DESCRIPTION
Part of #160 — the codegen `(N/5)` series. Follows #292 (build integration), which left the engine plumbing (`run_codegen`, `ensure_codegen_tools`) ready; this PR is purely the **CLI surface** on top of it.

## What

- **`konvoy generate [--verbose] [--locked] [--offline]`** — run the configured code generators (OpenAPI/Fabrikt today) **without compiling**. It materializes the `.kt` sources, prints a per-generator summary, and is **read-only w.r.t. `konvoy.lock`**.
  - The graph-wide `[[codegen_tools]]` pins remain **owned by `konvoy build`** (which writes the deduplicated union for the whole project graph). A root-scoped `generate` must not clobber a path-dependency's pin with a subset — so it deliberately does not persist. Under `--locked` a missing pin still surfaces as drift via the resolver; a normal run downloads (without persisting) exactly what the next `build` will pin.
- **`konvoy doctor`** — now reports each configured codegen tool's install status (`[ok]` with version + path / `[--]` not downloaded / `[!!]` error), mirroring the existing detekt check.

## Engine

- New `codegen::generate` entry point (+ `GenerateResult`/`GeneratedOutput`).
- `run_codegen`'s per-generator body extracted into `run_one_generator`, reused for the per-generator summaries (no change to the build hot path).
- New `CodegenNotConfigured` error (mirrors `LintNotConfigured`).
- **Prep commit:** the detekt-named JRE resolver is generalized to be tool-agnostic (`resolve_detekt_jre` → `resolve_jre`; `DetektJreOffline`/`DetektNoJre` → `ToolchainJreOffline`/`ToolchainNoJre`) so a `generate` JRE failure doesn't surface a "detekt needs its JRE" message. Detekt behavior is unchanged.

## Tests

- Engine unit: `CodegenNotConfigured` fast-path.
- CLI: `generate` parse tests (defaults / all flags / help) + subcommand-list.
- Smoke (4): generate runs without compiling and is lock-read-only; generate-without-codegen fails fast; doctor reports not-downloaded (unique version → race-free) and `[ok]` after a build.

Local: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (all green), `RUSTDOCFLAGS=-D warnings cargo doc` clean. Smoke triggered on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)