### PR TITLE
ci(release-notes): categorize codegen PRs + exclude version-bump PRs

### DIFF
--- a/.github/scripts/release-notes.mjs
+++ b/.github/scripts/release-notes.mjs
@@ -36,6 +36,12 @@ const CATEGORY_OVERRIDES = new Map([
   [273, "Other Changes"],
   [274, "Security"],
   [275, "Other Changes"],
+  // CLI 1.3.0 / IntelliJ 1.1.0 — codegen + editor support. Titles the keyword
+  // heuristic can't place correctly:
+  [297, "Enhancements"], // --locked / --offline split (Cargo's model)
+  [299, "Bug Fixes"], // path-dep [plugins]/[dependencies] dropped when built as a dep
+  [301, "Other Changes"], // codegen docs + polish (title trips the "fix" heuristic)
+  [304, "Enhancements"], // IntelliJ: konvoy.toml validation via `konvoy check`
 ]);
 
 function parseArgs(argv) {
@@ -95,7 +101,15 @@ export function classifyPullRequest(pullRequest, stream) {
 }
 
 export function filterPullRequests(pullRequests, stream) {
-  return pullRequests.filter((pullRequest) => classifyPullRequest(pullRequest, stream));
+  return pullRequests.filter(
+    (pullRequest) =>
+      classifyPullRequest(pullRequest, stream) && !isExcludedFromNotes(pullRequest),
+  );
+}
+
+/** Release plumbing (e.g. version-bump PRs) is not a user-facing change. */
+export function isExcludedFromNotes(pullRequest) {
+  return /^bump\b.*\bversions?\b/i.test(pullRequest.title);
 }
 
 function categoryByLabel(pullRequest) {
@@ -124,7 +138,7 @@ function categoryByTitle(pullRequest) {
   }
 
   if (
-    /\b(add|support|parallelize|perf|performance|typed|type-safety|enum|progress|diagnostics|completion|clickable)\b/.test(
+    /\b(add|support|parallelize|perf|performance|typed|type-safety|enum|progress|diagnostics|completion|clickable|codegen|openapi|generate)\b/.test(
       title,
     )
   ) {

--- a/.github/scripts/release-notes.test.mjs
+++ b/.github/scripts/release-notes.test.mjs
@@ -7,6 +7,7 @@ import {
   classifyPullRequest,
   extractPullRequestNumbers,
   filterPullRequests,
+  isExcludedFromNotes,
 } from "./release-notes.mjs";
 
 const owner = "arncore";
@@ -75,21 +76,64 @@ test("keeps IntelliJ documentation-only root edits out of CLI release notes", ()
   assert.equal(classifyPullRequest(pullRequest, "intellij"), true);
 });
 
-test("filters pull requests by release stream", () => {
+test("filters by release stream and drops version-bump PRs", () => {
   const pullRequests = [
     pr(251, "Add gutter run icons", ["editors/intellij/src/main/kotlin/Main.kt"]),
     pr(274, "Fix Rust dependency advisories", ["Cargo.toml"]),
+    // Touches both surfaces, but a version bump → excluded from both streams' notes.
     pr(275, "Bump release versions", ["Cargo.toml", "editors/intellij/gradle.properties"]),
     pr(201, "Update VS Code extension", ["editors/code/package.json"]),
   ];
 
   assert.deepEqual(
     filterPullRequests(pullRequests, "cli").map((pullRequest) => pullRequest.number),
-    [274, 275],
+    [274],
   );
   assert.deepEqual(
     filterPullRequests(pullRequests, "intellij").map((pullRequest) => pullRequest.number),
-    [251, 275],
+    [251],
+  );
+});
+
+test("excludes version-bump PRs but not feature PRs", () => {
+  assert.equal(
+    isExcludedFromNotes(pr(308, "Bump release versions: CLI 1.3.0, IntelliJ plugin 1.1.0", ["Cargo.toml"])),
+    true,
+  );
+  assert.equal(
+    isExcludedFromNotes(pr(283, "codegen (1/5): [codegen.openapi] manifest schema + validation", ["x"])),
+    false,
+  );
+});
+
+test("categorizes codegen/generate feature titles as Enhancements", () => {
+  assert.equal(
+    categoryForPullRequest(
+      pr(283, "codegen (1/5): [codegen.openapi] manifest schema + validation", [
+        "crates/konvoy-config/src/manifest.rs",
+      ]),
+    ).title,
+    "Enhancements",
+  );
+  assert.equal(
+    categoryForPullRequest(
+      pr(306, "intellij: `konvoy generate` run configuration + Build-menu action", [
+        "editors/intellij/src/main/kotlin/X.kt",
+      ]),
+    ).title,
+    "Enhancements",
+  );
+});
+
+test("override keeps the codegen docs PR out of Bug Fixes", () => {
+  // #301's title contains "regression fix" but it's a docs/polish PR.
+  assert.equal(
+    categoryForPullRequest(
+      pr(301, "codegen (5/5): docs + polish (README, error/doc copy, smoke regression fix)", [
+        "README.md",
+      ]),
+    ).title,
+    "Other Changes",
   );
 });
 


### PR DESCRIPTION
The auto-generated release notes for the v1.3.0 / intellij-v1.1.0 releases buried the codegen work in **Other Changes** (the title heuristic had no matching keyword) and listed the version-bump PR. This fixes the generator so future releases categorize correctly, and the already-published notes were regenerated + updated.

## Changes to `release-notes.mjs`
- **Enhancements heuristic** gains `codegen|openapi|generate` — so codegen feature PRs land in Enhancements instead of Other.
- **Exclude version-bump PRs** (`isExcludedFromNotes`, title `^Bump … version`) — release plumbing, not user-facing.
- **Overrides** for titles the heuristic can't place: #297 (`--locked`/`--offline` split) → Enhancements, #299 (path-dep config dropped) → Bug Fixes, #301 (codegen docs/polish, trips the "regression fix" heuristic) → Other Changes, #304 (IntelliJ validation via `konvoy check`) → Enhancements.

## Already done
Regenerated the **published** v1.3.0 and intellij-v1.1.0 release notes with this logic and updated them via `gh release edit` — codegen is now under Enhancements and the bump PR is gone.

## Tests
`release-notes.test.mjs`: updated the stream-filter test (bump now excluded) + added the exclusion, the codegen→Enhancements heuristic, and the docs-PR override. `node --test` → 15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)