### PR TITLE
intellij: index generated codegen sources so they resolve in the editor

### DIFF
--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyGeneratedSources.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyGeneratedSources.kt
@@ -1,0 +1,31 @@
+package com.konvoy.ide.sync
+
+import java.io.File
+
+/**
+ * Locates a Konvoy project's generated-source output directories.
+ *
+ * Codegen writes each generator's sources under `.konvoy/gen/<generator>/` (e.g.
+ * `.konvoy/gen/openapi/`). These are detected purely on disk — the plugin never
+ * parses `[codegen]` config; konvoy owns what is generated and where.
+ *
+ * The generator *output* directory is returned (not a nested `src/main/kotlin`), so
+ * this stays generator-agnostic: Kotlin resolves symbols by their `package`
+ * declaration, so the directory layout inside the output dir doesn't matter for
+ * indexing.
+ */
+object KonvoyGeneratedSources {
+
+    /**
+     * The generator output dirs under `<projectDir>/.konvoy/gen/` (one per
+     * generator), sorted by name. Empty when nothing has been generated yet.
+     */
+    fun generatedSourceDirs(projectDir: File): List<File> {
+        val genDir = File(projectDir, ".konvoy/gen")
+        if (!genDir.isDirectory) return emptyList()
+        return genDir.listFiles()
+            ?.filter { it.isDirectory }
+            ?.sortedBy { it.name }
+            ?: emptyList()
+    }
+}

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyWorkspaceModelUpdater.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyWorkspaceModelUpdater.kt
@@ -22,6 +22,8 @@ import org.jetbrains.kotlin.platform.konan.NativePlatforms
 import com.intellij.facet.FacetManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import org.jetbrains.jps.model.java.JavaSourceRootType
+import org.jetbrains.jps.model.java.JpsJavaExtensionService
 import java.io.File
 
 /**
@@ -110,10 +112,30 @@ object KonvoyWorkspaceModelUpdater {
             contentEntry.addSourceFolder(testDir, true)
         }
 
-        // Exclude build output directory
-        val buildDir = projectDir.findChild(".konvoy")
-        if (buildDir != null) {
-            contentEntry.addExcludeFolder(buildDir)
+        // .konvoy/ holds build artifacts (excluded) plus, when codegen has run,
+        // generated sources under .konvoy/gen/<generator>/ that must be indexed so
+        // generated code resolves in the editor. Register those as generated source
+        // roots and exclude the rest of .konvoy/; if nothing has been generated,
+        // exclude .konvoy/ wholesale as before.
+        val konvoyDir = projectDir.findChild(".konvoy")
+        if (konvoyDir != null) {
+            val genDirs = KonvoyGeneratedSources.generatedSourceDirs(File(basePath))
+            if (genDirs.isEmpty()) {
+                contentEntry.addExcludeFolder(konvoyDir)
+            } else {
+                konvoyDir.children.forEach { child ->
+                    if (child.isDirectory && child.name != "gen") {
+                        contentEntry.addExcludeFolder(child)
+                    }
+                }
+                val props =
+                    JpsJavaExtensionService.getInstance().createSourceRootProperties("", true)
+                val lfs = LocalFileSystem.getInstance()
+                genDirs.forEach { dir ->
+                    val vDir = lfs.refreshAndFindFileByPath(dir.path) ?: return@forEach
+                    contentEntry.addSourceFolder(vDir, JavaSourceRootType.SOURCE, props)
+                }
+            }
         }
 
         model.commit()
@@ -273,12 +295,19 @@ object KonvoyWorkspaceModelUpdater {
         depPath: String,
     ) {
         val srcDir = File(depPath, "src")
-        if (!srcDir.exists()) return
+        // Include the dependency's generated sources too (when it has codegen), so a
+        // path-dep's generated classes resolve in the consuming project.
+        val genDirs = KonvoyGeneratedSources.generatedSourceDirs(File(depPath))
+        if (!srcDir.exists() && genDirs.isEmpty()) return
 
         val lib = tableModel.createLibrary(name)
         val libModel = lib.modifiableModel
-        val url = VfsUtil.getUrlForLibraryRoot(srcDir)
-        libModel.addRoot(url, OrderRootType.SOURCES)
+        if (srcDir.exists()) {
+            libModel.addRoot(VfsUtil.getUrlForLibraryRoot(srcDir), OrderRootType.SOURCES)
+        }
+        genDirs.forEach { gen ->
+            libModel.addRoot(VfsUtil.getUrlForLibraryRoot(gen), OrderRootType.SOURCES)
+        }
         libModel.commit()
         moduleModel.addLibraryEntry(lib)
     }

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/sync/KonvoyGeneratedSourcesTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/sync/KonvoyGeneratedSourcesTest.kt
@@ -1,0 +1,48 @@
+package com.konvoy.ide.sync
+
+import junit.framework.TestCase
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Pure-logic tests for on-disk discovery of generated-source directories. No
+ * IntelliJ platform needed.
+ */
+class KonvoyGeneratedSourcesTest : TestCase() {
+
+    private fun tempProject(): File = Files.createTempDirectory("konvoy-gen-test").toFile()
+
+    fun testNoKonvoyDirIsEmpty() {
+        assertTrue(KonvoyGeneratedSources.generatedSourceDirs(tempProject()).isEmpty())
+    }
+
+    fun testKonvoyDirWithoutGenIsEmpty() {
+        val proj = tempProject()
+        File(proj, ".konvoy/build").mkdirs()
+        File(proj, ".konvoy/cache").mkdirs()
+        assertTrue(KonvoyGeneratedSources.generatedSourceDirs(proj).isEmpty())
+    }
+
+    fun testReturnsEachGeneratorDirSortedByName() {
+        val proj = tempProject()
+        File(proj, ".konvoy/gen/openapi").mkdirs()
+        File(proj, ".konvoy/gen/grpc").mkdirs()
+        val dirs = KonvoyGeneratedSources.generatedSourceDirs(proj)
+        assertEquals(listOf("grpc", "openapi"), dirs.map { it.name })
+    }
+
+    fun testIgnoresNonDirectoryEntriesUnderGen() {
+        val proj = tempProject()
+        File(proj, ".konvoy/gen").mkdirs()
+        File(proj, ".konvoy/gen/stray.txt").writeText("not a generator dir")
+        File(proj, ".konvoy/gen/openapi").mkdirs()
+        val dirs = KonvoyGeneratedSources.generatedSourceDirs(proj)
+        assertEquals(listOf("openapi"), dirs.map { it.name })
+    }
+
+    fun testEmptyGenDirIsEmpty() {
+        val proj = tempProject()
+        File(proj, ".konvoy/gen").mkdirs()
+        assertTrue(KonvoyGeneratedSources.generatedSourceDirs(proj).isEmpty())
+    }
+}


### PR DESCRIPTION
PR3 of the IntelliJ codegen initiative — the highest user-impact piece. Generated Kotlin (e.g. OpenAPI/Fabrikt models) now **resolves in the editor** instead of showing as unresolved.

## Problem
`configureSourceRoots` excluded all of `.konvoy/`, so the generated sources under `.konvoy/gen/<generator>/` were never indexed — `import com.example.api.Pet` was red.

## Fix (on-disk, generator-agnostic — no `[codegen]` parsing)
- **`KonvoyGeneratedSources.generatedSourceDirs(projectDir)`** — pure discovery of `.konvoy/gen/<generator>/` dirs. Registers the *generator output dir* (not a nested `src/main/kotlin`), so it's generator-agnostic: Kotlin resolves by `package` declaration.
- **Root project** — when generated dirs exist, exclude the other `.konvoy/` children (build/cache/tools/…) and add each gen dir as a **generated** source root (`JavaSourceRootType.SOURCE`, `isForGeneratedSources=true` — suppresses package/dir-mismatch noise). No generated dirs → exclude `.konvoy/` wholesale, as before.
- **Path deps** — also add a dependency's `.konvoy/gen/<generator>/` dirs as library SOURCES roots, so a path-dep's generated classes resolve in the consumer.

## Tests
`KonvoyGeneratedSourcesTest` (pure): no-konvoy, no-gen, multiple generators sorted, ignores non-dirs, empty gen. Full plugin suite green (**66 tests**); `./gradlew build` passes. Built + tested locally on JDK 21.

The decision logic is unit-tested; the IntelliJ source-root registration is thin glue (same shape as the existing `src/` handling) and is eyeball-verifiable via `./gradlew runIde`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)