### PR TITLE
Bump release versions: CLI 1.3.0, IntelliJ plugin 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-cli"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "clap",
  "konvoy-config",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-config"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "konvoy-util",
  "proptest",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-engine"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "indicatif",
  "konvoy-config",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-konanc"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "flate2",
  "indicatif",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-targets"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "proptest",
  "serde",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "konvoy-util"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "glob",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/editors/intellij/gradle.properties
+++ b/editors/intellij/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup = com.konvoy.ide
 pluginName = Konvoy
-pluginVersion = 1.0.1
+pluginVersion = 1.1.0
 
 platformType = IC
 platformVersion = 2024.2.1


### PR DESCRIPTION
Version bump for the next release of the konvoy CLI and the IntelliJ plugin.

- **CLI** `1.2.1 → 1.3.0` (minor) — `Cargo.toml` workspace version + `Cargo.lock`. Since 1.2.1: the OpenAPI codegen system, `konvoy generate`/`check`, `konvoy doctor` codegen status, the `--locked`/`--offline` split, and graph-wide path-dep config.
- **IntelliJ plugin** `1.0.1 → 1.1.0` (minor) — `editors/intellij/gradle.properties`. Since 1.0.1: codegen editor support (validation via `konvoy check`, generated-sources indexing, `konvoy generate` run-config + action, `[codegen.openapi]` completion/docs) and the target selector.

Verified locally: `cargo check --workspace` clean (lock synced, no stale 1.2.1); `./gradlew patchPluginXml` embeds `1.1.0`.

**After merge:** tag `v1.3.0` (→ `release.yml`: smoke gate → cross-compiled binaries → GitHub release, notes `--stream cli`) and `intellij-v1.1.0` (→ `intellij-plugin.yml`: plugin zip → release, notes `--stream intellij`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)