### PR TITLE
intellij: `konvoy generate` run configuration + Build-menu action

### DIFF
--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyConfigurationType.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyConfigurationType.kt
@@ -7,7 +7,7 @@ import javax.swing.Icon
 
 /**
  * Registers Konvoy run configuration type in IntelliJ's run configuration UI.
- * Provides factories for build, run, test, and lint configurations.
+ * Provides factories for build, run, test, lint, and generate configurations.
  */
 class KonvoyConfigurationType : ConfigurationType {
     override fun getDisplayName(): String = "Konvoy"
@@ -20,6 +20,7 @@ class KonvoyConfigurationType : ConfigurationType {
         KonvoyBuildFactory(this),
         KonvoyTestFactory(this),
         KonvoyLintFactory(this),
+        KonvoyGenerateFactory(this),
     )
 
     companion object {

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfiguration.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunConfiguration.kt
@@ -64,10 +64,12 @@ enum class KonvoyCommand(val displayName: String, val subcommand: String) {
     RUN("Run", "run"),
     TEST("Test", "test"),
     LINT("Lint", "lint"),
+    GENERATE("Generate", "generate"),
 }
 
+// `lint` and `generate` are target-agnostic — they take no --target.
 internal val KonvoyCommand.supportsTarget: Boolean
-    get() = this != KonvoyCommand.LINT
+    get() = this != KonvoyCommand.LINT && this != KonvoyCommand.GENERATE
 
 enum class KonvoyTarget(val displayName: String, val cliValue: String?) {
     HOST("Host", null),

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunFactories.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/run/KonvoyRunFactories.kt
@@ -31,3 +31,11 @@ class KonvoyLintFactory(type: KonvoyConfigurationType) : ConfigurationFactory(ty
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         KonvoyRunConfiguration(project, this, "konvoy lint").also { it.command = KonvoyCommand.LINT }
 }
+
+class KonvoyGenerateFactory(type: KonvoyConfigurationType) : ConfigurationFactory(type) {
+    override fun getId(): String = "KonvoyGenerate"
+    override fun getName(): String = "Generate"
+    override fun createTemplateConfiguration(project: Project): RunConfiguration =
+        KonvoyRunConfiguration(project, this, "konvoy generate")
+            .also { it.command = KonvoyCommand.GENERATE }
+}

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyGenerateAction.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/sync/KonvoyGenerateAction.kt
@@ -1,0 +1,83 @@
+package com.konvoy.ide.sync
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Build-menu action that runs `konvoy generate` and refreshes the project so freshly
+ * generated sources are picked up (and indexed via the generated source roots).
+ *
+ * A thin wrapper over the CLI — no generation logic lives here. If codegen isn't
+ * configured, `konvoy generate` says so and that message is surfaced as the
+ * notification body.
+ */
+class KonvoyGenerateAction : AnAction() {
+
+    private data class Result(val ok: Boolean, val output: String)
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val basePath = project.basePath ?: return
+
+        ProgressManager.getInstance().run(
+            object : Task.Backgroundable(project, "Running konvoy generate", true) {
+                override fun run(indicator: ProgressIndicator) {
+                    val result = runGenerate(File(basePath))
+                    ApplicationManager.getApplication().invokeLater {
+                        if (project.isDisposed) return@invokeLater
+                        if (result.ok) {
+                            // Bring the new sources into the VFS and re-sync so they
+                            // register as (generated) source roots and get indexed.
+                            LocalFileSystem.getInstance()
+                                .refreshAndFindFileByPath("$basePath/.konvoy/gen")
+                            KonvoyProjectService.getInstance(project).sync()
+                        }
+                        notify(project, result)
+                    }
+                }
+            },
+        )
+    }
+
+    private fun runGenerate(dir: File): Result {
+        return try {
+            val process = ProcessBuilder("konvoy", "generate")
+                .directory(dir)
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            if (!process.waitFor(120, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                return Result(false, "konvoy generate timed out")
+            }
+            Result(process.exitValue() == 0, output)
+        } catch (e: Exception) {
+            Result(false, e.message ?: "failed to run konvoy generate")
+        }
+    }
+
+    private fun notify(project: Project, result: Result) {
+        val type = if (result.ok) NotificationType.INFORMATION else NotificationType.ERROR
+        val title = if (result.ok) "Konvoy generate complete" else "Konvoy generate failed"
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("Konvoy")
+            .createNotification(title, result.output.trim().ifEmpty { "(no output)" }, type)
+            .notify(project)
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible =
+            project != null && KonvoyProjectService.getInstance(project).isKonvoyProject
+    }
+}

--- a/editors/intellij/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij/src/main/resources/META-INF/plugin.xml
@@ -105,5 +105,12 @@
                 icon="AllIcons.Actions.Refresh">
             <add-to-group group-id="BuildMenu" anchor="first"/>
         </action>
+        <action id="Konvoy.Generate"
+                class="com.konvoy.ide.sync.KonvoyGenerateAction"
+                text="Generate Konvoy Sources"
+                description="Run konvoy generate to (re)generate sources from specs"
+                icon="AllIcons.Actions.Compile">
+            <add-to-group group-id="BuildMenu" anchor="after" relative-to-action="Konvoy.SyncProject"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationCommandLineTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/run/KonvoyRunConfigurationCommandLineTest.kt
@@ -64,10 +64,22 @@ class KonvoyRunConfigurationCommandLineTest : TestCase() {
         assertEquals(listOf("lint", "--verbose"), cmd.parametersList.parameters)
     }
 
+    fun testCommandLineDoesNotAddTargetForGenerate() {
+        val cmd = createKonvoyCommandLine(
+            File("/tmp/project"),
+            KonvoyCommand.GENERATE,
+            KonvoyTarget.LINUX_X64,
+            "--verbose",
+        )
+
+        assertEquals(listOf("generate", "--verbose"), cmd.parametersList.parameters)
+    }
+
     fun testTargetSelectorIsOnlyEnabledForCommandsThatAcceptTargets() {
         assertTrue(isTargetSelectorEnabled(KonvoyCommand.BUILD))
         assertTrue(isTargetSelectorEnabled(KonvoyCommand.RUN))
         assertTrue(isTargetSelectorEnabled(KonvoyCommand.TEST))
         assertFalse(isTargetSelectorEnabled(KonvoyCommand.LINT))
+        assertFalse(isTargetSelectorEnabled(KonvoyCommand.GENERATE))
     }
 }


### PR DESCRIPTION
PR4 of the IntelliJ codegen initiative. Exposes `konvoy generate` in the IDE.

## What
- **Run configuration** — `KonvoyCommand.GENERATE` (`konvoy generate`), a new `KonvoyGenerateFactory` registered in `KonvoyConfigurationType`. "Generate" now appears as a Konvoy run-config type; the settings editor and gutter pick it up automatically (both enumerate `KonvoyCommand`). Like `lint`, it's **target-agnostic** — no `--target`.
- **Build-menu action** — "Generate Konvoy Sources" (`KonvoyGenerateAction`): runs `konvoy generate` in the background, then refreshes `.konvoy/gen` into the VFS and re-syncs so the freshly generated sources register as source roots and get indexed (builds on #305). A thin CLI wrapper — no generation logic here; if codegen isn't configured, `konvoy generate`'s message is shown in the notification.

## Tests
`KonvoyRunConfigurationCommandLineTest`: `generate` builds `["generate", "--verbose"]` with **no** `--target` even when one is selected; target selector disabled for `GENERATE`. Full plugin suite green (8 run-config tests); `./gradlew build` passes (plugin.xml with the new action validates). Built + tested locally on JDK 21.

The action's process/notification glue is thin (same shape as `KonvoySyncAction`); the command-line construction is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)