### PR TITLE
konvoy check: validate konvoy.toml + structured diagnostics (editor backend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "konvoy-konanc",
  "konvoy-targets",
  "konvoy-util",
+ "serde_json",
  "tempfile",
 ]
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ hello/
 - `konvoy update` — resolve Maven dependencies (including transitives via POM) and update `konvoy.lock`
 - `konvoy clean` — remove build artifacts
 - `konvoy doctor` — check environment, toolchain, and dependency setup
+- `konvoy check [--format human|json]` — validate `konvoy.toml` and report configuration issues (JSON output is a stable contract for editors/tools)
 - `konvoy toolchain install [<version>]` — install a Kotlin/Native version
 - `konvoy toolchain list` — list installed toolchain versions
 

--- a/crates/konvoy-cli/Cargo.toml
+++ b/crates/konvoy-cli/Cargo.toml
@@ -18,6 +18,7 @@ konvoy-engine.workspace = true
 konvoy-konanc.workspace = true
 konvoy-targets.workspace = true
 konvoy-util.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/konvoy-cli/src/main.rs
+++ b/crates/konvoy-cli/src/main.rs
@@ -143,11 +143,27 @@ enum Command {
     },
     /// Check environment and toolchain setup
     Doctor,
+    /// Validate konvoy.toml and report configuration issues
+    Check {
+        /// Output format: human-readable text, or JSON (for editors/tools)
+        #[arg(long, value_enum, default_value_t = CheckFormat::Human)]
+        format: CheckFormat,
+    },
     /// Manage Kotlin/Native toolchains
     Toolchain {
         #[command(subcommand)]
         action: ToolchainAction,
     },
+}
+
+/// Output format for `konvoy check`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum CheckFormat {
+    /// Human-readable lines on stderr (non-zero exit if issues are found).
+    Human,
+    /// A JSON array of diagnostics on stdout (always exits 0 — the issues are the
+    /// data). Stable contract for editor integrations.
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -252,6 +268,7 @@ fn main() {
         Command::Update => with_resolver(false, false, cmd_update),
         Command::Clean { all } => cmd_clean(all),
         Command::Doctor => cmd_doctor(),
+        Command::Check { format } => cmd_check(format),
         Command::Toolchain { action } => {
             cmd_toolchain(action, &konvoy_util::net::NetworkClient::new(false))
         }
@@ -724,6 +741,39 @@ fn cmd_doctor() -> CliResult {
     } else {
         eprintln!("All checks passed");
         Ok(())
+    }
+}
+
+fn cmd_check(format: CheckFormat) -> CliResult {
+    let root = project_root()?;
+    let path = root.join("konvoy.toml");
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let diagnostics = konvoy_config::Manifest::check_str(&content, &path.display().to_string());
+
+    match format {
+        // Machine contract for editors: a JSON array on stdout, always exit 0 — the
+        // diagnostics are the payload, not a process failure.
+        CheckFormat::Json => {
+            let json = serde_json::to_string(&diagnostics)
+                .map_err(|e| format!("cannot serialize diagnostics: {e}"))?;
+            println!("{json}");
+            Ok(())
+        }
+        CheckFormat::Human => {
+            if diagnostics.is_empty() {
+                eprintln!("    No issues found in konvoy.toml");
+                return Ok(());
+            }
+            for d in &diagnostics {
+                let loc = match (d.line, d.column) {
+                    (Some(line), Some(col)) => format!("konvoy.toml:{line}:{col}: "),
+                    _ => String::new(),
+                };
+                eprintln!("  {loc}{}", d.message);
+            }
+            Err(format!("{} issue(s) found in konvoy.toml", diagnostics.len()).into())
+        }
     }
 }
 
@@ -1410,10 +1460,43 @@ mod tests {
             "update",
             "clean",
             "doctor",
+            "check",
             "toolchain",
         ] {
             assert!(help.contains(subcommand));
         }
+    }
+
+    // ── Check parsing ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_check_defaults_to_human() {
+        let cli = Cli::try_parse_from(["konvoy", "check"]).unwrap();
+        match cli.command {
+            Command::Check { format } => assert!(matches!(format, CheckFormat::Human)),
+            other => panic!("expected Check, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_check_json() {
+        let cli = Cli::try_parse_from(["konvoy", "check", "--format", "json"]).unwrap();
+        match cli.command {
+            Command::Check { format } => assert!(matches!(format, CheckFormat::Json)),
+            other => panic!("expected Check, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_check_rejects_unknown_format() {
+        let err = Cli::try_parse_from(["konvoy", "check", "--format", "xml"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn help_flag_on_check() {
+        let err = Cli::try_parse_from(["konvoy", "check", "--help"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     }
 
     // ── Passthrough edge cases ─────────────────────────────────────

--- a/crates/konvoy-config/src/manifest.rs
+++ b/crates/konvoy-config/src/manifest.rs
@@ -558,6 +558,124 @@ pub enum ManifestError {
     },
 }
 
+/// Severity of a configuration [`Diagnostic`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// A problem that prevents the project from building.
+    Error,
+}
+
+/// A single `konvoy.toml` diagnostic in a machine-readable form, produced by
+/// [`Manifest::check_str`] and emitted by `konvoy check` for editors to render.
+///
+/// Editors are thin clients: they consume these diagnostics rather than
+/// re-implementing any validation. `key_path` is the dotted TOML path the
+/// diagnostic concerns (e.g. `codegen.openapi` or `dependencies.foo`), so an
+/// editor can locate the offending table/key via its own PSI without knowing the
+/// rules. `line`/`column` (1-based) are filled in for TOML *syntax* errors, which
+/// carry a source span; semantic errors carry `key_path` instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Diagnostic {
+    /// How severe the problem is.
+    pub severity: Severity,
+    /// Human-readable description (the same text the CLI prints).
+    pub message: String,
+    /// Dotted TOML path the diagnostic concerns, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_path: Option<String>,
+    /// 1-based line of a syntax error, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    /// 1-based column of a syntax error, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<usize>,
+}
+
+impl Manifest {
+    /// Validate a `konvoy.toml` string and return its diagnostics.
+    ///
+    /// Returns an empty vector when the manifest is valid. Reports the first
+    /// validation error (mirroring [`from_str`](Self::from_str), so a `konvoy
+    /// check` never disagrees with a `konvoy build`); the structured form lets
+    /// `konvoy check` and the IDE plugins surface it without re-implementing any
+    /// validation.
+    #[must_use]
+    pub fn check_str(content: &str, path: &str) -> Vec<Diagnostic> {
+        match Self::from_str(content, path) {
+            Ok(_) => Vec::new(),
+            Err(e) => vec![e.to_diagnostic(content)],
+        }
+    }
+}
+
+impl ManifestError {
+    /// Render this error as a structured [`Diagnostic`], locating it in the source
+    /// (`key_path` for semantic errors; `line`/`column` for syntax errors that
+    /// carry a span).
+    fn to_diagnostic(&self, content: &str) -> Diagnostic {
+        let (key_path, line, column) = self.locate(content);
+        Diagnostic {
+            severity: Severity::Error,
+            message: self.to_string(),
+            key_path,
+            line,
+            column,
+        }
+    }
+
+    /// Best-effort source location: the dotted TOML path this error concerns, and
+    /// a 1-based line/column for syntax errors that carry a span.
+    fn locate(&self, content: &str) -> (Option<String>, Option<usize>, Option<usize>) {
+        let key = |path: String| (Some(path), None, None);
+        match self {
+            ManifestError::Parse { source, .. } => match source.span() {
+                Some(span) => {
+                    let (line, column) = offset_to_line_col(content, span.start);
+                    (None, Some(line), Some(column))
+                }
+                None => (None, None, None),
+            },
+            ManifestError::EmptyName { .. } | ManifestError::InvalidName { .. } => {
+                key("package.name".to_owned())
+            }
+            ManifestError::InvalidEntrypoint { .. } => key("package.entrypoint".to_owned()),
+            ManifestError::InvalidToolchain { .. } => key("toolchain".to_owned()),
+            ManifestError::DependencyNoSource { name, .. }
+            | ManifestError::DependencyMavenWithPath { name, .. }
+            | ManifestError::DependencyMavenWithoutVersion { name, .. }
+            | ManifestError::DependencyVersionWithoutMaven { name, .. }
+            | ManifestError::DependencyEmptyVersion { name, .. }
+            | ManifestError::DependencyInvalidMaven { name, .. }
+            | ManifestError::DependencyInvalidName { name, .. }
+            | ManifestError::DependencySelfReference { name, .. } => {
+                key(format!("dependencies.{name}"))
+            }
+            ManifestError::InvalidPluginConfig { name, .. } => key(format!("plugins.{name}")),
+            ManifestError::InvalidCodegenConfig { name, .. } => key(format!("codegen.{name}")),
+            ManifestError::Read { .. } | ManifestError::Serialize { .. } => (None, None, None),
+        }
+    }
+}
+
+/// Convert a 0-based byte offset into `content` to a 1-based `(line, column)`.
+fn offset_to_line_col(content: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut column = 1;
+    for (i, ch) in content.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -2391,5 +2509,58 @@ version = "1.0"
         assert_eq!(maven_only.as_maven_coord(), None);
         assert_eq!(version_only.as_maven_coord(), None);
         assert_eq!(neither.as_maven_coord(), None);
+    }
+
+    // ---- check_str (structured diagnostics for `konvoy check`) --------------
+
+    #[test]
+    fn check_str_valid_manifest_has_no_diagnostics() {
+        let toml = format!("[package]\nname = \"ok\"\n{TOOLCHAIN}");
+        assert!(Manifest::check_str(&toml, "konvoy.toml").is_empty());
+    }
+
+    #[test]
+    fn check_str_semantic_error_carries_key_path_not_line() {
+        // An invalid [codegen.openapi] is a *semantic* error: it should locate via
+        // the dotted key path (so an editor can find the table) and NOT a span.
+        let toml = format!(
+            "[package]\nname = \"ok\"\n{TOOLCHAIN}\n\
+             [codegen.openapi]\nversion = \"20.0.0\"\nspec = \"a.txt\"\nbase_package = \"com.x\"\n"
+        );
+        let diags = Manifest::check_str(&toml, "konvoy.toml");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].key_path.as_deref(), Some("codegen.openapi"));
+        assert_eq!(diags[0].line, None);
+        assert!(diags[0].message.contains(".yaml"));
+    }
+
+    #[test]
+    fn check_str_dependency_error_keys_on_the_dependency() {
+        let toml = format!(
+            "[package]\nname = \"ok\"\n{TOOLCHAIN}\n[dependencies]\nfoo = {{ maven = \"g:a\" }}\n"
+        );
+        let diags = Manifest::check_str(&toml, "konvoy.toml");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].key_path.as_deref(), Some("dependencies.foo"));
+    }
+
+    #[test]
+    fn check_str_syntax_error_carries_line_and_column() {
+        // A TOML *syntax* error carries a source span → 1-based line/column, no key.
+        let toml = "[package\nname = \"ok\"\n";
+        let diags = Manifest::check_str(toml, "konvoy.toml");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].line, Some(1));
+        assert!(diags[0].column.is_some());
+        assert_eq!(diags[0].key_path, None);
+    }
+
+    #[test]
+    fn check_str_empty_name_keys_on_package_name() {
+        let toml = format!("[package]\nname = \"\"\n{TOOLCHAIN}");
+        let diags = Manifest::check_str(&toml, "konvoy.toml");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].key_path.as_deref(), Some("package.name"));
     }
 }

--- a/tests/smoke/tests.sh
+++ b/tests/smoke/tests.sh
@@ -264,6 +264,251 @@ test_doctor_all_ok() {
 }
 
 # ---------------------------------------------------------------------------
+# Tests: konvoy check (manifest validation / structured diagnostics)
+#
+# `konvoy check` is pure manifest validation — no toolchain, network, or build —
+# so these are fast. `--format json` always exits 0 (diagnostics are the payload);
+# the default human format exits non-zero when issues are found.
+# ---------------------------------------------------------------------------
+
+# Expected: a valid manifest reports no issues — human prints a clean line (exit 0),
+# json prints an empty array (exit 0).
+test_check_valid_clean() {
+    konvoy init --name chk-ok >/dev/null 2>&1
+    cd chk-ok
+    local human
+    human=$(konvoy check 2>&1)
+    assert_contains "$human" "No issues found"
+    local json
+    json=$(konvoy check --format json)
+    if [ "$json" != "[]" ]; then
+        echo "    expected empty json array for a valid manifest, got: $json" >&2
+        return 1
+    fi
+}
+
+# Expected: a manifest exercising every section (package, toolchain, plugins,
+# dependencies, codegen) validates cleanly. check never resolves plugins/deps or
+# reads the spec file — it only validates the manifest structure.
+test_check_valid_full_manifest_clean() {
+    mkdir -p chk-full && cd chk-full
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-full"
+kind = "bin"
+
+[toolchain]
+kotlin = "2.2.0"
+detekt = "1.23.7"
+
+[plugins]
+kotlin-serialization = { maven = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version = "2.2.0" }
+
+[dependencies]
+kotlinx-serialization-core = { maven = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.7.3" }
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.yaml"
+base_package = "com.example.api"
+extra_spec_dirs = ["specs"]
+TOML
+    local json
+    json=$(konvoy check --format json)
+    if [ "$json" != "[]" ]; then
+        echo "    expected a clean full manifest, got: $json" >&2
+        return 1
+    fi
+}
+
+# Unexpected: an invalid [codegen.openapi] (bad spec extension). Human reports it and
+# exits non-zero; json reports it keyed on `codegen.openapi` and still exits 0.
+test_check_invalid_codegen_both_formats() {
+    mkdir -p chk-cg && cd chk-cg
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-cg"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "specs/api.txt"
+base_package = "com.example.api"
+TOML
+    local human
+    if human=$(konvoy check 2>&1); then
+        echo "    expected human check to exit non-zero on an invalid manifest" >&2
+        return 1
+    fi
+    assert_contains "$human" ".yaml, .yml, or .json"
+
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"severity":"error"'
+    assert_contains "$json" '"key_path":"codegen.openapi"'
+}
+
+# Unexpected (syntax): a TOML parse error carries line/column (no key path) in json,
+# and a file:line:col prefix in human output.
+test_check_syntax_error_line_col() {
+    mkdir -p chk-syn && cd chk-syn
+    printf '[package\nname = "x"\n' > konvoy.toml
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"line":'
+    assert_contains "$json" '"column":'
+    assert_not_contains "$json" '"key_path"'
+
+    local human
+    if human=$(konvoy check 2>&1); then
+        echo "    expected non-zero exit on a syntax error" >&2
+        return 1
+    fi
+    assert_contains "$human" "konvoy.toml:1:"
+}
+
+# Unexpected: an invalid package name keys the diagnostic on package.name.
+test_check_invalid_package_name() {
+    mkdir -p chk-name && cd chk-name
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "bad name!"
+
+[toolchain]
+kotlin = "2.2.0"
+TOML
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"key_path":"package.name"'
+    assert_contains "$json" '"severity":"error"'
+}
+
+# Unexpected: a malformed dependency keys on dependencies.<name>.
+test_check_dependency_error() {
+    mkdir -p chk-dep && cd chk-dep
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-dep"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[dependencies]
+foo = { maven = "g:a" }
+TOML
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"key_path":"dependencies.foo"'
+}
+
+# Unexpected: a malformed plugin keys on plugins.<name>.
+test_check_plugin_error() {
+    mkdir -p chk-plg && cd chk-plg
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-plg"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[plugins]
+p = { version = "1.0.0" }
+TOML
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"key_path":"plugins.p"'
+}
+
+# Unexpected: an unknown table is rejected (deny_unknown_fields) as a parse-level
+# diagnostic carrying a location, with the offending field named.
+test_check_unknown_field_rejected() {
+    mkdir -p chk-unk && cd chk-unk
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-unk"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[codegen.grpc]
+version = "1.0.0"
+TOML
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" "unknown field"
+    assert_contains "$json" "grpc"
+    assert_contains "$json" '"line":'
+}
+
+# Unexpected: an absolute spec path is rejected, keyed on codegen.openapi.
+test_check_absolute_spec_rejected() {
+    mkdir -p chk-abs && cd chk-abs
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "chk-abs"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "/etc/api.yaml"
+base_package = "com.example.api"
+TOML
+    local json
+    json=$(konvoy check --format json)
+    assert_contains "$json" '"key_path":"codegen.openapi"'
+    assert_contains "$json" "relative path inside the project"
+}
+
+# Edge: `konvoy check` outside a project (no konvoy.toml) fails clearly — the project
+# precondition fails before validation, in BOTH formats (so --format json does not
+# emit JSON here; that is the documented exception to "json always exits 0").
+test_check_no_manifest_fails() {
+    mkdir -p chk-empty && cd chk-empty
+    local output
+    if output=$(konvoy check 2>&1); then
+        echo "    expected konvoy check to fail with no konvoy.toml" >&2
+        return 1
+    fi
+    assert_contains "$output" "no konvoy.toml"
+    if konvoy check --format json >/dev/null 2>&1; then
+        echo "    expected konvoy check --format json to also fail with no konvoy.toml" >&2
+        return 1
+    fi
+}
+
+# Edge: check reports the FIRST error only (mirroring `konvoy build`), so a manifest
+# with multiple problems yields exactly one diagnostic — the earliest (package name,
+# validated before codegen).
+test_check_reports_first_error_only() {
+    mkdir -p chk-first && cd chk-first
+    cat > konvoy.toml << 'TOML'
+[package]
+name = "bad name!"
+
+[toolchain]
+kotlin = "2.2.0"
+
+[codegen.openapi]
+version = "20.0.0"
+spec = "api.txt"
+base_package = "com.example.api"
+TOML
+    local json
+    json=$(konvoy check --format json)
+    local count
+    count=$(echo "$json" | grep -o '"severity"' | wc -l | tr -d ' ')
+    if [ "$count" != "1" ]; then
+        echo "    expected exactly 1 diagnostic (first error only), got $count: $json" >&2
+        return 1
+    fi
+    assert_contains "$json" '"key_path":"package.name"'
+}
+
+# ---------------------------------------------------------------------------
 # Tests: build lifecycle (combined to minimize konanc invocations)
 # ---------------------------------------------------------------------------
 
@@ -3534,6 +3779,18 @@ run_test test_path_dep_undeclared_sibling_fails
 run_test test_doctor_maven_dep_checks
 run_test test_doctor_missing_lockfile_entry_warns
 run_test test_doctor_no_lockfile_warns
+# check command
+run_test test_check_valid_clean
+run_test test_check_valid_full_manifest_clean
+run_test test_check_invalid_codegen_both_formats
+run_test test_check_syntax_error_line_col
+run_test test_check_invalid_package_name
+run_test test_check_dependency_error
+run_test test_check_plugin_error
+run_test test_check_unknown_field_rejected
+run_test test_check_absolute_spec_rejected
+run_test test_check_no_manifest_fails
+run_test test_check_reports_first_error_only
 # test command
 run_test test_test_lifecycle
 run_test test_test_no_test_dir_fails


### PR DESCRIPTION
First PR of the IntelliJ-plugin codegen initiative. The plugin should be a **thin client** — validation comes from calling `konvoy`, not a Kotlin re-implementation of the rules. This adds the backend the plugin will consume.

## What
`konvoy check [--format human|json]` validates `konvoy.toml` and reports configuration issues.

- **`konvoy-config`**: `Manifest::check_str(content, path) -> Vec<Diagnostic>`.
  - `Diagnostic { severity, message, key_path?, line?, column? }`.
  - **Semantic** errors carry a `key_path` — the dotted TOML path (`codegen.openapi`, `dependencies.foo`, `package.name`, …) — so an editor locates the offending table/key via its own PSI **without knowing any rules**.
  - **Syntax** errors carry 1-based `line`/`column` from the TOML parser's source span.
  - Reports the first error, mirroring `from_str`, so `check` never disagrees with `build`. (All-diagnostics-at-once is a possible follow-up.)
- **`konvoy-cli`**: `konvoy check`.
  - `--format json` → JSON array on **stdout**, always exits **0** (the diagnostics are the payload, not a failure) — a stable contract for editors.
  - `--format human` (default) → `konvoy.toml:line:col: message` on stderr, non-zero exit if any issue.

## Why
Foundation for the IntelliJ plugin's **thin validation annotator**, which will replace the plugin's current Kotlin `KonvoyTomlAnnotator` that duplicates konvoy's validation. Same JSON contract can back the VS Code extension later.

## Tests
`konvoy-config`: 5 `check_str` tests (valid → empty; semantic → key_path, no line; syntax → line/col, no key; dependency/codegen/package keying). `konvoy-cli`: clap parse tests (human default, json, unknown-format rejected, help) + subcommand list. Manually verified the JSON output for valid/codegen/syntax/dependency cases.

Local: fmt, clippy `-D warnings`, `cargo test --workspace`, rustdoc all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)