### PR TITLE
intellij: codegen completion + hover docs for [codegen.openapi]

### DIFF
--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/toml/KonvoyTomlDocumentationProvider.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/toml/KonvoyTomlDocumentationProvider.kt
@@ -35,6 +35,8 @@ class KonvoyTomlDocumentationProvider : AbstractDocumentationProvider() {
                 sectionName == "toolchain" -> "<b>[toolchain]</b><br/>Toolchain versions: Kotlin/Native compiler and optional tools."
                 sectionName == "dependencies" -> "<b>[dependencies]</b><br/>Project dependencies — path-based or Maven-based."
                 sectionName == "plugins" -> "<b>[plugins]</b><br/>Compiler plugins (e.g., kotlinx-serialization)."
+                sectionName == "codegen" || sectionName == "codegen.openapi" ->
+                    "<b>[codegen.openapi]</b><br/>OpenAPI code generation via Fabrikt — generates Kotlin models from an OpenAPI spec before compilation."
                 else -> null
             }
         }

--- a/editors/intellij/src/main/kotlin/com/konvoy/ide/toml/KonvoyTomlSchema.kt
+++ b/editors/intellij/src/main/kotlin/com/konvoy/ide/toml/KonvoyTomlSchema.kt
@@ -13,7 +13,7 @@ object KonvoyTomlSchema {
     )
 
     /** Top-level sections that can appear in konvoy.toml. */
-    val SECTIONS = setOf("package", "toolchain", "dependencies", "plugins")
+    val SECTIONS = setOf("package", "toolchain", "dependencies", "plugins", "codegen")
 
     /** Keys within each section. */
     val SECTION_KEYS: Map<String, Map<String, KeyInfo>> = mapOf(
@@ -26,6 +26,18 @@ object KonvoyTomlSchema {
         "toolchain" to mapOf(
             "kotlin" to KeyInfo("Kotlin/Native version", required = true),
             "detekt" to KeyInfo("Detekt linter version"),
+        ),
+        // OpenAPI code generation via Fabrikt (the [codegen.openapi] sub-table).
+        "codegen.openapi" to mapOf(
+            "version" to KeyInfo("Fabrikt version (18.0.0 or newer)", required = true),
+            "spec" to KeyInfo(
+                "Project-relative path to the OpenAPI spec (.yaml, .yml, or .json)",
+                required = true,
+            ),
+            "base_package" to KeyInfo("Kotlin package for the generated sources", required = true),
+            "extra_spec_dirs" to KeyInfo(
+                "Optional: extra directories holding \$ref'd spec files to watch for changes",
+            ),
         ),
     )
 

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/toml/KonvoyCodegenDocTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/toml/KonvoyCodegenDocTest.kt
@@ -1,0 +1,50 @@
+package com.konvoy.ide.toml
+
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.toml.lang.psi.TomlKey
+
+/**
+ * Verifies hover documentation for `[codegen.openapi]` — both its keys (from the
+ * schema) and the section header.
+ */
+class KonvoyCodegenDocTest : BasePlatformTestCase() {
+
+    private val sample = """
+        [codegen.openapi]
+        version = "20.0.0"
+        spec = "specs/api.yaml"
+        base_package = "com.example.api"
+    """.trimIndent()
+
+    private fun key(file: PsiFile, predicate: (TomlKey) -> Boolean): TomlKey =
+        PsiTreeUtil.findChildrenOfType(file, TomlKey::class.java).first(predicate)
+
+    fun testKeyDocDescribesCodegenVersion() {
+        val file = myFixture.configureByText("konvoy.toml", sample)
+        val doc = KonvoyTomlDocumentationProvider()
+            .generateDoc(key(file) { it.text == "version" }, null)
+        assertNotNull(doc)
+        assertTrue("doc was: $doc", doc!!.contains("Fabrikt"))
+    }
+
+    fun testKeyDocDescribesExtraSpecDirsAsOptional() {
+        val file = myFixture.configureByText(
+            "konvoy.toml",
+            "$sample\nextra_spec_dirs = [\"specs\"]",
+        )
+        val doc = KonvoyTomlDocumentationProvider()
+            .generateDoc(key(file) { it.text == "extra_spec_dirs" }, null)
+        assertNotNull(doc)
+        assertFalse("extra_spec_dirs is optional: $doc", doc!!.contains("Required"))
+    }
+
+    fun testHeaderDocDescribesCodegenSection() {
+        val file = myFixture.configureByText("konvoy.toml", sample)
+        val doc = KonvoyTomlDocumentationProvider()
+            .generateDoc(key(file) { it.text.contains("codegen") }, null)
+        assertNotNull(doc)
+        assertTrue("doc was: $doc", doc!!.contains("OpenAPI"))
+    }
+}

--- a/editors/intellij/src/test/kotlin/com/konvoy/ide/toml/KonvoyTomlSchemaTest.kt
+++ b/editors/intellij/src/test/kotlin/com/konvoy/ide/toml/KonvoyTomlSchemaTest.kt
@@ -1,0 +1,36 @@
+package com.konvoy.ide.toml
+
+import junit.framework.TestCase
+
+/**
+ * Pure-logic tests for the konvoy.toml completion schema (no IntelliJ platform).
+ */
+class KonvoyTomlSchemaTest : TestCase() {
+
+    fun testCodegenIsATopLevelSection() {
+        assertTrue("codegen" in KonvoyTomlSchema.SECTIONS)
+    }
+
+    fun testCodegenOpenApiKeysMatchTheShippedConfig() {
+        val keys = KonvoyTomlSchema.keysForSection("codegen.openapi")
+        assertNotNull(keys)
+        // Shipped config — note `extra_spec_dirs`, NOT the old `spec_dirs`.
+        assertEquals(
+            setOf("version", "spec", "base_package", "extra_spec_dirs"),
+            keys!!.keys,
+        )
+        assertTrue(keys.getValue("version").required)
+        assertTrue(keys.getValue("spec").required)
+        assertTrue(keys.getValue("base_package").required)
+        assertFalse(keys.getValue("extra_spec_dirs").required)
+    }
+
+    fun testDoesNotReintroduceStaleSpecDirsKey() {
+        val keys = KonvoyTomlSchema.keysForSection("codegen.openapi")!!
+        assertFalse("spec_dirs" in keys)
+    }
+
+    fun testUnknownSectionHasNoKeys() {
+        assertNull(KonvoyTomlSchema.keysForSection("codegen.grpc"))
+    }
+}


### PR DESCRIPTION
PR5 — the final piece of the IntelliJ codegen initiative. Editor ergonomics for `[codegen.openapi]`.

## What
- `codegen` added to the top-level sections; `[codegen.openapi]` added to the completion schema with `version`/`spec`/`base_package` (required) and `extra_spec_dirs` (optional) — so the keys **autocomplete** and **hover-document**.
- Documentation provider describes the `[codegen.openapi]` section.

Keys match the **shipped** config (`extra_spec_dirs`) — explicitly *not* the codex branch's stale `spec_dirs`.

This is editor assistance (a static schema of known keys + descriptions), **not** validation — validation remains konvoy-driven via `konvoy check` (#304). So the plugin still knows no validation rules.

## Tests
- `KonvoyTomlSchemaTest` (pure): codegen section present; the four keys with correct required-ness; no stale `spec_dirs`; unknown sub-table (`codegen.grpc`) has no keys.
- `KonvoyCodegenDocTest` (PSI): hover doc for a codegen key (mentions Fabrikt) and for the section header; `extra_spec_dirs` shown as optional.

Full plugin suite green (**73 tests**); `./gradlew build` passes. Built + tested locally on JDK 21. (Completion is exercised via the existing contributor + the schema it reads; the IDE completion popup itself is verified manually via `runIde`, consistent with the repo's prior approach.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)