### PR TITLE
ci(intellij): workflow_dispatch with test filter for fast iteration

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -10,6 +10,12 @@ on:
       - "intellij-v*"
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      test_filter:
+        description: "Gradle test filter, e.g. '*Codegen*' or 'com.konvoy.ide.toml.*' (empty runs all tests)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -66,6 +72,35 @@ jobs:
         with:
           name: konvoy-intellij
           path: editors/intellij/build/distributions/*.zip
+
+  # Fast, on-demand iteration: compile the plugin and run only the matching tests.
+  # `gh workflow run intellij-plugin.yml --ref <branch> -f test_filter='*Codegen*'`.
+  # Compilation still runs in full (so this catches build errors), but the (slow,
+  # IDE-spinning) test suite is narrowed to the filter. PRs still run the full suite.
+  quick-test:
+    name: Quick Test
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Test (filtered)
+        run: |
+          filter='${{ github.event.inputs.test_filter }}'
+          if [ -n "$filter" ]; then
+            echo "Running tests matching: $filter"
+            ./gradlew test --tests "$filter"
+          else
+            echo "No filter provided — running all tests"
+            ./gradlew test
+          fi
 
   verify:
     name: Verify Compatibility


### PR DESCRIPTION
Enables fast, on-demand CI iteration on the IntelliJ plugin while the codegen-support work lands — useful because there's no local JDK to compile/test the plugin.

- Adds `workflow_dispatch` with a `test_filter` input.
- Adds a **Quick Test** job (manual-dispatch only) that compiles the plugin and runs only matching tests: `./gradlew test --tests "<filter>"`.

```
gh workflow run intellij-plugin.yml --ref <branch> -f test_filter='*Codegen*'
```

Compilation still runs in full (so build errors are caught); only the slow, IDE-spinning test suite is narrowed. PRs/pushes are unchanged — they still run the full `Build & Test`.

**Must merge to `main`** for the dispatch to be runnable against feature branches (same as `ci.yml`'s smoke dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)