### PR TITLE
codegen (5/5): docs + polish (README, error/doc copy, smoke regression fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ konvoy generate            # run all configured generators
 konvoy generate --verbose  # show raw generator output
 ```
 
-The Fabrikt JAR is downloaded to `~/.konvoy/tools/fabrikt/<version>/` on first use and its SHA-256 is pinned in `konvoy.lock` (under `[[codegen_tools]]`), exactly like the detekt JAR. It runs on the JRE bundled with the managed Kotlin/Native toolchain, so no separate Java installation is needed. `konvoy doctor` reports whether each configured tool is downloaded.
+The Fabrikt JAR is downloaded to `~/.konvoy/tools/fabrikt/<version>/` on first use, and its SHA-256 is pinned in `konvoy.lock` (under `[[codegen_tools]]`) by `konvoy build`. (`konvoy generate` downloads it under the same `--locked`/`--offline` policy but does not write the lockfile — `build` owns the pins.) It runs on the JRE bundled with the managed Kotlin/Native toolchain, so no separate Java installation is needed. `konvoy doctor` reports whether each configured tool is downloaded.
 
 Code generation also works for [path dependencies](#path-dependencies): a dependency that configures `[codegen.openapi]` generates its own sources when it is built, and its Fabrikt tool is pinned once in the root project's `konvoy.lock`.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Konvoy avoids Gradle/Maven-style complexity by providing:
 - [Testing](#testing)
 - [Managed toolchains](#managed-toolchains)
 - [Linting](#linting)
+- [Code generation](#code-generation)
 - [Editor support](#editor-support)
 - [Development](#development)
 
@@ -257,14 +258,14 @@ Transitive dependencies are tracked automatically with a `required_by` field lis
 
 ### Reproducible builds: `--locked` and `--offline`
 
-`build`, `run`, `test`, and `lint` accept two **orthogonal** reproducibility flags, mirroring Cargo:
+`build`, `run`, `test`, `lint`, and `generate` accept two **orthogonal** reproducibility flags, mirroring Cargo:
 
-- **`--locked`** — *reproducible install.* Never modify `konvoy.lock`. Pinned artifacts (the toolchain, plugins, the detekt JAR) are still **downloaded and verified against their pinned SHA-256** when missing from the local cache; the only failure is **lockfile drift** — a missing or mismatched pin — which errors with `lockfile is out of date`. This is the flag for clean-CI builds: check out the repo (with its committed `konvoy.lock`) and `konvoy build --locked` reproducibly, downloading whatever the lockfile pins.
+- **`--locked`** — *reproducible install.* Never modify `konvoy.lock`. Pinned artifacts (the toolchain, plugins, the detekt JAR, codegen tools) are still **downloaded and verified against their pinned SHA-256** when missing from the local cache; the only failure is **lockfile drift** — a missing or mismatched pin — which errors with `lockfile is out of date`. This is the flag for clean-CI builds: check out the repo (with its committed `konvoy.lock`) and `konvoy build --locked` reproducibly, downloading whatever the lockfile pins.
 - **`--offline`** — *no network.* Every managed artifact must already be present under `~/.konvoy`; an absent artifact is a hard error (e.g. `… is not installed and --offline prevents downloads`). Nothing is fetched.
 
 The two combine freely. `--locked --offline` together is the strictest mode (Cargo's `--frozen`): no lockfile changes **and** no network. When both are set and the lockfile is also drifting, the drift is reported first — it is the actionable root cause.
 
-All managed artifacts — the konanc toolchain, Maven dependency klibs, compiler plugins, and the detekt JAR + its JRE — obey these two flags identically. (`--offline` also refuses the automatic `konvoy update` that resolves missing Maven deps, since that fetches from Maven Central.)
+All managed artifacts — the konanc toolchain, Maven dependency klibs, compiler plugins, the detekt JAR + its JRE, and codegen tools — obey these two flags identically. (`--offline` also refuses the automatic `konvoy update` that resolves missing Maven deps, since that fetches from Maven Central.)
 
 ### Plugins
 
@@ -356,6 +357,57 @@ To customize detekt rules, place a `detekt.yml` file in the project root or pass
 konvoy lint                        # run with defaults or detekt.yml
 konvoy lint --config my-rules.yml  # use custom config
 konvoy lint --verbose              # show raw detekt output
+```
+
+## Code generation
+
+Konvoy can generate Kotlin sources from [OpenAPI](https://www.openapis.org/) specs before compilation, using [Fabrikt](https://github.com/cjbooms/fabrikt) as a managed tool (like detekt). The generated `@Serializable` data classes are compiled into your project alongside your hand-written code.
+
+Enable it with a `[codegen.openapi]` section. The generated models use `kotlinx.serialization`, so add the serialization compiler plugin and runtime libraries as well:
+
+```toml
+[package]
+name = "my-app"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "{kotlin}" }
+
+[dependencies]
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+kotlinx-serialization-json = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+
+[codegen.openapi]
+version = "20.0.0"                # Fabrikt version (18.0.0 or newer)
+spec = "specs/api.yaml"           # project-relative path to the spec (.yaml, .yml, or .json)
+base_package = "com.example.api"  # Kotlin package for the generated code
+```
+
+Generation runs automatically as part of `konvoy build`: sources are written to `.konvoy/gen/openapi/` and compiled in. The output is **ephemeral** — never commit it; `konvoy clean --all` removes it with the rest of `.konvoy/`. Generation is folded into the build cache by hashing the spec, so an unchanged spec is a full cache hit (no regeneration, no recompilation) and editing the spec triggers a rebuild.
+
+To generate **without** compiling — to inspect the output or feed an editor's indexer — run `konvoy generate`:
+
+```
+konvoy generate            # run all configured generators
+konvoy generate --verbose  # show raw generator output
+```
+
+The Fabrikt JAR is downloaded to `~/.konvoy/tools/fabrikt/<version>/` on first use and its SHA-256 is pinned in `konvoy.lock` (under `[[codegen_tools]]`), exactly like the detekt JAR. It runs on the JRE bundled with the managed Kotlin/Native toolchain, so no separate Java installation is needed. `konvoy doctor` reports whether each configured tool is downloaded.
+
+Code generation also works for [path dependencies](#path-dependencies): a dependency that configures `[codegen.openapi]` generates its own sources when it is built, and its Fabrikt tool is pinned once in the root project's `konvoy.lock`.
+
+### Multi-file specs
+
+When a spec is split across multiple files via `$ref`, list the directories holding the referenced files in `extra_spec_dirs` so a change to any of them regenerates sources (Fabrikt resolves `$ref`s internally but never reports which files it read, so Konvoy cannot discover them on its own):
+
+```toml
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.api"
+extra_spec_dirs = ["specs"]
 ```
 
 ## Editor support

--- a/crates/konvoy-config/src/manifest.rs
+++ b/crates/konvoy-config/src/manifest.rs
@@ -67,7 +67,9 @@ pub struct DependencySpec {
     pub maven: Option<String>,
 }
 
-/// Code generation tools configured for this project.
+/// Code generation tools configured for this project (the `[codegen]` section of
+/// `konvoy.toml`). Each field is one generator type; only `[codegen.openapi]` is
+/// supported today.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Codegen {
@@ -88,7 +90,8 @@ impl Codegen {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OpenApiCodegen {
-    /// Fabrikt version to use.
+    /// Fabrikt version to use. Must be 18.0.0 or newer — earlier releases lack the
+    /// `--serialization-library` flag Konvoy always passes.
     pub version: String,
     /// Project-relative path to the OpenAPI spec file.
     pub spec: String,

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -21,17 +21,6 @@ pub mod openapi;
 // the engine root (`crate::managed_tool`); re-exported here for codegen callers.
 pub use crate::managed_tool::ManagedToolSpec;
 
-/// Display metadata for a configured generator.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GeneratorSummary {
-    /// Stable generator name used in paths and cache key tags.
-    pub name: String,
-    /// Human-readable generator label.
-    pub display_name: String,
-    /// Directory containing this generator's outputs.
-    pub output_dir: PathBuf,
-}
-
 /// A configured code generator.
 ///
 /// Implemented by each concrete generator (OpenAPI/Fabrikt today; gRPC etc.
@@ -98,31 +87,6 @@ pub fn active_generators(codegen: &Codegen) -> Vec<Box<dyn CodeGenerator>> {
         generators.push(Box::new(openapi::OpenApiGenerator::new(openapi.clone())));
     }
     generators
-}
-
-/// Return display summaries for the given generators.
-#[must_use]
-pub fn generator_summaries(
-    project_root: &Path,
-    generators: &[Box<dyn CodeGenerator>],
-) -> Vec<GeneratorSummary> {
-    generators
-        .iter()
-        .map(|generator| GeneratorSummary {
-            name: generator.name().to_owned(),
-            display_name: generator.display_name().to_owned(),
-            output_dir: generator_output_dir(project_root, generator.name()),
-        })
-        .collect()
-}
-
-/// Return the managed tools required by the given generators.
-#[must_use]
-pub fn managed_tools(generators: &[Box<dyn CodeGenerator>]) -> Vec<ManagedToolSpec> {
-    generators
-        .iter()
-        .map(|generator| generator.managed_tool())
-        .collect()
 }
 
 /// Compute `(generator name, input hash)` pairs for the given generators, in the
@@ -910,24 +874,6 @@ mod tests {
     fn output_dir_is_under_dot_konvoy_gen() {
         let dir = generator_output_dir(Path::new("/proj"), "openapi");
         assert_eq!(dir, PathBuf::from("/proj/.konvoy/gen/openapi"));
-    }
-
-    #[test]
-    fn summaries_and_managed_tools_reflect_the_given_generators() {
-        let gens = vec![
-            fake_full("demo", "Demo Label", &[], &[]),
-            fake("other", &[], &[]),
-        ];
-        let summaries = generator_summaries(Path::new("/proj"), &gens);
-        assert_eq!(summaries.len(), 2);
-        assert_eq!(summaries[0].name, "demo");
-        assert_eq!(summaries[0].display_name, "Demo Label");
-        assert_eq!(
-            summaries[0].output_dir,
-            PathBuf::from("/proj/.konvoy/gen/demo")
-        );
-        assert_eq!(summaries[1].name, "other");
-        assert_eq!(managed_tools(&gens).len(), 2);
     }
 
     // ---- ensure_codegen_tools (download/pin orchestration) ------------------

--- a/crates/konvoy-engine/src/codegen/mod.rs
+++ b/crates/konvoy-engine/src/codegen/mod.rs
@@ -338,7 +338,8 @@ pub struct GenerateResult {
 /// project graph; a root-scoped `generate` must not clobber a path-dependency's
 /// pin with a subset. Generation is therefore read-only w.r.t. the lockfile: under
 /// `--locked` a missing pin still surfaces as drift via the resolver, and a normal
-/// run downloads (without persisting) exactly what the next `build` will pin.
+/// run downloads and verifies the required tool (so generation succeeds) but does
+/// not update `konvoy.lock` — the next `konvoy build` writes the pin.
 ///
 /// # Errors
 /// Returns [`EngineError::CodegenNotConfigured`] when no `[codegen]` is configured,

--- a/crates/konvoy-engine/src/error.rs
+++ b/crates/konvoy-engine/src/error.rs
@@ -161,7 +161,7 @@ pub enum EngineError {
     },
 
     /// A codegen tool artifact hash does not match the lockfile.
-    #[error("codegen tool `{name}` {version} hash mismatch — expected {expected}, got {actual}; delete ~/.konvoy/tools/{name}/{version}/ and re-run `konvoy generate`, or verify the artifact upstream")]
+    #[error("codegen tool `{name}` {version} hash mismatch — expected {expected}, got {actual}; delete ~/.konvoy/tools/{name}/{version}/ and re-run `konvoy build` (or `konvoy generate`), or verify the artifact upstream")]
     CodegenHashMismatch {
         name: String,
         version: String,

--- a/crates/konvoy-engine/src/lib.rs
+++ b/crates/konvoy-engine/src/lib.rs
@@ -21,8 +21,7 @@ pub use build::{build, BuildOptions, BuildOutcome, BuildResult};
 pub use cache::{CacheInputs, CacheKey};
 pub use codegen::{
     compute_codegen_hash_pairs, compute_codegen_hashes, generate, generator_output_dir,
-    generator_summaries, managed_tools, CodeGenerator, GenerateResult, GeneratedOutput,
-    GeneratorSummary,
+    CodeGenerator, GenerateResult, GeneratedOutput,
 };
 pub use common::{ArtifactResolver, LockfileManager};
 pub use detekt::{lint, DetektDiagnostic, LintOptions, LintResult};

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -3035,7 +3035,7 @@ TOML
         echo "    expected lint --offline to fail at JRE resolution" >&2
         return 1
     fi
-    assert_contains "$output" "detekt needs its JRE"
+    assert_contains "$output" "bundled JRE is needed to run JVM tools"
     assert_contains "$output" "--offline prevents downloads"
     assert_files_identical konvoy.lock lock.bak
 }


### PR DESCRIPTION
The final PR of the codegen `(N/5)` series — user documentation **and** a polish pass over the completed feature. Completes #160.

## Documentation
A dedicated **Code generation** README section: the `[codegen.openapi]` config (with the required `kotlin-serialization` plugin + `kotlinx-serialization` runtime), how generation folds into `konvoy build` (`.konvoy/gen/openapi/`, ephemeral, cached by hashing the spec), the standalone **`konvoy generate`** command, the managed Fabrikt JAR + `[[codegen_tools]]` pinning (by `konvoy build`), path-dependency codegen, and `extra_spec_dirs` for multi-file specs. The example config is the one the smoke tests prove compiles.

Also: added `generate` + codegen tools to the **Reproducible builds** (`--locked`/`--offline`) docs and the table of contents.

## Polish (from a documentation/audit pass)
- **Regression fix:** the lint smoke test `test_offline_lint_jre_failure_keeps_lockfile` still asserted the pre-#300 error wording (`detekt needs its JRE`); #300 made that message tool-agnostic, and since smoke isn't a merge gate it had landed **broken on main**. Fixed the assertion.
- **README accuracy:** the `[[codegen_tools]]` pin is attributed to `konvoy build` (it had read as though `konvoy generate` writes it; generate is lockfile-read-only).
- **Error copy:** `CodegenHashMismatch` now points at `konvoy build` (or `konvoy generate`), matching `CodegenToolOffline`.
- **Doc comments:** clarified `generate`'s lockfile-read-only wording; documented the Fabrikt 18.0.0 minimum on `OpenApiCodegen::version` and the `[codegen]` section on `Codegen`.
- **Dead code:** removed orphaned public API (`generator_summaries`, `GeneratorSummary`, `managed_tools`) that had no production caller — only a self-referential test.

Local: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS=-D warnings cargo doc` all green. Smoke re-run to confirm the lint regression fix + all 26 codegen tests.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)